### PR TITLE
Refactor extension shared client and runtime contract

### DIFF
--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -19,6 +19,7 @@ import {
   clearCache,
 } from './lib/cache.js';
 import { createCanvasClient } from './lib/canvas-client.js';
+import { MESSAGE_TYPES } from './lib/extension-contract.js';
 
 const NOTIFY_BEFORE = [24 * 3600, 3600]; // 24h and 1h before deadline
 const canvasClient = createCanvasClient();
@@ -86,81 +87,60 @@ function sendError(sendResponse, error) {
 
 // ── Message Handlers ──────────────────────────────────────────────────────────
 
+const messageHandlers = {
+  [MESSAGE_TYPES.getUpcoming]: () =>
+    getUpcomingAssignments(() => canvasClient.getUpcomingAssignments()),
+
+  [MESSAGE_TYPES.getCourses]: () =>
+    getCourses(() => canvasClient.getCourses()),
+
+  [MESSAGE_TYPES.getCourseAssignments]: (msg) =>
+    getCourseAssignments((courseId) => canvasClient.getCourseAssignments(courseId), msg.courseId),
+
+  [MESSAGE_TYPES.validateToken]: async () => {
+    const { user } = await canvasClient.validateToken();
+    return { user };
+  },
+
+  [MESSAGE_TYPES.dismiss]: async (msg) => {
+    await dismissAssignment(msg.assignmentId);
+    await updateBadge();
+    return {};
+  },
+
+  [MESSAGE_TYPES.clearCache]: async () => {
+    await clearCache();
+    return {};
+  },
+
+  [MESSAGE_TYPES.getToken]: async () => {
+    const token = await canvasClient.getToken().catch(() => null);
+    return { token };
+  },
+
+  [MESSAGE_TYPES.setToken]: async (msg) => {
+    await canvasClient.setToken(msg.token);
+    const { user } = await canvasClient.validateToken();
+    clearCache().catch(() => {});
+    updateBadge();
+    return { user };
+  },
+
+  [MESSAGE_TYPES.refreshBadge]: async () => {
+    await clearCache().catch(() => {});
+    await updateBadge().catch(() => {});
+    return {};
+  },
+};
+
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-  if (msg.type === 'GET_UPCOMING') {
-    getUpcomingAssignments(() => canvasClient.getUpcomingAssignments())
-      .then(({ data, cached, stale }) => sendOk(sendResponse, { data, cached, stale }))
-      .catch((err) => sendError(sendResponse, err));
-    return true;
-  }
+  const handler = messageHandlers[msg.type];
+  if (!handler) return false;
 
-  if (msg.type === 'GET_COURSES') {
-    getCourses(() => canvasClient.getCourses())
-      .then(({ data, cached, stale }) => sendOk(sendResponse, { data, cached, stale }))
-      .catch((err) => sendError(sendResponse, err));
-    return true;
-  }
-
-  if (msg.type === 'GET_COURSE_ASSIGNMENTS') {
-    getCourseAssignments(() => canvasClient.getCourseAssignments(msg.courseId), msg.courseId)
-      .then(({ data, cached, stale }) => sendOk(sendResponse, { data, cached, stale }))
-      .catch((err) => sendError(sendResponse, err));
-    return true;
-  }
-
-  if (msg.type === 'VALIDATE_TOKEN') {
-    canvasClient
-      .validateToken()
-      .then(({ user }) => sendOk(sendResponse, { user }))
-      .catch((err) => sendError(sendResponse, err));
-    return true;
-  }
-
-  if (msg.type === 'DISMISS') {
-    dismissAssignment(msg.assignmentId)
-      .then(() => {
-        updateBadge();
-        sendOk(sendResponse);
-      })
-      .catch((err) => sendError(sendResponse, err));
-    return true;
-  }
-
-  if (msg.type === 'CLEAR_CACHE') {
-    clearCache()
-      .then(() => sendOk(sendResponse))
-      .catch((err) => sendError(sendResponse, err));
-    return true;
-  }
-
-  if (msg.type === 'GET_TOKEN') {
-    canvasClient
-      .getToken()
-      .then((token) => sendOk(sendResponse, { token }))
-      .catch(() => sendOk(sendResponse, { token: null }));
-    return true;
-  }
-
-  if (msg.type === 'SET_TOKEN') {
-    canvasClient
-      .setToken(msg.token)
-      .then(() => canvasClient.validateToken())
-      .then(({ user }) => {
-        clearCache().catch(() => {});
-        updateBadge();
-        sendOk(sendResponse, { user });
-      })
-      .catch((err) => sendError(sendResponse, err));
-    return true;
-  }
-
-  if (msg.type === 'REFRESH_BADGE') {
-    clearCache()
-      .then(() => updateBadge())
-      .then(() => sendOk(sendResponse))
-      .catch(() => sendOk(sendResponse));
-    return true;
-  }
+  Promise.resolve(handler(msg))
+    .then((payload) => sendOk(sendResponse, payload))
+    .catch((err) => sendError(sendResponse, err));
+  return true;
 });
 
 // ── Startup ──────────────────────────────────────────────────────────────────

