### PR TITLE
Add filter tests for courses and combinations

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -141,6 +141,43 @@ class TestFilterItems:
         result = filter_items(items, q)
         assert len(result) == len(items)
 
+    def test_course_filter_no_matches(self):
+        items = self._make_items()
+        q = FilterQuery.parse("course:MATH9999")
+
+        result = filter_items(items, q)
+
+        assert result == []
+
+    def test_combined_filter_no_matches(self):
+        items = self._make_items()
+        q = FilterQuery.parse("course:CS3214 type:quiz")
+
+        result = filter_items(items, q)
+
+        assert result == []
+
+    def test_course_filter_is_case_insensitive(self):
+        items = self._make_items()
+        q = FilterQuery.parse("course:cs3214")
+
+        result = filter_items(items, q)
+
+        assert len(result) == 2
+        assert all(items[i].course_code == "CS3214" for i in result)
+
+    def test_integration_parse_filter_and_fuzzy_text(self):
+        items = self._make_items()
+        q = FilterQuery.parse("course:CS4104 type:assignment final")
+
+        result = filter_items(items, q)
+
+        assert len(result) == 1
+        matched = items[result[0]]
+        assert matched.title == "Final Exam"
+        assert matched.course_code == "CS4104"
+        assert matched.ptype == "assignment"
+
 
 class TestFormatFilterSummary:
     def test_basic(self):


### PR DESCRIPTION
Added tests for filtering functionality including case insensitivity and no matches.

## Summary
- What changed?
- Why?

## Checklist
- [ ] Linked issue/task
- [ ] Tests added or updated (if applicable)
- [ ] `ruff check src tests` passes locally
- [ ] `pytest tests` passes locally
- [ ] Docs/README updated (if behavior changed)
- [ ] No secrets or credentials introduced

## Screenshots / Evidence (if UI/docs changed)

## Risk / Rollback
- Risk level: low / medium / high
- Rollback plan:
