### PR TITLE
Update site docs for extension architecture and governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ This is the **CS3704 team project repository** for a Canvas LMS productivity too
 
 ### Architecture goals
 - **Current**: Feature-complete TUI application
-- **Shared core**: Reusable domain logic and orchestration
-- **Future**: Browser extension parity with same business logic
+- **Current**: Browser extension with popup, background worker, IndexedDB cache, and shared JS client/runtime layer
+- **Shared core direction**: Reusable domain logic and orchestration where practical across surfaces
+- **Future**: Deeper parity between TUI and browser-facing features
 
 ---
 
@@ -138,6 +139,8 @@ docs/architecture/        Mermaid diagrams and SVG exports
 docs/assets/              Static images and captures
 docs/project/             Planning artifacts and legacy docs
 docs-site/                GitHub Pages documentation
+extension/                Browser extension source
+sdk/                      Python SDK experiments and support code
 ```
 
 ---
@@ -145,16 +148,17 @@ docs-site/                GitHub Pages documentation
 ## Team Workflow
 
 ### For maintainers
-1. Push directly to `main` (protected, but admin bypass enabled)
-2. Ensure CI passes before merging others' PRs
-3. Review team PRs promptly
+1. Treat `main` as the only long-term branch
+2. Use short-lived feature branches for scoped work when possible
+3. Ensure CI passes before merging others' PRs
+4. Prefer squash merges and let GitHub auto-delete merged branches
 
 ### For team members
 1. **Never push directly to `main`**
-2. Create a feature branch: `feature/your-feature-name`
-3. Open a Pull Request
+2. Create a short-lived feature branch: `feature/your-feature-name`
+3. Open a Pull Request into `main`
 4. Wait for CI to pass and a maintainer to review
-5. Merge when approved
+5. Merge with squash when approved
 
 ### Branch naming convention
 - `feature/*` — new features
@@ -177,13 +181,16 @@ This repository has extensive automation:
 | **Stale** | Close inactive issues/PRs after 30 days |
 | **Labeler** | Auto-label PRs by changed files |
 
+The repository is configured for squash-only merges into protected `main`, linear history, and branch auto-delete after merge.
 All commits to protected branches must be **GPG signed**.
 
 ---
 
 ## Documentation
 
+- **[Docs site](https://kleinpanic.github.io/CS3704-Canvas-Project/)** — live project docs
 - **[Architecture docs](docs-site/architecture.md)** — system design decisions
+- **[Browser extension docs](docs-site/extension.md)** — shared client/runtime architecture
 - **[Workflow guide](docs-site/workflow.md)** — how the team works
 - **[Contributing](CONTRIBUTING.md)** — contribution guidelines
 - **[Maintainers](MAINTAINERS.md)** — maintainer responsibilities

--- a/docs-site/architecture.md
+++ b/docs-site/architecture.md
@@ -1,88 +1,93 @@
 # Architecture
 
-The Canvas TUI follows a **Model-View-Controller (MVC)** architecture with a **shared domain core** designed for future parity with a browser extension.
+This project now has two active product surfaces:
+- a Python/Textual TUI
+- a browser extension with its own shared JS client/runtime layer
 
-## Design Philosophy
+## Design Principles
 
-- **Offline-first**: SQLite cache enables reliable offline operation
-- **Shared logic**: Business rules in reusable domain layer
-- **Platform adapters**: UI and storage specific to each platform
-- **Observable**: Structured logging and metrics for maintenance
+- **Offline-first** where practical, using persistent cache layers
+- **Shared contracts** instead of scattered UI-to-service coupling
+- **Platform-specific adapters** for storage, notifications, and runtime details
+- **Governed delivery** through CI/CD and protected `main`
 
-## Architecture Diagrams
+## High-Level Layout
 
-### High-level System Design
+```text
+TUI (Python)
+  -> src/canvas_tui/
+  -> Canvas API + SQLite-backed local state
 
-![Complex Architecture](assets/architecture/complex-architecture.svg)
+Extension (JS)
+  -> extension/src/popup/
+  -> extension/src/background.js
+  -> extension/src/lib/canvas-client.js
+  -> extension/src/lib/cache.js
+  -> Canvas API + IndexedDB-backed local state
+```
 
-*Component relationships and data flow*
-
-### Sync Sequence
-
-![Sync Flow](assets/architecture/sync-flow.svg)
-
-*Data refresh and synchronization flow*
-
-## Core Patterns
-
-### MVC Pattern
+## TUI Architecture
 
 | Layer | Components | Files |
 |-------|------------|-------|
-| **Model** | API client, state management, cache | `api.py`, `state.py`, `cache.py`, `models.py` |
-| **View** | Textual screens and widgets | `screens/`, `widgets/` |
-| **Controller** | App orchestration, routing | `app.py`, `cli.py` |
+| **Application** | App orchestration, routing, screens | `app.py`, `cli.py`, `screens/`, `widgets/` |
+| **Domain/Data** | API, models, state, caching | `api.py`, `models.py`, `state.py`, `cache.py` |
+| **Infrastructure** | Config, sync helpers, adapters | `config.py`, `prefetch.py`, `adapters/` |
 
-### Command Pattern
+## Browser Extension Architecture
 
-User actions are encapsulated as commands:
-- `RefreshDataCommand` — sync with Canvas API
-- `SwitchScreenCommand` — navigate between views
-- `ApplyFilterCommand` — filter displayed data
+The extension is no longer just an aspirational diagram. It now has a real layered structure.
 
-This decouples UI widgets from application logic.
+| Layer | Role | Files |
+|------|------|------|
+| **UI** | Popup rendering and interaction | `extension/src/popup/*` |
+| **Runtime bridge** | Message helpers and shared contract | `extension/src/lib/extension-api.js`, `extension/src/lib/extension-contract.js` |
+| **Service orchestration** | Background handlers, badge updates, notifications | `extension/src/background.js` |
+| **Canvas access** | Shared browser-side client methods | `extension/src/lib/canvas-client.js` |
+| **Persistence** | IndexedDB stale-while-revalidate cache | `extension/src/lib/cache.js` |
 
-### Repository Pattern
+## Why the Extension Refactor Matters
 
-Data access is abstracted through the API gateway and cache:
-- Transparent offline/online operation
-- Consistent error handling
-- Rate limiting and retry logic
+Recent work moved the extension away from:
+- raw endpoint strings spread across multiple files
+- popup code depending on raw Chrome runtime message names
+- background logic acting as both transport and domain layer
 
-## Component Overview
+The new structure centralizes:
+- Canvas auth and endpoint access in `canvas-client.js`
+- runtime message names in `extension-contract.js`
+- popup/background calls in `extension-api.js`
 
-### Canvas API Gateway
+That makes the extension easier to reason about and safer to extend.
 
-- Authentication and session management
-- Request normalization
-- Rate limiting (429 handling)
-- Retry with exponential backoff
+## Cache Strategy
 
-### Offline Cache
+| Surface | Cache |
+|---------|-------|
+| **TUI** | SQLite / local Python-side persistence |
+| **Extension** | IndexedDB with stale-while-revalidate helpers |
 
-- SQLite persistence layer
-- Full + incremental sync strategies
-- Cache invalidation policies
-- Conflict resolution
+The two surfaces do **not** share a runtime cache implementation today, but they follow similar separation principles.
 
-### Textual TUI
+## Documentation Assets
 
-- Dashboard with course overview
-- Assignment detail screens
-- Grades with trend visualization
-- File browser and downloads
-- Calendar with ICS export
+### Static diagrams
+- [Full Architecture SVG](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/docs/architecture/complex-architecture.svg)
+- [Sync Flow SVG](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/docs/architecture/sync-flow.svg)
 
-## Source Files
+### Source diagrams
+- `docs/architecture/complex-architecture.mmd`
+- `docs/architecture/sync-sequence.mmd`
 
-- Architecture diagrams: `docs/architecture/*.mmd`
-- SVG exports: `docs/assets/architecture/*.svg`
-- Wiki documentation: [Architecture Overview](https://github.com/kleinpanic/CS3704-Canvas-Project/wiki/Architecture-Overview)
+## Current Reality vs Future Goal
 
-## Future: Browser Extension
+### Current reality
+- strong TUI codebase
+- working extension foundation
+- shared browser-side client layer
+- repo governance cleaned up around `main`
 
-The shared domain core enables:
-- Same business logic for TUI and extension
-- Platform-specific UI adapters
-- Shared test suite for core logic
-- Feature parity without duplication
+### Future goal
+- deeper shared-core parity where business logic can be reused more directly across surfaces
+- stronger tests around the extension runtime bridge and client methods
+- broader extension feature coverage for files, announcements, and richer Canvas context

--- a/docs-site/extension.md
+++ b/docs-site/extension.md
@@ -1,0 +1,83 @@
+# Browser Extension Architecture
+
+This page documents the current browser extension architecture after the shared-client refactor landed on `main`.
+
+## Current Status
+
+The browser extension is now a real part of the project, not just a future placeholder.
+
+Implemented pieces:
+- MV3 browser extension source under `extension/`
+- popup UI for upcoming assignments and course filtering
+- background service worker for sync, badge updates, and notifications
+- IndexedDB cache adapter for stale-while-revalidate behavior
+- shared extension-side Canvas client layer
+- shared runtime contract between popup and background code
+
+## What Changed Recently
+
+The extension no longer keeps raw Canvas access logic scattered across UI files.
+
+Instead, the browser-facing stack is organized like this:
+
+```text
+popup UI
+  -> extension-api.js
+  -> extension-contract.js
+  -> background.js
+  -> canvas-client.js
+  -> Canvas REST API
+```
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `extension/src/lib/canvas-client.js` | Shared Canvas domain client for browser-side code |
+| `extension/src/lib/extension-contract.js` | Central message-type contract |
+| `extension/src/lib/extension-api.js` | Shared runtime bridge used by popup/content code |
+| `extension/src/background.js` | Service worker orchestration, cache access, notifications, badge refresh |
+| `extension/src/lib/cache.js` | IndexedDB cache and stale-while-revalidate helpers |
+| `extension/src/popup/app.js` | Popup UI logic |
+| `extension/src/popup/styles.css` | Popup visual system |
+
+## Why This Matters
+
+Before the refactor, raw endpoint knowledge and runtime message details leaked into more than one layer.
+
+Now:
+- Canvas auth and endpoint access are centralized in `canvas-client.js`
+- popup code talks through a shared runtime bridge instead of raw message strings
+- runtime message names are defined once in `extension-contract.js`
+- background logic is thinner and easier to extend
+
+That gives the project:
+- cleaner maintenance
+- fewer UI-to-background coupling mistakes
+- easier future extension features
+- a better path toward testable shared browser logic
+
+## Current Constraints
+
+The browser extension does **not** use the Python SDK directly.
+
+That is expected.
+
+A browser extension cannot natively consume the Python package in the same way the TUI does. The correct browser-side equivalent is a shared JS client layer, which is what this project now uses.
+
+## Next Recommended Steps
+
+1. Extend the shared client for more Canvas domains as features expand
+2. Add tests around the browser-side runtime contract and client methods
+3. Reduce any remaining direct Chrome runtime assumptions outside the bridge layer
+4. Decide whether content scripts should also consume `extension-api.js`
+5. Document token/auth strategy more explicitly if OAuth replaces manual tokens later
+
+## Relationship to the TUI
+
+The TUI and browser extension are still separate runtime stacks, but the extension is now closer to the same architectural discipline:
+- domain access centralized
+- cache isolated
+- UI and transport separated
+
+That is the right intermediate step before any deeper shared-core unification.

--- a/docs-site/index.md
+++ b/docs-site/index.md
@@ -4,80 +4,77 @@ Welcome to the team documentation portal. This site is built with MkDocs and dep
 
 ## Project Overview
 
-**Canvas TUI** is a Canvas LMS productivity client with a Textual terminal interface today, and a documented path toward browser extension parity using a shared-core architecture.
+**CS3704 Canvas Project** is a Canvas LMS productivity client with a mature Textual TUI, a live browser extension codebase, and a maintained documentation portal.
 
-> **Current status:** Feature-complete TUI in production use. Phase 2 (core architecture refactor) is the next milestone toward browser extension parity.
+> **Current status:** `main` is the only long-term branch, the docs site deploys from `main`, and the browser extension now has a shared client/runtime architecture instead of ad hoc popup-to-background wiring.
 
 ## Quick Links
 
 | Resource | Link |
 |----------|------|
-| **Live TUI** | Run `pip install -e ".[dev]"` then `python -m canvas_tui` |
 | **GitHub Repo** | [kleinpanic/CS3704-Canvas-Project](https://github.com/kleinpanic/CS3704-Canvas-Project) |
 | **Open Issues** | [Issue Tracker](https://github.com/kleinpanic/CS3704-Canvas-Project/issues) |
 | **Open PRs** | [Pull Requests](https://github.com/kleinpanic/CS3704-Canvas-Project/pulls) |
-| **Dependabot** | [Dependency Updates](https://github.com/kleinpanic/CS3704-Canvas-Project/security/dependabot) |
 | **Project Board** | [Sprint Board](https://github.com/users/kleinpanic/projects/5) |
+| **Docs Site** | [GitHub Pages](https://kleinpanic.github.io/CS3704-Canvas-Project/) |
 
 ## Architecture Documentation
 
-- **[Architecture Overview](architecture.md)** — System design, MVC pattern, shared-core strategy, and extension roadmap
-- **[Team Workflow](workflow.md)** — Branch strategy, PR process, CI gates, and contribution guidelines
-- **[Project Roadmap](roadmap.md)** — Milestones, PM deliverables, and planned features
+- **[Architecture Overview](architecture.md)** — current application structure and platform layout
+- **[Browser Extension](extension.md)** — shared client, runtime contract, popup/background architecture
+- **[Team Workflow](workflow.md)** — branch strategy, PR process, CI gates, and contribution policy
+- **[Project Roadmap](roadmap.md)** — current status, active architecture work, and next milestones
 
-## Project Status
+## Current Product Surface
 
-### Features Implemented
-- TUI dashboard with course scores, due-soon items, grade trends, and completion gauges
-- Per-course grade breakdown with what-if calculator, sort modes, and trend sparklines
-- Calendar week view with 7-day grid
-- Offline-first caching with SQLite persistence
-- ICS export, Pomodoro timer, notification support
-- Command bar filtering with query syntax
+### Implemented Today
+- Textual TUI dashboard and course views
+- grades and assignment workflows
+- offline-first cache layers
+- browser extension popup and background worker
+- extension-side shared Canvas client layer
+- GitHub Pages documentation site
+- CI/CD and protected-branch governance
 
-### Upcoming (Phase 2)
-- Core architecture refactor: extract `CanvasClient` and `CacheBackend` interfaces
-- Browser extension scaffolding with shared-domain architecture
-- Deployment automation: PyPI upload, Chrome/Firefox extension stores
-
-See [VISUAL-AUDIT.md](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/docs-site/VISUAL-AUDIT.md) for the full advancement plan.
+### Important Repo Policy
+- `main` is the canonical long-term branch
+- feature branches are temporary and PR-scoped
+- merged PR branches should be deleted
+- direct AI automation is not part of the merge path
 
 ## Deployment
 
 | Environment | URL | Trigger |
 |-------------|-----|---------|
 | **Docs Site** | [kleinpanic.github.io/CS3704-Canvas-Project](https://kleinpanic.github.io/CS3704-Canvas-Project) | Every push to `main` |
-| **PyPI Package** | `pip install canvas-tui` | On git tag push |
+| **Release snapshots** | GitHub Releases | Main/release workflow |
 
-The docs site is built with MkDocs Material and deployed via GitHub Actions — no manual steps required.
+The docs site is built with MkDocs Material and deployed via GitHub Actions.
+
+## CI/CD Snapshot
+
+```text
+feature/docs/fix branch
+  -> PR to main
+  -> Branch Name Policy
+  -> Test
+  -> Python Compat matrix
+  -> maintainer review
+  -> squash merge
+  -> branch auto-deleted
+
+main
+  -> Pages deploy
+  -> release/security follow-up workflows
+```
 
 ## Team
 
 | Role | Member | Responsibility |
 |------|--------|----------------|
 | **Owner** | Klein Panic | Architecture, CI/CD, releases |
-| **Maintainer** | Williammm23 | Grades screen, feature development |
-| **Maintainer** | pjie22 | Documentation, implementation reviews |
-| **Maintainer** | 802797liu | Test coverage, filtering improvements |
+| **Maintainer** | Williammm23 | Feature development |
+| **Maintainer** | pjie22 | Documentation and implementation review |
+| **Maintainer** | 802797liu | Tests and filtering work |
 
-See [CONTRIBUTORS.md](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/CONTRIBUTORS.md) for full credits and [MAINTAINERS.md](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/MAINTAINERS.md) for working agreements.
-
-## CI/CD Pipeline
-
-```
-PR opened
-  → Test (pytest, py3.11)
-  → Coverage (80% threshold, bypass with #no-coverage-check)
-  → Python Compat (3.11/3.12/3.13 smoke, informational)
-  → PASS → review + merge
-  → FAIL → AI fixup branch pushed (via Nemotron on DGX Spark)
-
-Merged to main
-  → Pages (docs site rebuild + deploy)
-  → Auto Docs (Nemotron docstring generation, separate PR)
-  → Security scan (CodeQL, informational)
-```
-
-## Security
-
-See [SECURITY.md](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/SECURITY.md) for the security policy and [dependabot.yml](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/.github/dependabot.yml) for automated dependency updates.
+See [CONTRIBUTORS.md](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/CONTRIBUTORS.md) and [MAINTAINERS.md](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/MAINTAINERS.md) for more detail.

--- a/docs-site/roadmap.md
+++ b/docs-site/roadmap.md
@@ -1,85 +1,69 @@
 # Project Roadmap
 
-This page tracks major milestones and upcoming work for the CS3704 Canvas project.
+This roadmap reflects the current post-cleanup state of the repository.
 
-## Current Milestone: PM3
+## Current State
 
-**Focus**: Design documentation and architecture visualization
+Recently completed:
+- repo governance cleanup around `main`
+- removal of AI auto-fix and auto-doc workflows from the main merge path
+- browser extension popup visual polish pass
+- browser extension shared client/runtime contract refactor
+- cleanup of stale remote branches
 
-### Deliverables
+## Near-Term Priorities
 
-- [x] Repository setup and governance
-- [x] CI/CD pipeline (lint, test, build, security)
-- [x] Architecture diagrams (Mermaid + SVG)
-- [x] Documentation portal (Pages)
-- [x] Team workflow documentation
-- [ ] Design pattern rationale (in progress)
-- [ ] Wireframes/storyboards
+### 1. Browser extension hardening
+- add tests around the shared client and runtime contract
+- expand course-context features that use modules, files, and announcements
+- reduce any remaining direct background/runtime coupling
 
-**Due**: April 4, 2026
+### 2. Docs and site maintenance
+- keep MkDocs pages aligned with current architecture
+- update screenshots/diagrams when UI or structure changes
+- keep workflow/governance pages consistent with real repo settings
 
-## Upcoming: PM4
+### 3. Repo architecture cleanup
+- decide how to isolate `GemmaReranker` and related data from core app concerns
+- clarify what is core product code versus experimental/support tooling
 
-**Focus**: Core implementation
+## Delivery Model
 
-### Planned Work
-
-- [ ] Canvas API integration
-- [ ] Offline cache implementation
-- [ ] Dashboard screen
-- [ ] Assignment detail view
-- [ ] Basic test coverage
-
-**Due**: TBD
-
-## Sprint Backlog
-
-Check the [Project Board](https://github.com/users/kleinpanic/projects/5) for current sprint tasks.
-
-### Active Issues
-
-| Issue | Title | Status |
-|-------|-------|--------|
-| [#15](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/15) | Dashboard landing screen | Open |
-| [#16](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/16) | Assignment detail view | Open |
-| [#17](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/17) | Grades overview | Open |
-| [#18](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/18) | Canvas API authentication | Open |
-| [#19](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/19) | Offline cache with SQLite | Open |
-
-## Technical Debt
-
-| Item | Priority | Status |
-|------|----------|--------|
-| Mypy stabilization (75 errors) | Medium | Advisory |
-| Test coverage expansion | Medium | Ongoing |
-| Documentation completeness | Low | In progress |
-
-## Future Milestones
-
-### PM5: Testing & Quality
-- Comprehensive test suite
-- Code coverage >80%
-- Performance benchmarks
-- Security audit
-
-### PM6: Delivery
-- Final integration
-- Documentation polish
-- Release preparation
-- Course submission
-
-## Milestones Timeline
-
-```
-PM3 ─── Apr 4 ─── Design docs
-PM4 ─── TBD ───── Core implementation
-PM5 ─── TBD ───── Testing & quality
-PM6 ─── TBD ───── Final delivery
+```text
+small scoped branch
+  -> PR to main
+  -> CI checks
+  -> maintainer review
+  -> squash merge
+  -> docs site auto-deploys from main
 ```
 
----
+## Extension Roadmap Snapshot
 
-**See also**:
-- [Architecture](architecture.md) — system design
-- [Workflow](workflow.md) — team process
-- [GitHub Issues](https://github.com/kleinpanic/CS3704-Canvas-Project/issues) — task tracker
+The extension is no longer just a future placeholder.
+
+Implemented now:
+- popup UI
+- background worker
+- IndexedDB cache
+- shared Canvas client layer
+- shared runtime contract
+
+Still needed:
+- broader feature coverage
+- deeper tests
+- clearer auth strategy if OAuth replaces token entry
+
+## Medium-Term Follow-Ups
+
+- richer extension parity with the TUI
+- improved architecture diagrams reflecting the browser-side layers
+- possible isolation of optional tooling/data into better-scoped directories or repos
+
+## Success Criteria
+
+The project is in a good state when:
+- `main` stays the only durable branch
+- docs site reflects actual architecture, not stale plans
+- extension changes land through a predictable contract layer
+- maintainers do not need ad hoc branch-protection surgery for normal work

--- a/docs-site/workflow.md
+++ b/docs-site/workflow.md
@@ -1,124 +1,97 @@
-# Team Workflow
+# Workflow & Governance
 
-This page documents how the team coordinates on the CS3704 Canvas project.
+This page documents how the team should work in the repository after the branch and protection cleanup.
 
-## Quick Reference
+## Canonical Branch Policy
 
-| Action | How |
-|--------|-----|
-| **Report a bug** | [Open an Issue](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/new/choose) |
-| **Request a feature** | [Open an Issue](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/new/choose) |
-| **Ask a question** | [Start a Discussion](https://github.com/kleinpanic/CS3704-Canvas-Project/discussions) |
-| **Check sprint tasks** | [Project Board](https://github.com/users/kleinpanic/projects/5) |
-| **Read documentation** | [Wiki](https://github.com/kleinpanic/CS3704-Canvas-Project/wiki) |
+- `main` is the only long-term branch
+- feature branches are temporary and should exist only long enough to support a PR
+- merged PR branches should be deleted automatically
+- maintainers should avoid leaving stale remote branches around
 
 ## Contribution Flow
 
-### 1. Find Work
-
-- Check the [Project Board](https://github.com/users/kleinpanic/projects/5) for ready tasks
-- Browse [Open Issues](https://github.com/kleinpanic/CS3704-Canvas-Project/issues)
-- Comment on an issue to claim it
-
-### 2. Create Branch
+### 1. Create a short-lived branch
 
 ```bash
 git checkout main
-git pull
-git checkout -b feature/your-feature-name
+git pull --ff-only
+git checkout -b feature/your-change
 ```
 
-**Branch naming**:
+Accepted prefixes:
+- `feature/*`
+- `fix/*`
+- `chore/*`
+- `docs/*`
+- `refactor/*`
+- `test/*`
+- `hotfix/*`
 
-| Prefix | Purpose | Example |
-|--------|---------|---------|
-| `feature/` | New functionality | `feature/grades-chart` |
-| `fix/` | Bug fixes | `fix/api-timeout` |
-| `chore/` | Maintenance | `chore/update-deps` |
-| `docs/` | Documentation | `docs/improve-readme` |
+### 2. Make changes
 
-### 3. Make Changes
+- keep commits focused
+- test locally when relevant
+- avoid landing generated AI artifacts without human review
+- keep docs in sync when architecture or workflow changes
 
-- Write clean, tested code
-- Follow the [Development Guide](https://github.com/kleinpanic/CS3704-Canvas-Project/wiki/Development-Guide)
-- Commit with descriptive messages
-
-### 4. Open Pull Request
+### 3. Open a PR to `main`
 
 ```bash
-git push origin feature/your-feature-name
+git push origin feature/your-change
 ```
 
-Then:
-1. Go to GitHub and open a PR
-2. Fill in the PR template
-3. Link to related issues
-4. Request review from a maintainer
+Then open a PR and let GitHub run checks.
 
-### 5. Pass Checks
+## Required Merge Shape
 
-CI will automatically run:
-- **Lint** (ruff) — code style
-- **Tests** (pytest) — unit tests on Python 3.11/3.12/3.13
-- **Package build** — verify build succeeds
-- **Security** (CodeQL) — vulnerability scan
+The repository is configured for:
+- **squash merge only**
+- **linear history**
+- **conversation resolution before merge**
+- **branch auto-delete after merge**
 
-Fix any failures before review.
+Merge commits and rebase merges are disabled.
 
-### 6. Address Review
+## Required Checks
 
-- Respond to all comments
-- Make requested changes
-- Mark conversations as resolved
-- Push new commits
+Current protected-branch checks are:
+- `Branch Name Policy`
+- `Test`
+- `Python Compat (3.11)`
+- `Python Compat (3.12)`
+- `Python Compat (3.13)`
 
-### 7. Merge
+## Important Maintainer Notes
 
-A maintainer will merge when:
-- All checks pass
-- Review is approved
-- Conversations are resolved
+- admins are enforced on `main`
+- protections should match real workflow job names, not guessed names
+- if branch protection is blocking valid maintainer work, fix the policy instead of piling on bypasses
+- if a repo-owned PR must be merged urgently, document why
 
-## Branch Protection
+## AI and Automation Policy
 
-The `main` branch is protected with:
+The repo no longer uses AI auto-fix or AI auto-doc workflows in the normal merge path.
 
-- ✅ PR required (no direct push for team)
-- ✅ Passing CI checks required
-- ✅ Code owner review required
-- ✅ Signed commits required
-- ✅ Linear history enforced
-- ✅ Conversations must be resolved
+That means:
+- CI failures should be fixed intentionally
+- documentation updates should be reviewed by a maintainer
+- generated output should never be merged blindly
 
-**Maintainers** can bypass these for emergency fixes.
+## Docs Site Workflow
 
-## Automation
+The public docs site is built with MkDocs from `docs-site/` and deployed from pushes to `main`.
 
-| Bot | Purpose | Frequency |
-|-----|---------|-----------|
-| **CI** | Lint, test, build | Every push |
-| **Dependabot** | Dependency updates | Weekly |
-| **Stale** | Close inactive issues | Daily |
-| **Labeler** | Label PRs by files | Every PR |
-| **Auto-assign** | Assign new issues | Every issue |
-| **Release** | Create snapshots | Every main push |
+When updating docs:
+- update `docs-site/` for site-facing pages
+- update `README.md` for repo-facing overview changes
+- keep roadmap/workflow/architecture pages consistent with actual repo behavior
 
-## Issue Templates
+## Quick Reference
 
-Use the appropriate template when opening issues:
-
-- **Bug Report** — Report something broken
-- **Feature Request** — Propose new functionality
-- **Task** — General work item
-
-[Create an Issue →](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/new/choose)
-
-## Questions?
-
-- **Quick questions**: [Discussions](https://github.com/kleinpanic/CS3704-Canvas-Project/discussions)
-- **Bugs/Features**: [Issues](https://github.com/kleinpanic/CS3704-Canvas-Project/issues)
-- **Urgent**: Contact [@kleinpanic](https://github.com/kleinpanic)
-
----
-
-**See also**: [Team Workflow (Wiki)](https://github.com/kleinpanic/CS3704-Canvas-Project/wiki/Team-Workflow)
+| Action | Expected path |
+|--------|----------------|
+| Feature work | short-lived branch -> PR -> squash merge |
+| Docs update | `docs-site/` + README when needed |
+| Governance change | update GitHub protections and document it |
+| Extension architecture change | update code + `docs-site/extension.md` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Architecture: architecture.md
+  - Browser Extension: extension.md
   - Workflow & Governance: workflow.md
   - Roadmap: roadmap.md
   - PM3 Review: pm3-review.md


### PR DESCRIPTION
## Summary\n- refresh the docs site home, architecture, workflow, and roadmap pages\n- add a dedicated browser extension docs page\n- update the README and MkDocs navigation to reflect the current repo and extension architecture\n\n## Validation\n- .docs-venv/bin/mkdocs build --site-dir site\n