--- a/extension/src/background.js
+++ b/extension/src/background.js
@@ -3,49 +3,38 @@
  * Handles API calls, caching, badge updates, and notifications.
  *
  * Architecture:
+ * - Shared Canvas client layer for auth + endpoint access
  * - IndexedDB cache with stale-while-revalidate (instant popup loads)
  * - Badge shows count of non-dismissed upcoming assignments
  * - Notifications at 24h and 1h before deadline
  * - Message passing to popup for data + cache operations
  */
 
-import { getUpcomingAssignments, getCourses, getCourseAssignments, dismissAssignment, getDismissed, clearCache, getSetting, setSetting } from './lib/cache.js';
+import {
+  getUpcomingAssignments,
+  getCourses,
+  getCourseAssignments,
+  dismissAssignment,
+  getDismissed,
+  clearCache,
+} from './lib/cache.js';
+import { createCanvasClient } from './lib/canvas-client.js';
 
-const API_BASE = "https://canvas.vt.edu/api/v1";
 const NOTIFY_BEFORE = [24 * 3600, 3600]; // 24h and 1h before deadline
-
-// ── Canvas API ────────────────────────────────────────────────────────────────
-
-async function canvasGet(path) {
-  const token = await getSetting("canvas_token", "settings");
-  if (!token) throw new Error("Not authenticated");
-  const url = `${API_BASE}${path}`;
-  const res = await fetch(url, {
-    headers: {
-      Authorization: `Bearer ${token}`,
-      Accept: "application/json",
-    },
-  });
-  if (res.status === 401) {
-    await setSetting(null, "canvas_token", "settings");
-    throw new Error("Token expired");
-  }
-  if (!res.ok) throw new Error(`Canvas API error: ${res.status}`);
-  return res.json();
-}
+const canvasClient = createCanvasClient();
 
 // ── Badge Update ─────────────────────────────────────────────────────────────
 
 async function updateBadge() {
   try {
-    const { data: events } = await getUpcomingAssignments(canvasGet);
+    const { data: events } = await getUpcomingAssignments(() => canvasClient.getUpcomingAssignments());
     const dismissed = await getDismissed();
-    const count = events.filter(e => e.type === "assignment" && !dismissed.has(String(e.assignment?.id))).length;
-    chrome.action.setBadgeText({ text: count > 0 ? String(count) : "" });
-    chrome.action.setBadgeBackgroundColor({ color: "#d63e36" });
+    const count = events.filter((e) => e.type === 'assignment' && !dismissed.has(String(e.assignment?.id))).length;
+    chrome.action.setBadgeText({ text: count > 0 ? String(count) : '' });
+    chrome.action.setBadgeBackgroundColor({ color: '#d63e36' });
   } catch {
-    chrome.action.setBadgeText({ text: "?" });
-    chrome.action.setBadgeBackgroundColor({ color: "#f48c06" });
+    chrome.action.setBadgeText({ text: '?' });
+    chrome.action.setBadgeBackgroundColor({ color: '#f48c06' });
   }
 }
 
@@ -53,12 +42,12 @@ async function updateBadge() {
 
 async function checkDeadlines() {
   try {
-    const { data: events } = await getUpcomingAssignments(canvasGet);
+    const { data: events } = await getUpcomingAssignments(() => canvasClient.getUpcomingAssignments());
     const dismissed = await getDismissed();
     const now = Date.now();
 
     for (const event of events) {
-      if (event.type !== "assignment") continue;
+      if (event.type !== 'assignment') continue;
       const id = String(event.assignment?.id || event.id);
       if (dismissed.has(id)) continue;
 
@@ -68,16 +57,16 @@ async function checkDeadlines() {
       for (const seconds of NOTIFY_BEFORE) {
         if (diff > 0 && diff <= seconds) {
           const notifiedKey = `notified:${id}:${seconds}`;
-          const already = await getSetting(notifiedKey, "settings");
-          if (!already) {
-            const title = seconds >= 86400 ? "24h Reminder" : "1h Reminder";
+          const already = await canvasClient.tokenStore(notifiedKey, 'settings');
+          if (!already?.value) {
+            const title = seconds >= 86400 ? '24h Reminder' : '1h Reminder';
             await chrome.notifications.create({
               title: `Canvas — ${title}`,
               message: event.title,
-              iconUrl: "assets/icon-48.png",
+              iconUrl: 'assets/icon-48.png',
               tag: id,
             });
-            await setSetting("true", notifiedKey, "settings");
+            await canvasClient.tokenWriter('true', notifiedKey, 'settings');
           }
         }
       }
@@ -87,52 +76,89 @@ async function checkDeadlines() {
   }
 }
 
+function sendOk(sendResponse, payload = {}) {
+  sendResponse({ ok: true, ...payload });
+}
+
+function sendError(sendResponse, error) {
+  sendResponse({ ok: false, error: error?.message || String(error) });
+}
+
 // ── Message Handlers ──────────────────────────────────────────────────────────
 
 chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
-  if (msg.type === "GET_UPCOMING") {
-    getUpcomingAssignments(canvasGet)
-      .then(({ data, cached }) => sendResponse({ ok: true, data, cached }))
-      .catch(err => sendResponse({ ok: false, error: err.message }));
+  if (msg.type === 'GET_UPCOMING') {
+    getUpcomingAssignments(() => canvasClient.getUpcomingAssignments())
+      .then(({ data, cached, stale }) => sendOk(sendResponse, { data, cached, stale }))
+      .catch((err) => sendError(sendResponse, err));
     return true;
   }
 
-  if (msg.type === "GET_COURSES") {
-    getCourses(canvasGet)
-      .then(({ data, cached }) => sendResponse({ ok: true, data, cached }))
-      .catch(err => sendResponse({ ok: false, error: err.message }));
+  if (msg.type === 'GET_COURSES') {
+    getCourses(() => canvasClient.getCourses())
+      .then(({ data, cached, stale }) => sendOk(sendResponse, { data, cached, stale }))
+      .catch((err) => sendError(sendResponse, err));
     return true;
   }
 
-  if (msg.type === "DISMISS") {
+  if (msg.type === 'GET_COURSE_ASSIGNMENTS') {
+    getCourseAssignments(() => canvasClient.getCourseAssignments(msg.courseId), msg.courseId)
+      .then(({ data, cached, stale }) => sendOk(sendResponse, { data, cached, stale }))
+      .catch((err) => sendError(sendResponse, err));
+    return true;
+  }
+
+  if (msg.type === 'VALIDATE_TOKEN') {
+    canvasClient
+      .validateToken()
+      .then(({ user }) => sendOk(sendResponse, { user }))
+      .catch((err) => sendError(sendResponse, err));
+    return true;
+  }
+
+  if (msg.type === 'DISMISS') {
     dismissAssignment(msg.assignmentId)
       .then(() => {
         updateBadge();
-        sendResponse({ ok: true });
+        sendOk(sendResponse);
       })
-      .catch(err => sendResponse({ ok: false, error: err.message }));
+      .catch((err) => sendError(sendResponse, err));
     return true;
   }
 
-  if (msg.type === "CLEAR_CACHE") {
-    clearCache().then(() => sendResponse({ ok: true })).catch(err => sendResponse({ ok: false, error: err.message }));
+  if (msg.type === 'CLEAR_CACHE') {
+    clearCache()
+      .then(() => sendOk(sendResponse))
+      .catch((err) => sendError(sendResponse, err));
     return true;
   }
 
-  if (msg.type === "GET_TOKEN") {
-    getSetting("canvas_token", "settings").then(t => sendResponse({ token: t })).catch(() => sendResponse({ token: null }));
+  if (msg.type === 'GET_TOKEN') {
+    canvasClient
+      .getToken()
+      .then((token) => sendOk(sendResponse, { token }))
+      .catch(() => sendOk(sendResponse, { token: null }));
     return true;
   }
 
-  if (msg.type === "SET_TOKEN") {
-    setSetting(msg.token, "canvas_token", "settings")
-      .then(() => { updateBadge(); sendResponse({ ok: true }); })
-      .catch(err => sendResponse({ ok: false, error: err.message }));
+  if (msg.type === 'SET_TOKEN') {
+    canvasClient
+      .setToken(msg.token)
+      .then(() => canvasClient.validateToken())
+      .then(({ user }) => {
+        clearCache().catch(() => {});
+        updateBadge();
+        sendOk(sendResponse, { user });
+      })
+      .catch((err) => sendError(sendResponse, err));
     return true;
   }
 
-  if (msg.type === "REFRESH_BADGE") {
-    clearCache().then(() => { updateBadge(); sendResponse({ ok: true }); }).catch(() => sendResponse({ ok: true }));
+  if (msg.type === 'REFRESH_BADGE') {
+    clearCache()
+      .then(() => updateBadge())
+      .then(() => sendOk(sendResponse))
+      .catch(() => sendOk(sendResponse));
     return true;
   }
 });
@@ -142,15 +168,12 @@ chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
 chrome.runtime.onInstalled.addListener(() => {
   chrome.storage.session.clear();
   chrome.notifications.create({
-    title: "Canvas Deadline Tracker",
-    message: "Extension installed. Enter your Canvas API token in the popup settings to get started.",
-    iconUrl: "assets/icon-48.png",
+    title: 'Canvas Deadline Tracker',
+    message: 'Extension installed. Enter your Canvas API token in the popup settings to get started.',
+    iconUrl: 'assets/icon-48.png',
   });
 });
 
-// Periodically check for deadline notifications
 setInterval(checkDeadlines, 10 * 60 * 1000); // every 10 min
-
-// Badge and notification check on startup
 updateBadge().then(checkDeadlines);
 setInterval(updateBadge, 5 * 60 * 1000); // refresh badge every 5 min

--- a/extension/src/lib/cache.js
+++ b/extension/src/lib/cache.js
@@ -92,14 +92,10 @@ async function refreshInBackground(key, fetchFn, ttlSeconds) {
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-function callFetcher(fetcher, path) {
-  return fetcher.length === 0 ? fetcher() : fetcher(path);
-}
-
 export async function getUpcomingAssignments(fetcher) {
   return swrGet(
     "upcoming",
-    () => callFetcher(fetcher, "/users/self/upcoming_events?per_page=20"),
+    () => fetcher(),
     300 // 5 min TTL
   );
 }
@@ -107,7 +103,7 @@ export async function getUpcomingAssignments(fetcher) {
 export async function getCourses(fetcher) {
   return swrGet(
     "courses",
-    () => callFetcher(fetcher, "/courses?per_page=100&enrollment_state=active"),
+    () => fetcher(),
     3600 // 1 hour TTL
   );
 }
@@ -115,7 +111,7 @@ export async function getCourses(fetcher) {
 export async function getCourseAssignments(fetcher, courseId) {
   return swrGet(
     `assignments:${courseId}`,
-    () => callFetcher(fetcher, `/courses/${courseId}/assignments?per_page=50`),
+    () => fetcher(courseId),
     300
   );
 }

--- a/extension/src/lib/cache.js
+++ b/extension/src/lib/cache.js
@@ -92,26 +92,30 @@ async function refreshInBackground(key, fetchFn, ttlSeconds) {
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
-export async function getUpcomingAssignments(canvasGet) {
+function callFetcher(fetcher, path) {
+  return fetcher.length === 0 ? fetcher() : fetcher(path);
+}
+
+export async function getUpcomingAssignments(fetcher) {
   return swrGet(
     "upcoming",
-    () => canvasGet("/users/self/upcoming_events?per_page=20"),
+    () => callFetcher(fetcher, "/users/self/upcoming_events?per_page=20"),
     300 // 5 min TTL
   );
 }
 
-export async function getCourses(canvasGet) {
+export async function getCourses(fetcher) {
   return swrGet(
     "courses",
-    () => canvasGet("/courses?per_page=100&enrollment_state=active"),
+    () => callFetcher(fetcher, "/courses?per_page=100&enrollment_state=active"),
     3600 // 1 hour TTL
   );
 }
 
-export async function getCourseAssignments(canvasGet, courseId) {
+export async function getCourseAssignments(fetcher, courseId) {
   return swrGet(
     `assignments:${courseId}`,
-    () => canvasGet(`/courses/${courseId}/assignments?per_page=50`),
+    () => callFetcher(fetcher, `/courses/${courseId}/assignments?per_page=50`),
     300
   );
 }

--- a/extension/src/lib/canvas-client.js
+++ b/extension/src/lib/canvas-client.js
@@ -79,8 +79,12 @@ export class CanvasClient {
     return response.text();
   }
 
+  async getCurrentUser() {
+    return this.request('/users/self');
+  }
+
   async validateToken() {
-    const profile = await this.request('/users/self');
+    const profile = await this.getCurrentUser();
     return {
       ok: true,
       user: profile,
@@ -91,6 +95,10 @@ export class CanvasClient {
     return this.request('/users/self/upcoming_events', {
       params: { per_page: perPage },
     });
+  }
+
+  async getDashboardCards() {
+    return this.request('/dashboard/dashboard_cards');
   }
 
   async getCourses({ perPage = 100, enrollmentState = 'active' } = {}) {
@@ -105,6 +113,27 @@ export class CanvasClient {
   async getCourseAssignments(courseId, { perPage = 50 } = {}) {
     return this.request(`/courses/${courseId}/assignments`, {
       params: { per_page: perPage },
+    });
+  }
+
+  async getCourseModules(courseId, { perPage = 100 } = {}) {
+    return this.request(`/courses/${courseId}/modules`, {
+      params: { per_page: perPage },
+    });
+  }
+
+  async getCourseFiles(courseId, { perPage = 100 } = {}) {
+    return this.request(`/courses/${courseId}/files`, {
+      params: { per_page: perPage },
+    });
+  }
+
+  async getCourseAnnouncements(courseId, { perPage = 25 } = {}) {
+    return this.request('/announcements', {
+      params: {
+        'context_codes[]': `course_${courseId}`,
+        per_page: perPage,
+      },
     });
   }
 }

--- a/extension/src/lib/canvas-client.js
+++ b/extension/src/lib/canvas-client.js
@@ -1,0 +1,114 @@
+/**
+ * Shared Canvas client for browser-facing code.
+ *
+ * This is the extension-side equivalent of a lightweight SDK layer:
+ * - centralizes Canvas base URL + auth handling
+ * - exposes domain methods instead of scattered fetch calls
+ * - keeps popup/background logic thin
+ */
+
+import { getSetting, setSetting } from './cache.js';
+
+const DEFAULT_BASE_URL = 'https://canvas.vt.edu';
+const API_PREFIX = '/api/v1';
+
+function stripTrailingSlash(value) {
+  return String(value || DEFAULT_BASE_URL).replace(/\/+$/, '');
+}
+
+export class CanvasClient {
+  constructor({ baseUrl = DEFAULT_BASE_URL, tokenStore = getSetting, tokenWriter = setSetting } = {}) {
+    this.baseUrl = stripTrailingSlash(baseUrl);
+    this.tokenStore = tokenStore;
+    this.tokenWriter = tokenWriter;
+  }
+
+  async getToken() {
+    const stored = await this.tokenStore('canvas_token', 'settings');
+    return stored?.value ?? null;
+  }
+
+  async setToken(token) {
+    const normalized = token?.trim() || null;
+    await this.tokenWriter(normalized, 'canvas_token', 'settings');
+    return normalized;
+  }
+
+  async clearToken() {
+    await this.tokenWriter(null, 'canvas_token', 'settings');
+  }
+
+  buildUrl(path, params = null) {
+    const url = new URL(`${this.baseUrl}${API_PREFIX}${path}`);
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value === undefined || value === null || value === '') return;
+        url.searchParams.set(key, String(value));
+      });
+    }
+    return url.toString();
+  }
+
+  async request(path, { method = 'GET', params = null, headers = {}, body = undefined } = {}) {
+    const token = await this.getToken();
+    if (!token) throw new Error('Not authenticated');
+
+    const response = await fetch(this.buildUrl(path, params), {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/json',
+        ...headers,
+      },
+      body,
+    });
+
+    if (response.status === 401) {
+      await this.clearToken();
+      throw new Error('Token expired');
+    }
+
+    if (!response.ok) {
+      throw new Error(`Canvas API error: ${response.status}`);
+    }
+
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    return response.text();
+  }
+
+  async validateToken() {
+    const profile = await this.request('/users/self');
+    return {
+      ok: true,
+      user: profile,
+    };
+  }
+
+  async getUpcomingAssignments({ perPage = 20 } = {}) {
+    return this.request('/users/self/upcoming_events', {
+      params: { per_page: perPage },
+    });
+  }
+
+  async getCourses({ perPage = 100, enrollmentState = 'active' } = {}) {
+    return this.request('/courses', {
+      params: {
+        per_page: perPage,
+        enrollment_state: enrollmentState,
+      },
+    });
+  }
+
+  async getCourseAssignments(courseId, { perPage = 50 } = {}) {
+    return this.request(`/courses/${courseId}/assignments`, {
+      params: { per_page: perPage },
+    });
+  }
+}
+
+export function createCanvasClient(options = {}) {
+  return new CanvasClient(options);
+}

--- a/extension/src/lib/extension-api.js
+++ b/extension/src/lib/extension-api.js
@@ -1,0 +1,47 @@
+/**
+ * Shared runtime bridge for popup/content-script code.
+ *
+ * Keeps Chrome message names and background contract details out of UI files.
+ */
+
+import { MESSAGE_TYPES } from './extension-contract.js';
+
+function send(type, payload = {}) {
+  return chrome.runtime.sendMessage({ type, ...payload });
+}
+
+export async function getUpcomingAssignments() {
+  return send(MESSAGE_TYPES.getUpcoming);
+}
+
+export async function getCourses() {
+  return send(MESSAGE_TYPES.getCourses);
+}
+
+export async function getCourseAssignments(courseId) {
+  return send(MESSAGE_TYPES.getCourseAssignments, { courseId });
+}
+
+export async function validateToken() {
+  return send(MESSAGE_TYPES.validateToken);
+}
+
+export async function setToken(token) {
+  return send(MESSAGE_TYPES.setToken, { token });
+}
+
+export async function getToken() {
+  return send(MESSAGE_TYPES.getToken);
+}
+
+export async function clearCache() {
+  return send(MESSAGE_TYPES.clearCache);
+}
+
+export async function refreshBadge() {
+  return send(MESSAGE_TYPES.refreshBadge);
+}
+
+export async function dismissAssignmentRemote(assignmentId) {
+  return send(MESSAGE_TYPES.dismiss, { assignmentId });
+}

--- a/extension/src/lib/extension-contract.js
+++ b/extension/src/lib/extension-contract.js
@@ -1,0 +1,17 @@
+/**
+ * Shared extension runtime contract.
+ *
+ * Keeps message type names centralized so UI/background stay in sync.
+ */
+
+export const MESSAGE_TYPES = {
+  getUpcoming: 'GET_UPCOMING',
+  getCourses: 'GET_COURSES',
+  getCourseAssignments: 'GET_COURSE_ASSIGNMENTS',
+  validateToken: 'VALIDATE_TOKEN',
+  getToken: 'GET_TOKEN',
+  setToken: 'SET_TOKEN',
+  dismiss: 'DISMISS',
+  clearCache: 'CLEAR_CACHE',
+  refreshBadge: 'REFRESH_BADGE',
+};

--- a/extension/src/popup/app.js
+++ b/extension/src/popup/app.js
@@ -10,6 +10,13 @@
  */
 
 import { getDismissed, dismissAssignment } from '../lib/cache.js';
+import {
+  getCourses,
+  getUpcomingAssignments,
+  setToken,
+  clearCache,
+  refreshBadge,
+} from '../lib/extension-api.js';
 
 // ── DOM Refs ──────────────────────────────────────────────────────────────────
 
@@ -151,7 +158,7 @@ function attachHandlers() {
       await dismissAssignment(id);
       dismissedIds.add(id);
       render(allAssignments);
-      chrome.runtime.sendMessage({ type: "REFRESH_BADGE" });
+      refreshBadge();
     });
   });
 
@@ -194,7 +201,7 @@ async function fetchAll() {
   try {
     dismissedIds = await getDismissed();
 
-    const coursesRes = await chrome.runtime.sendMessage({ type: "GET_COURSES" });
+    const coursesRes = await getCourses();
     if (coursesRes.ok && coursesRes.data?.length) {
       courses = coursesRes.data;
       $userInfo.textContent = `${courses.length} course${courses.length === 1 ? "" : "s"}`;
@@ -202,7 +209,7 @@ async function fetchAll() {
       $userInfo.textContent = "Canvas";
     }
 
-    const res = await chrome.runtime.sendMessage({ type: "GET_UPCOMING" });
+    const res = await getUpcomingAssignments();
     if (!res.ok) throw new Error(res.error || "Failed to fetch assignments");
 
     allAssignments = res.data.filter((entry) => entry.type === "assignment");
@@ -263,7 +270,7 @@ function openSettings() {
     }
 
     status.textContent = "Saving and validating...";
-    const res = await chrome.runtime.sendMessage({ type: "SET_TOKEN", token });
+    const res = await setToken(token);
     status.textContent = res.ok
       ? `Connected as ${res.user?.name || res.user?.short_name || 'Canvas user'}.`
       : `Error: ${res.error}`;
@@ -283,8 +290,9 @@ function closeSettings() {
 
 // ── Init ──────────────────────────────────────────────────────────────────────
 
-$refreshBtn.addEventListener("click", () => {
-  chrome.runtime.sendMessage({ type: "CLEAR_CACHE" }, () => fetchAll());
+$refreshBtn.addEventListener("click", async () => {
+  await clearCache();
+  fetchAll();
 });
 
 $settingsBtn.addEventListener("click", () => {

--- a/extension/src/popup/app.js
+++ b/extension/src/popup/app.js
@@ -262,10 +262,17 @@ function openSettings() {
       return;
     }
 
-    status.textContent = "Saving...";
+    status.textContent = "Saving and validating...";
     const res = await chrome.runtime.sendMessage({ type: "SET_TOKEN", token });
-    status.textContent = res.ok ? "Token saved." : `Error: ${res.error}`;
-    if (res.ok) setTimeout(closeSettings, 900);
+    status.textContent = res.ok
+      ? `Connected as ${res.user?.name || res.user?.short_name || 'Canvas user'}.`
+      : `Error: ${res.error}`;
+    if (res.ok) {
+      setTimeout(() => {
+        closeSettings();
+        fetchAll();
+      }, 900);
+    }
   };
 }
 


### PR DESCRIPTION
## Summary\n- expand the shared extension-side Canvas client with additional domain methods\n- centralize the popup/background runtime contract into shared message helpers\n- remove more raw endpoint and message knowledge from non-client UI code\n\n## Validation\n- node --check extension/src/background.js\n- node --check extension/src/popup/app.js\n- node --check extension/src/lib/canvas-client.js\n- node --check extension/src/lib/extension-api.js\n- node --check extension/src/lib/extension-contract.js\n