### PR TITLE
feat(reranker): Phase 01.1 + agent skeleton + GemmaReranker pipeline sync

### DIFF
--- a/GemmaReranker/README.md
+++ b/GemmaReranker/README.md
@@ -1,6 +1,19 @@
-# GemmaReranker — DPO Training for Canvas Priority Reranker
+# GemmaReranker — Multi-Method Fine-Tuning for Canvas Priority Reranker
 
-Self-contained project for training a DPO-based priority reranker for the Canvas Deadline Tracker.
+Source-of-truth pipeline for training Canvas LMS preference rerankers
+on Gemma-4-E2B-IT. Compares 9 fine-tuning methods (SFT, LoRA, QLoRA,
+DPO, IPO, APO-zero, SPPO, NCA, KTO) on a single shared corrected base
+and a single item-disjoint train/test split.
+
+## 🔗 Published artifacts
+
+| Artifact | URL |
+|----------|-----|
+| **HF Collection** (all variants + dataset + paper) | [huggingface.co/collections/kleinpanic93/canvas-reranker-gemma-4-e2b-it-v10-69f5799662d65c8f39be0a94](https://huggingface.co/collections/kleinpanic93/canvas-reranker-gemma-4-e2b-it-v10-69f5799662d65c8f39be0a94) |
+| **Primary model repo** (4 GGUF quants + BF16 + paper) | [`kleinpanic93/gemma4-canvas-reranker`](https://huggingface.co/kleinpanic93/gemma4-canvas-reranker) |
+| **Method-variant repos** | `kleinpanic93/gemma4-canvas-reranker-{sft,lora,qlora,dpo,ipo,apo-zero,sppo,nca,kto}` |
+| **Dataset** | [`kleinpanic93/canvas-preference-2k`](https://huggingface.co/datasets/kleinpanic93/canvas-preference-2k) (1,347 unique pairs) |
+| **Paper** | `paper/main.pdf` in primary model repo (Zenodo DOI pending) |
 
 ## Quick Links
 
@@ -13,20 +26,58 @@ Self-contained project for training a DPO-based priority reranker for the Canvas
 ```
 GemmaReranker/
 ├── docker/          # Docker compose files for teacher + student slots + trainer
-├── scripts/         # All pipeline scripts (self-contained copies)
+├── scripts/         # All pipeline scripts (data prep + train + bench + publish)
 ├── configs/         # ENV templates for each Docker slot
 ├── data/            # collab/ (PRIVATE teammate data), train/test JSONL
 └── docs/            # Architecture, setup, dataset guides
 ```
 
-## Current Status
+### Scripts overview
 
-- [ ] Phase 1: Spark sync + Gemma license — DONE (Klein)
-- [ ] Phase 2: Teammate data collection — PENDING (need 3+ contributors)
-- [ ] Phase 3: Run Pipeline Path B — PENDING
-- [ ] Phase 4: Validate benchmark — PENDING
+**Data prep** (canonical training-data generators):
+- `generate_rerank_data.py` — main pair generator (multi-dimensional urgency)
+- `collect_rerank_dataset.py` — splitter + deduplicator + format_for_dpo
+- `generate_teacher_preferences.py` — two-call directed teacher distillation
+- `scrub_names.py`, `scrub.py`, `convert_to_pipeline.py` — anonymization + format conversion
+- `prep_dataset_release.py` — final dedup + `preference_signal_present` annotation
+- `audit_dataset.py` — pre-release PII / schema / hallucination scan
 
-## Key Papers
+**Training** (one method per script):
+- `extract_text_base.py` — recover `gemma4-text-base` from the multimodal Gemma-4 checkpoint
+- `train_v4_matrix.py` — 9-method matrix runner (SFT/LoRA/QLoRA/DPO/IPO/APO-zero/SPPO/NCA/KTO)
+- `train_dpo.py`, `train_dpo_v3.py` — single-method DPO drivers (legacy + held-out-validation reproducible)
 
-- [DPO: Direct Preference Optimization](https://arxiv.org/pdf/2305.18290) (Rafailov et al., 2023)
-- [Attention Is All You Need](https://arxiv.org/pdf/1706.03762) (Vaswani et al., 2017)
+**Validation + bench**:
+- `validate_dpo_holdout.py` — held-out logprob-delta + pairwise prediction with Wilson 95% CIs
+- `benchmark_quants.py` — multi-quant accuracy + latency on the held-out set
+- `bench_v4_methods.py` — apples-to-apples cross-method comparison
+- `benchmark.py`, `run_benchmark.py` — Phase 06 single-letter benchmark (legacy, kept for reproducibility)
+
+**Inference + export**:
+- `export_gguf.py` — QLoRA merge + GGUF export
+- `smoke_test_gguf.py` — quick GGUF sanity check
+- `latency_bench.py` — INT-03 latency measurement
+
+**Publishing**:
+- `publish_v4_models.py` — push each variant to its own HF repo + add to Collection
+- `deposit_zenodo.py` — paper DOI via Zenodo REST API
+
+## Current status
+
+- ✅ Phase 1: Spark sync + Gemma license
+- ✅ Phase 2: Single-contributor data collection (1,347 unique pairs; multi-contributor deferred to v2)
+- ✅ Phase 3: Pipeline executed (v1 random-init bug + v2 corrected retrain + v3 held-out + v4 multi-method)
+- ✅ Phase 4: Held-out benchmark on n=148 item-disjoint pairs
+- ✅ Phase 5: Public release on Hugging Face (model + dataset + Collection + paper)
+
+## Key papers
+
+- [Rafailov 2023 — DPO](https://arxiv.org/abs/2305.18290) — canonical preference optimization
+- [Azar 2023 — IPO](https://arxiv.org/abs/2310.12036) — fixes DPO overoptimization
+- [Pan 2024 — APO](https://arxiv.org/abs/2408.06266) — anchored preference optimization
+- [Wu 2024 — SPPO](https://arxiv.org/abs/2405.00675) — self-play preference optimization
+- [Chen 2024 — NCA](https://arxiv.org/abs/2402.05369) — noise-contrastive alignment
+- [Ethayarajh 2024 — KTO](https://arxiv.org/abs/2402.01306) — Kahneman-Tversky optimization
+- [Liu 2024 — Reference Policies in DPO](https://arxiv.org/abs/2407.13709) — reference policy as upper bound
+- [Feng 2026 — SFT-DPO Interaction](https://arxiv.org/abs/2603.20100) — concurrent finding at GPT-2 scale
+- [Hu 2022 — LoRA](https://arxiv.org/abs/2106.09685), [Dettmers 2023 — QLoRA](https://arxiv.org/abs/2305.14314)

--- a/GemmaReranker/scripts/audit_dataset.py
+++ b/GemmaReranker/scripts/audit_dataset.py
@@ -1,0 +1,219 @@
+"""
+audit_dataset.py — sanity / privacy / integrity audit of data/dpo_train.jsonl
+before any potential HuggingFace dataset release.
+
+Checks:
+  A. Schema integrity — required fields present, no nulls, pair_type valid
+  B. PII / leakage — real course codes, names, emails, URLs, Canvas IDs
+  C. Anonymization quality — @COURSE codes consistent, no real-looking codes
+  D. Duplicate detection — duplicate prompts / triples
+  E. Length distribution — prompt + chosen + rejected token-length stats
+  F. Label quality — chosen/rejected lead with "Item A"/"Item B"
+  G. Hallucination check — does completion mention attributes absent from prompt
+  H. pair_type sanity — hard_negative pairs structurally distinct from standard
+
+Output: structured JSON + human-readable summary.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from collections import Counter, defaultdict
+from pathlib import Path
+
+DATA_PATHS = [
+    Path("data/dpo_train.jsonl"),
+    Path("data/dpo_train_v3.jsonl"),
+    Path("data/dpo_test_v3.jsonl"),
+]
+
+# ── Patterns ──────────────────────────────────────────────────────────────────
+
+EMAIL = re.compile(r"\b[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}\b")
+URL = re.compile(r"https?://[^\s]+")
+COURSE_GOOD = re.compile(r"@COURSE\w+")
+COURSE_BAD = re.compile(r"@(?!COURSE)([A-Z]{2,5}\d{3,5}[A-Z]?)\b")  # e.g. @CS3704, @ENGL2204
+NAME_HINT = re.compile(r"\b(Dr|Prof|Professor|Mr|Mrs|Ms)\.\s+[A-Z][a-z]+", re.IGNORECASE)
+CANVAS_ID = re.compile(r"\b[1-9]\d{6,}\b")  # Canvas item IDs are typically 7-9 digit ints
+PRONOUN_LEAK = re.compile(r"\b(my professor|my instructor|my TA|my section|my dorm)\b", re.IGNORECASE)
+
+ITEM_RE = re.compile(r"^Item [AB]:\s*(\[[^\]]+\])\s*(.+?)\s*(@COURSE\w+)\s+(.+?)\s+(\d+)pts\s*$", re.MULTILINE)
+ITEM_LEAD = re.compile(r"\bItem\s*([AB])\b")
+
+
+def audit_one_file(path: Path) -> dict:
+    rec_list = [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+    n = len(rec_list)
+    report = {"file": str(path), "n_records": n, "checks": {}}
+
+    # A. Schema integrity
+    schema_issues = []
+    pair_type_counter = Counter()
+    for i, r in enumerate(rec_list):
+        for k in ("prompt", "chosen", "rejected", "pair_type"):
+            if k not in r:
+                schema_issues.append(f"rec {i}: missing field {k}")
+            elif r[k] is None or (isinstance(r[k], str) and not r[k].strip()):
+                schema_issues.append(f"rec {i}: empty/null field {k}")
+        pt = r.get("pair_type")
+        pair_type_counter[pt] += 1
+        if pt not in ("standard", "hard_negative"):
+            schema_issues.append(f"rec {i}: unknown pair_type {pt!r}")
+    report["checks"]["A_schema"] = {
+        "issues": len(schema_issues),
+        "pair_type_distribution": dict(pair_type_counter),
+        "first_5_issues": schema_issues[:5],
+    }
+
+    # B. PII / leakage scan over ALL text fields
+    pii_hits = defaultdict(list)
+    for i, r in enumerate(rec_list):
+        for field in ("prompt", "chosen", "rejected"):
+            text = r.get(field, "")
+            for m in EMAIL.findall(text):
+                pii_hits["emails"].append((i, field, m))
+            for m in URL.findall(text):
+                pii_hits["urls"].append((i, field, m))
+            for m in NAME_HINT.findall(text):
+                pii_hits["name_hints"].append((i, field, m))
+            for m in CANVAS_ID.findall(text):
+                pii_hits["canvas_ids"].append((i, field, m))
+            for m in PRONOUN_LEAK.findall(text):
+                pii_hits["pronoun_leaks"].append((i, field, m))
+    report["checks"]["B_pii"] = {
+        category: {"count": len(hits), "first_3": hits[:3]}
+        for category, hits in pii_hits.items()
+    }
+    if not pii_hits:
+        report["checks"]["B_pii"]["clean"] = True
+
+    # C. Anonymization quality — course codes
+    good_codes = Counter()
+    bad_codes = Counter()
+    for r in rec_list:
+        for m in COURSE_GOOD.findall(r.get("prompt", "")):
+            good_codes[m] += 1
+        for m in COURSE_BAD.findall(r.get("prompt", "")):
+            bad_codes[m] += 1
+    report["checks"]["C_anonymization"] = {
+        "anonymized_course_codes_distinct": len(good_codes),
+        "anonymized_course_codes_top10": good_codes.most_common(10),
+        "real_looking_codes_distinct": len(bad_codes),
+        "real_looking_codes_first5": list(bad_codes.most_common(5)),
+    }
+
+    # D. Duplicate detection
+    prompt_counter = Counter()
+    triple_counter = Counter()
+    for r in rec_list:
+        prompt_counter[r.get("prompt", "")] += 1
+        triple_counter[(r.get("prompt", ""), r.get("chosen", ""), r.get("rejected", ""))] += 1
+    dup_prompts = sum(1 for v in prompt_counter.values() if v > 1)
+    dup_triples = sum(1 for v in triple_counter.values() if v > 1)
+    report["checks"]["D_duplicates"] = {
+        "duplicate_prompts": dup_prompts,
+        "duplicate_triples_count": dup_triples,
+        "prompt_uniqueness_pct": round(len(prompt_counter) / n * 100, 1),
+    }
+
+    # E. Length distribution (chars; tokens is more relevant but expensive)
+    p_lens = [len(r.get("prompt", "")) for r in rec_list]
+    c_lens = [len(r.get("chosen", "")) for r in rec_list]
+    rj_lens = [len(r.get("rejected", "")) for r in rec_list]
+    def stats(xs):
+        xs = sorted(xs)
+        return {
+            "min": xs[0], "p25": xs[len(xs)//4], "median": xs[len(xs)//2],
+            "p75": xs[3*len(xs)//4], "max": xs[-1], "mean": round(sum(xs)/len(xs), 1),
+        }
+    report["checks"]["E_lengths_chars"] = {
+        "prompt": stats(p_lens),
+        "chosen": stats(c_lens),
+        "rejected": stats(rj_lens),
+    }
+
+    # F. Label quality — chosen/rejected lead with "Item X"
+    chosen_picks = Counter()
+    rejected_picks = Counter()
+    label_consistency_issues = []
+    for i, r in enumerate(rec_list):
+        cm = ITEM_LEAD.search(r.get("chosen", ""))
+        rm = ITEM_LEAD.search(r.get("rejected", ""))
+        chosen_picks[cm.group(1) if cm else "(none)"] += 1
+        rejected_picks[rm.group(1) if rm else "(none)"] += 1
+        if cm and rm and cm.group(1) == rm.group(1):
+            label_consistency_issues.append((i, "chosen+rejected pick same letter", cm.group(1)))
+    report["checks"]["F_label_quality"] = {
+        "chosen_first_letter": dict(chosen_picks),
+        "rejected_first_letter": dict(rejected_picks),
+        "consistency_issues": len(label_consistency_issues),
+        "first_3_issues": label_consistency_issues[:3],
+    }
+
+    # G. Hallucination check — does chosen/rejected mention point-values not in prompt
+    pts_re = re.compile(r"(\d+)\s*pts?\b", re.IGNORECASE)
+    halluc = 0
+    halluc_examples = []
+    for i, r in enumerate(rec_list):
+        prompt = r.get("prompt", "")
+        prompt_pts = set(pts_re.findall(prompt))
+        for field in ("chosen", "rejected"):
+            text = r.get(field, "")
+            for pt in pts_re.findall(text):
+                if pt not in prompt_pts and pt != "1" and len(pt) > 1:  # exclude common defaults
+                    halluc += 1
+                    if len(halluc_examples) < 3:
+                        halluc_examples.append((i, field, pt, list(prompt_pts)))
+                    break
+    report["checks"]["G_hallucination_pts"] = {
+        "fabricated_points_count": halluc,
+        "first_3_examples": halluc_examples,
+    }
+
+    # H. pair_type structural distinctness
+    standard_prompt_lens = [len(r["prompt"]) for r in rec_list if r.get("pair_type") == "standard"]
+    hard_prompt_lens = [len(r["prompt"]) for r in rec_list if r.get("pair_type") == "hard_negative"]
+    if standard_prompt_lens and hard_prompt_lens:
+        report["checks"]["H_pair_type_check"] = {
+            "standard_count": len(standard_prompt_lens),
+            "hard_count": len(hard_prompt_lens),
+            "standard_mean_len": round(sum(standard_prompt_lens)/len(standard_prompt_lens), 1),
+            "hard_mean_len": round(sum(hard_prompt_lens)/len(hard_prompt_lens), 1),
+        }
+
+    return report
+
+
+def main():
+    overall = {"audits": [], "summary": {}}
+    for path in DATA_PATHS:
+        if not path.exists():
+            overall["audits"].append({"file": str(path), "error": "missing"})
+            continue
+        overall["audits"].append(audit_one_file(path))
+
+    out_path = Path(".planning/research/DATASET-AUDIT.json")
+    out_path.write_text(json.dumps(overall, indent=2, default=str))
+    print(f"\nFull report: {out_path}")
+    print("\n=== Headline summary per file ===")
+    for a in overall["audits"]:
+        if "error" in a:
+            print(f"  {a['file']}: ERROR {a['error']}")
+            continue
+        c = a["checks"]
+        print(f"\n  {a['file']} (n={a['n_records']})")
+        print(f"    A. schema issues:         {c['A_schema']['issues']}")
+        for k, v in c['B_pii'].items():
+            if k == 'clean': continue
+            print(f"    B. PII {k}: {v['count']}")
+        print(f"    C. real-looking codes:    {c['C_anonymization']['real_looking_codes_distinct']}")
+        print(f"    C. anonymized codes:      {c['C_anonymization']['anonymized_course_codes_distinct']}")
+        print(f"    D. duplicate prompts:     {c['D_duplicates']['duplicate_prompts']}")
+        print(f"    D. duplicate triples:     {c['D_duplicates']['duplicate_triples_count']}")
+        print(f"    F. label consistency:     {c['F_label_quality']['consistency_issues']} issues")
+        print(f"    G. fabricated pts count:  {c['G_hallucination_pts']['fabricated_points_count']}")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/bench_v4_methods.py
+++ b/GemmaReranker/scripts/bench_v4_methods.py
@@ -1,0 +1,184 @@
+"""
+bench_v4_methods.py — apples-to-apples comparison of all 6 v4 method
+variants on the v3 held-out test partition (n=148 item-disjoint
+standard pairs).
+
+For each method's checkpoint:
+  - load via transformers (PEFT-wrapped if adapter)
+  - greedy-decode chat-template prompts
+  - extract first "Item A"/"Item B" → score vs gold from chosen text
+  - report pairwise accuracy + Wilson 95% CI + cross-variant agreement
+
+Output: checkpoints/benchmark/v4_methods_benchmark.json + a printed
+markdown comparison table suitable for paper §6.7 + HF model cards.
+"""
+from __future__ import annotations
+
+import json
+import math
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+TEST_PATH = Path("data/dpo_test_v3.jsonl")
+BASE_FOR_ADAPTERS = "checkpoints/gemma4-text-base"
+OUT_PATH = Path("checkpoints/benchmark/v4_methods_benchmark.json")
+
+VARIANTS = [
+    {"method": "ref",      "ckpt": "checkpoints/gguf/merged_bf16",  "is_adapter": False, "label": "merged_bf16 (v2 reference)"},
+    {"method": "sft",      "ckpt": "checkpoints/v4-sft",             "is_adapter": False, "label": "SFT v4"},
+    {"method": "lora",     "ckpt": "checkpoints/v4-lora",            "is_adapter": True,  "label": "LoRA v4"},
+    {"method": "qlora",    "ckpt": "checkpoints/v4-qlora",           "is_adapter": True,  "label": "QLoRA v4"},
+    {"method": "dpo",      "ckpt": "checkpoints/v4-dpo",             "is_adapter": False, "label": "DPO v4 (sigmoid, Rafailov 2023)"},
+    {"method": "ipo",      "ckpt": "checkpoints/v4-ipo",             "is_adapter": False, "label": "IPO v4 (Azar 2023)"},
+    {"method": "apo_zero", "ckpt": "checkpoints/v4-apo-zero",        "is_adapter": False, "label": "APO-zero v4 (Pan 2024)"},
+    {"method": "sppo",     "ckpt": "checkpoints/v4-sppo",            "is_adapter": False, "label": "SPPO v4 (Wu 2024)"},
+    {"method": "nca",      "ckpt": "checkpoints/v4-nca",             "is_adapter": False, "label": "NCA v4 (Chen 2024)"},
+    {"method": "kto",      "ckpt": "checkpoints/v4-kto",             "is_adapter": False, "label": "KTO v4 (Ethayarajh 2024)"},
+]
+
+ITEM_LEAD = re.compile(r"\bItem\s*([AB])\b")
+
+
+def chosen_picks(text: str) -> str | None:
+    m = ITEM_LEAD.search(text)
+    return m.group(1).upper() if m else None
+
+
+def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    if n == 0:
+        return (0.0, 0.0)
+    p = k / n
+    denom = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    half = (z / denom) * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+def load_model(variant: dict):
+    import torch
+    from transformers import AutoTokenizer, Gemma4ForCausalLM
+    ckpt = variant["ckpt"]
+    if variant["is_adapter"]:
+        from peft import PeftModel
+        base = Gemma4ForCausalLM.from_pretrained(
+            BASE_FOR_ADAPTERS, torch_dtype=torch.bfloat16,
+            attn_implementation="sdpa", device_map="auto",
+        )
+        model = PeftModel.from_pretrained(base, ckpt)
+    else:
+        model = Gemma4ForCausalLM.from_pretrained(
+            ckpt, torch_dtype=torch.bfloat16,
+            attn_implementation="sdpa", device_map="auto",
+        )
+    model.train(False)
+    tok = AutoTokenizer.from_pretrained(ckpt if not variant["is_adapter"] else BASE_FOR_ADAPTERS)
+    return model, tok
+
+
+def benchmark(variant: dict, pairs: list[dict]) -> dict:
+    import torch
+    if not Path(variant["ckpt"]).exists():
+        return {"method": variant["method"], "error": f"missing checkpoint {variant['ckpt']}"}
+
+    print(f"\n[{variant['method']}] loading {variant['ckpt']} ...")
+    model, tok = load_model(variant)
+    print(f"[{variant['method']}] loaded; n_params(trainable)={sum(p.numel() for p in model.parameters() if p.requires_grad):,}")
+
+    n_correct = 0
+    n_abstain = 0
+    preds = []
+    for i, pair in enumerate(pairs):
+        prompt = pair["prompt"]
+        gold = chosen_picks(pair["chosen"])
+        chat = tok.apply_chat_template(
+            [{"role": "user", "content": prompt}],
+            tokenize=False, add_generation_prompt=True,
+        )
+        enc = tok(chat, return_tensors="pt").to(model.device)
+        with torch.inference_mode():
+            out = model.generate(
+                **enc, max_new_tokens=32, do_sample=False,
+                pad_token_id=tok.pad_token_id or tok.eos_token_id,
+            )
+        n_prompt = enc["input_ids"].shape[1]
+        text = tok.decode(out[0][n_prompt:], skip_special_tokens=True)
+        pred = chosen_picks(text)
+        preds.append({"pair": i + 1, "gold": gold, "pred": pred})
+        if pred is None:
+            n_abstain += 1
+        elif pred == gold:
+            n_correct += 1
+        if (i + 1) % 25 == 0:
+            print(f"  [{i+1:3d}/{len(pairs)}] correct={n_correct}")
+
+    n_scored = len(pairs) - n_abstain
+    acc = n_correct / n_scored if n_scored else 0.0
+    lo, hi = wilson_ci(n_correct, n_scored)
+
+    # Free GPU before next variant
+    del model
+    import gc; gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+
+    return {
+        "method": variant["method"],
+        "label": variant["label"],
+        "ckpt": variant["ckpt"],
+        "n_pairs": len(pairs),
+        "n_correct": n_correct,
+        "n_scored": n_scored,
+        "n_abstain": n_abstain,
+        "pairwise_accuracy": round(acc, 4),
+        "wilson_95ci": [round(lo, 4), round(hi, 4)],
+        "predictions": preds,
+    }
+
+
+def main():
+    pairs = [json.loads(l) for l in TEST_PATH.read_text().splitlines() if l.strip()]
+    print(f"[load] {len(pairs)} held-out pairs from {TEST_PATH}")
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    only = sys.argv[1] if len(sys.argv) > 1 else None
+    variants_to_run = [v for v in VARIANTS if not only or v["method"] == only]
+
+    results = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "test_data": str(TEST_PATH),
+        "n_pairs": len(pairs),
+        "test_partition": "v3 item-disjoint, 148 standard pairs (zero hard-neg)",
+        "variants": {},
+    }
+    for variant in variants_to_run:
+        results["variants"][variant["method"]] = benchmark(variant, pairs)
+        OUT_PATH.write_text(json.dumps(results, indent=2))
+        print(f"[saved] {OUT_PATH}")
+
+    # Cross-variant agreement matrix (which methods make the same prediction?)
+    methods_with_results = [m for m in results["variants"] if "predictions" in results["variants"][m]]
+    if len(methods_with_results) > 1:
+        print(f"\n=== Cross-variant prediction agreement ===")
+        for i, m1 in enumerate(methods_with_results):
+            for m2 in methods_with_results[i+1:]:
+                p1 = results["variants"][m1]["predictions"]
+                p2 = results["variants"][m2]["predictions"]
+                agree = sum(1 for a, b in zip(p1, p2) if a["pred"] == b["pred"])
+                print(f"  {m1:8s} vs {m2:8s}: {agree}/{len(p1)} agreement")
+
+    print(f"\n{'='*78}")
+    print(f"  V4 METHOD COMPARISON  (n={len(pairs)} held-out, item-disjoint)")
+    print(f"{'='*78}")
+    print(f"  {'Method':>10s}  {'n_correct':>9s}  {'Acc':>7s}  {'Wilson 95% CI':>20s}  {'Abstain':>7s}")
+    for m in methods_with_results:
+        r = results["variants"][m]
+        ci = r["wilson_95ci"]
+        ci_str = f"[{ci[0]*100:.1f}%, {ci[1]*100:.1f}%]"
+        print(f"  {m:>10s}  {r['n_correct']:>4d}/{r['n_scored']:<4d}  {r['pairwise_accuracy']*100:>5.1f}%  {ci_str:>20s}  {r['n_abstain']:>7d}")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/benchmark_quants.py
+++ b/GemmaReranker/scripts/benchmark_quants.py
@@ -1,0 +1,184 @@
+"""
+benchmark_quants.py — pairwise accuracy + latency benchmark across all
+GGUF quantization levels on the v3 held-out test set.
+
+For each quant in {Q4_K_M, Q5_K_M, Q6_K, Q8_0, f16}:
+  - Load via llama-cpp-python (n_gpu_layers=-1 for full GPU offload)
+  - For each of the 148 held-out pairs, send the chat-templated prompt
+    and greedy-decode the response (max 32 new tokens)
+  - Time each call (warm-state, after one warmup round)
+  - Parse the first "Item A"/"Item B" mention from the generation
+  - Compare to the gold extracted from the chosen text
+  - Report: pairwise accuracy + Wilson 95% CI + per-call latency stats
+
+Output: checkpoints/benchmark/quants_benchmark.json with per-quant
+results for paper Table 3 / HF model card "Quantization quality
+comparison" entry.
+
+Run after multi-quant generation. Wall time: ~20 min for 5 quants × 148
+pairs at ~300ms/call warm.
+"""
+from __future__ import annotations
+
+import json
+import math
+import re
+import time
+from pathlib import Path
+
+GGUF_DIR = Path("checkpoints/gguf")
+TEST_PATH = Path("data/dpo_test_v3.jsonl")
+OUT_PATH = Path("checkpoints/benchmark/quants_benchmark.json")
+
+QUANTS = [
+    "Q4_K_M",
+    "Q5_K_M",
+    "Q6_K",
+    "Q8_0",
+    "f16",
+]
+
+ITEM_LEAD = re.compile(r"\bItem\s*([AB])\b")
+
+
+def chosen_picks(text: str) -> str | None:
+    m = ITEM_LEAD.search(text)
+    return m.group(1).upper() if m else None
+
+
+def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    if n == 0:
+        return (0.0, 0.0)
+    p = k / n
+    denom = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    half = (z / denom) * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return (max(0.0, center - half), min(1.0, center + half))
+
+
+def benchmark_quant(quant_name: str, pairs: list[dict]) -> dict:
+    from llama_cpp import Llama
+
+    gguf_path = GGUF_DIR / f"gemma4-reranker-{quant_name}.gguf"
+    if not gguf_path.exists():
+        return {"quant": quant_name, "error": f"missing {gguf_path}"}
+
+    print(f"\n[{quant_name}] loading {gguf_path.name} ({gguf_path.stat().st_size/1024**3:.2f} GiB)")
+    t0 = time.time()
+    llm = Llama(
+        model_path=str(gguf_path),
+        n_ctx=1024,
+        n_gpu_layers=-1,
+        verbose=False,
+        seed=42,
+    )
+    load_time = time.time() - t0
+    print(f"[{quant_name}] loaded in {load_time:.1f}s")
+
+    # Warm-up call so the first measured call isn't cold-start
+    _ = llm.create_chat_completion(
+        messages=[{"role": "user", "content": "warmup"}],
+        max_tokens=4,
+        temperature=0.0,
+    )
+
+    n_correct = 0
+    n_abstain = 0
+    warm_warm_latencies_ms: list[float] = []
+    cold_call_ms = None
+
+    for i, pair in enumerate(pairs):
+        prompt = pair["prompt"]
+        gold = chosen_picks(pair["chosen"])
+
+        t0 = time.time()
+        response = llm.create_chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=32,
+            temperature=0.0,
+        )
+        dt_ms = (time.time() - t0) * 1000
+        if i == 0:
+            # First measured call is cold (despite the warmup_call above
+            # priming the model load, the first real-prompt call still
+            # sees first-token-position cache misses). Excluded from the
+            # warm distribution per codex cross-audit.
+            cold_call_ms = dt_ms
+        else:
+            warm_warm_latencies_ms.append(dt_ms)
+
+        text = response["choices"][0]["message"]["content"]
+        pred = chosen_picks(text)
+        if pred is None:
+            n_abstain += 1
+        elif pred == gold:
+            n_correct += 1
+
+        if (i + 1) % 25 == 0:
+            print(f"  [{i+1:3d}/{len(pairs)}] correct={n_correct}  mean_ms={sum(warm_latencies_ms)/len(warm_latencies_ms):.0f}")
+
+    n_scored = len(pairs) - n_abstain
+    acc = n_correct / n_scored if n_scored else 0.0
+    lo, hi = wilson_ci(n_correct, n_scored)
+    sorted_lat = sorted(warm_latencies_ms)
+    mid = len(sorted_lat) // 2
+
+    return {
+        "quant": quant_name,
+        "gguf_path": str(gguf_path),
+        "size_gib": round(gguf_path.stat().st_size / 1024**3, 2),
+        "load_seconds": round(load_time, 1),
+        "n_pairs": len(pairs),
+        "n_correct": n_correct,
+        "n_scored": n_scored,
+        "n_abstain": n_abstain,
+        "pairwise_accuracy": round(acc, 4),
+        "wilson_95ci": [round(lo, 4), round(hi, 4)],
+        "latency_ms": {
+            "cold_first_call": round(cold_call_ms, 1) if cold_call_ms else None,
+            "warm_min": round(sorted_lat[0], 1),
+            "warm_p25": round(sorted_lat[len(sorted_lat)//4], 1),
+            "warm_median": round(sorted_lat[mid], 1),
+            "warm_p75": round(sorted_lat[3*len(sorted_lat)//4], 1),
+            "warm_max": round(sorted_lat[-1], 1),
+            "warm_mean": round(sum(sorted_lat)/len(sorted_lat), 1),
+        },
+    }
+
+
+def main():
+    pairs = [json.loads(l) for l in TEST_PATH.read_text().splitlines() if l.strip()]
+    print(f"[load] {len(pairs)} held-out pairs from {TEST_PATH}")
+
+    OUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+
+    results = {
+        "test_data": str(TEST_PATH),
+        "n_pairs": len(pairs),
+        "test_partition": "v3 item-disjoint, 148 standard pairs (zero hard-neg)",
+        "results": {},
+    }
+
+    for q in QUANTS:
+        results["results"][q] = benchmark_quant(q, pairs)
+        OUT_PATH.write_text(json.dumps(results, indent=2))
+        print(f"[saved] {OUT_PATH}")
+
+    print(f"\n{'='*70}")
+    print(f"  QUANT BENCHMARK SUMMARY  (n={len(pairs)})")
+    print(f"{'='*70}")
+    print(f"  {'Quant':10s}  {'GiB':>5}  {'Acc':>6}  {'CI':>20}  {'Med ms':>8}  {'Mean ms':>8}")
+    for q in QUANTS:
+        r = results["results"].get(q, {})
+        if "error" in r:
+            print(f"  {q:10s}  ERROR: {r['error']}")
+            continue
+        ci = r.get("wilson_95ci", [0,0])
+        ci_str = f"[{ci[0]*100:.1f}%, {ci[1]*100:.1f}%]"
+        l = r.get("latency_ms", {})
+        print(f"  {q:10s}  {r.get('size_gib',0):>5.2f}  {r.get('pairwise_accuracy',0)*100:>5.1f}%  {ci_str:>20}  {l.get('warm_median',0):>8.1f}  {l.get('warm_mean',0):>8.1f}")
+    print(f"\nFull report: {OUT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/callbacks.py
+++ b/GemmaReranker/scripts/callbacks.py
@@ -1,0 +1,20 @@
+from transformers import TrainerCallback
+
+
+class RewardCollapseCallback(TrainerCallback):
+    """Halt training when rewards/chosen sustains below threshold for sustained_intervals steps."""
+
+    def __init__(self, threshold: float = -2.0, sustained_intervals: int = 5):
+        self.threshold = threshold
+        self.sustained = sustained_intervals
+        self.below_count = 0
+
+    def on_log(self, args, state, control, logs=None, **kwargs):
+        if not logs or "rewards/chosen" not in logs:
+            return
+        if logs["rewards/chosen"] < self.threshold:
+            self.below_count += 1
+            if self.below_count >= self.sustained:
+                control.should_training_stop = True
+        else:
+            self.below_count = 0

--- a/GemmaReranker/scripts/collect_trajectories.py
+++ b/GemmaReranker/scripts/collect_trajectories.py
@@ -1,0 +1,375 @@
+"""
+collect_trajectories.py — teammate-runnable v2 trajectory collector.
+
+Purpose: build the v2 calendar-agent training dataset by replaying a fixed
+set of canonical user queries against a teacher LLM (Nemotron-120B at
+Spark slot0:18080 by default) with the canvas-tui agent's tool surface
+exposed for function-calling. Captures the full tool-call trajectory
+(tool calls + tool results + final answer) per query.
+
+This is the v2 analogue of the v1 generate_dataset.py / collect_rerank_
+dataset.py preference collectors. Same anonymization pipeline; same
+multi-contributor model.
+
+Usage (from canvas-tui repo root, with canvas_sdk installed and a
+Canvas API token in your env):
+
+    export CANVAS_TOKEN=...
+    export CANVAS_BASE_URL=https://canvas.vt.edu
+    export TEACHER_ENDPOINT=http://spark.local:18080/v1   # optional
+    python3 GemmaReranker/scripts/collect_trajectories.py \
+        --contributor alice \
+        --queries GemmaReranker/data/canonical_queries.txt \
+        --output GemmaReranker/data/collab/alice_trajectories.jsonl \
+        --max-trajectories 50
+
+The output JSONL is the v2 SFT corpus. Each line is one trajectory:
+    {user_query, context, trajectory[], teacher_model, contributor_id}
+
+Contributors push their anonymized JSONL to GemmaReranker/data/collab/
+in a PR; the maintainer concatenates + further audits before training.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+# ── Tool surface (mirrors canvas_tui.agent.tools registry) ───────────────────
+
+TOOL_SCHEMAS: list[dict] = []  # populated lazily by import
+
+
+def _import_tools():
+    """Lazy-import the agent tool registry. Falls back to a minimal
+    schema set if canvas_tui isn't installed (so contributors without
+    the full app can still produce stub trajectories)."""
+    global TOOL_SCHEMAS
+    try:
+        from canvas_tui.agent.tools import get_schemas  # type: ignore
+        TOOL_SCHEMAS = get_schemas()
+        return True
+    except ImportError:
+        TOOL_SCHEMAS = _minimal_tool_schemas()
+        return False
+
+
+def _minimal_tool_schemas() -> list[dict]:
+    """Standalone copy of the tool schemas — keeps this script runnable
+    even when canvas_tui isn't on the PYTHONPATH (e.g. teammate has
+    only cloned GemmaReranker/ standalone)."""
+    return [
+        {"type": "function", "function": {
+            "name": "canvas.list_courses",
+            "description": "List the student's enrolled courses.",
+            "parameters": {"type": "object", "properties": {"active_only": {"type": "boolean"}}},
+        }},
+        {"type": "function", "function": {
+            "name": "canvas.get_assignments",
+            "description": "Get assignments per course.",
+            "parameters": {"type": "object", "properties": {
+                "course_id": {"type": ["integer", "null"]},
+                "horizon_days": {"type": "integer"},
+            }},
+        }},
+        {"type": "function", "function": {
+            "name": "canvas.get_todo",
+            "description": "Get the Canvas TODO feed.",
+            "parameters": {"type": "object", "properties": {}},
+        }},
+        {"type": "function", "function": {
+            "name": "canvas.get_syllabus",
+            "description": "Get a course's syllabus text.",
+            "parameters": {"type": "object", "properties": {"course_id": {"type": "integer"}}, "required": ["course_id"]},
+        }},
+        {"type": "function", "function": {
+            "name": "calendar.list_events",
+            "description": "List calendar events in a window.",
+            "parameters": {"type": "object", "properties": {
+                "start_iso": {"type": "string"}, "end_iso": {"type": "string"},
+            }},
+        }},
+        {"type": "function", "function": {
+            "name": "calendar.find_free_blocks",
+            "description": "Find free blocks of time.",
+            "parameters": {"type": "object", "properties": {
+                "min_minutes": {"type": "integer"}, "horizon_days": {"type": "integer"},
+            }},
+        }},
+        {"type": "function", "function": {
+            "name": "calendar.create_event",
+            "description": "Create a calendar event.",
+            "parameters": {"type": "object", "properties": {
+                "title": {"type": "string"}, "start_iso": {"type": "string"}, "end_iso": {"type": "string"},
+            }, "required": ["title", "start_iso", "end_iso"]},
+        }},
+        {"type": "function", "function": {
+            "name": "study.spaced_schedule",
+            "description": "Compute spaced-repetition session dates for an exam (Cepeda 2008).",
+            "parameters": {"type": "object", "properties": {
+                "exam_iso": {"type": "string"}, "n_sessions": {"type": "integer"},
+            }, "required": ["exam_iso"]},
+        }},
+        {"type": "function", "function": {
+            "name": "study.recommend_block_size",
+            "description": "Recommend deep-work block size for a task type.",
+            "parameters": {"type": "object", "properties": {
+                "task_type": {"type": "string", "enum": ["writing","problem_set","exam_prep","reading","review","admin","discussion","project_work"]},
+            }, "required": ["task_type"]},
+        }},
+    ]
+
+
+# ── Canonical queries (default; --queries file overrides) ────────────────────
+
+CANONICAL_QUERIES = [
+    # 1. Exam prep — neuroscience-grounded spacing
+    "I have a CS3704 midterm in 12 days. Plan my prep using spaced repetition.",
+    "I have a final exam on May 15. What should my prep schedule look like?",
+    "How should I structure my study time for two midterms in the same week?",
+    # 2. Realistic week — multi-source planning
+    "I have 5 things due this week and a 6-hour shift on Saturday. What's the realistic schedule?",
+    "I have a doctor's appointment Tuesday and a quiz Wednesday. When do I prep?",
+    "Walk me through my upcoming week with specific time blocks.",
+    # 3. Project-only courses
+    "My software engineering class only has a final project. When should I work on it?",
+    "I have a 4-credit class with one big group project due in 6 weeks. Allocate weekly time.",
+    # 4. Priority queries
+    "What's most urgent right now?",
+    "What can I safely skip this week if I run out of time?",
+    "Which assignments are highest grade impact?",
+    # 5. Edge cases
+    "I'm overwhelmed. Where do I start?",
+    "I have 3 assignments due tomorrow. Triage.",
+    "What did I miss this week?",
+    # 6. Recovery / rescheduling
+    "I'm sick and missed two days. Reschedule everything.",
+    "An exam got moved up by a week. Replan.",
+    # 7. Life balance
+    "Block time for the gym 3x this week without breaking my study schedule.",
+    "When can I realistically take Friday night off?",
+]
+
+
+# ── Anonymization (mirrors GemmaReranker/scripts/scrub.py) ───────────────────
+
+def anonymize_course_code(real_code: str) -> str:
+    """Same SHA-256 → 4-digit modulo as canvas-tui agent's serialize_item.
+    Deterministic per real code, so contributors with overlapping courses
+    produce identical anonymized codes."""
+    h = int(hashlib.sha256(real_code.strip().encode("utf-8")).hexdigest()[:8], 16)
+    return f"COURSE{(h % 9000) + 1000}"
+
+
+def anonymize_record(rec: dict, contributor_salt: str) -> dict:
+    """Walk a trajectory record, replace real course codes / Canvas IDs /
+    contributor PII with deterministic anonymized stand-ins. Contributor-
+    salt makes IDs non-overlapping across contributors."""
+    text = json.dumps(rec, default=str)
+    # Replace anything matching a 7-9 digit Canvas ID with a SHA-prefixed stub.
+    import re
+    text = re.sub(r"\b([1-9]\d{6,8})\b",
+                  lambda m: f"ID{int(hashlib.sha256((contributor_salt + m.group(1)).encode()).hexdigest()[:6], 16) % 1000000:06d}",
+                  text)
+    # Real course codes like "CS 3704", "ENGL 2204" → anonymized.
+    text = re.sub(r"\b([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b",
+                  lambda m: anonymize_course_code(m.group(0)),
+                  text)
+    return json.loads(text)
+
+
+# ── Teacher interaction (Nemotron-120B at slot0:18080 by default) ────────────
+
+def call_teacher(messages: list[dict], tools: list[dict], endpoint: str, model: str) -> dict:
+    """Make one tool-aware call to the teacher. Returns the full response
+    (including tool_calls if the model decided to call tools, or content
+    if it decided to answer)."""
+    import requests
+    payload = {
+        "model": model,
+        "messages": messages,
+        "tools": tools,
+        "tool_choice": "auto",
+        "temperature": 0.2,  # low but not zero — diversity for plan candidates
+        "max_tokens": 1024,
+    }
+    r = requests.post(f"{endpoint}/chat/completions", json=payload, timeout=120)
+    r.raise_for_status()
+    return r.json()
+
+
+# ── Mock tool executor — for trajectory capture, we don't actually mutate
+# the calendar; we synthesize plausible results from the contributor's
+# Canvas snapshot. Real execution happens at deploy time.
+def execute_tool(name: str, args: dict, snapshot: dict) -> Any:
+    """Minimal mock — returns plausible-looking results for trajectory
+    capture without actually calling Canvas/calendar APIs at collection
+    time. The teacher's reasoning + tool-call sequence is what we capture;
+    the tool-result content is regenerated at training time from the
+    snapshot to keep the trajectory deterministic."""
+    if name == "canvas.list_courses":
+        return snapshot.get("courses", [])
+    if name == "canvas.get_assignments":
+        cid = args.get("course_id")
+        items = snapshot.get("assignments", [])
+        if cid is not None:
+            items = [a for a in items if a.get("course_id") == cid]
+        horizon = args.get("horizon_days", 14)
+        cutoff = (dt.datetime.now() + dt.timedelta(days=horizon)).isoformat()
+        return [a for a in items if a.get("due_iso", "9999") <= cutoff]
+    if name == "canvas.get_todo":
+        return snapshot.get("todo", [])
+    if name == "canvas.get_syllabus":
+        cid = args.get("course_id")
+        return snapshot.get("syllabi", {}).get(str(cid), "(no syllabus on file)")
+    if name == "calendar.list_events":
+        return snapshot.get("calendar_events", [])
+    if name == "calendar.find_free_blocks":
+        # Synthesize plausible free blocks based on calendar density
+        return [
+            {"start_iso": (dt.datetime.now() + dt.timedelta(days=d, hours=9)).isoformat(),
+             "end_iso":   (dt.datetime.now() + dt.timedelta(days=d, hours=10, minutes=30)).isoformat()}
+            for d in range(1, 1 + args.get("horizon_days", 7))
+        ]
+    if name == "calendar.create_event":
+        return {"event_id": f"mock-{abs(hash(json.dumps(args, sort_keys=True)))}", "status": "created"}
+    if name == "study.spaced_schedule":
+        # Use the canvas-tui implementation if available
+        try:
+            from canvas_tui.agent.tools.study_tools import SpacedSchedule
+            return SpacedSchedule.call(args)
+        except ImportError:
+            return [{"start_iso": "...", "end_iso": "..."}]
+    if name == "study.recommend_block_size":
+        try:
+            from canvas_tui.agent.tools.study_tools import DeepBlockSize
+            return DeepBlockSize.call(args)
+        except ImportError:
+            return {"minutes": 90, "rationale": "default deep-work block"}
+    return {"error": f"unknown tool: {name}"}
+
+
+# ── Trajectory loop ──────────────────────────────────────────────────────────
+
+def collect_one(query: str, snapshot: dict, contributor_id: str,
+                endpoint: str, model: str, max_calls: int = 12) -> dict:
+    """Run one query through the teacher with tool calls, capturing the
+    full trajectory. Returns the trajectory record."""
+    sys_prompt = Path(__file__).parent.parent.parent / "src/canvas_tui/agent/prompts/system.md"
+    if sys_prompt.exists():
+        system = sys_prompt.read_text()
+    else:
+        system = "You are a personal AI calendar + study assistant. Use tool calls when you need data."
+    messages = [
+        {"role": "system", "content": system},
+        {"role": "user", "content": query},
+    ]
+    trajectory = []
+    for step in range(max_calls):
+        resp = call_teacher(messages, TOOL_SCHEMAS, endpoint, model)
+        msg = resp["choices"][0]["message"]
+        tool_calls = msg.get("tool_calls") or []
+        if tool_calls:
+            for tc in tool_calls:
+                name = tc["function"]["name"]
+                args = json.loads(tc["function"]["arguments"]) if isinstance(tc["function"]["arguments"], str) else tc["function"]["arguments"]
+                trajectory.append({"role": "assistant", "tool_call": {"name": name, "args": args}})
+                result = execute_tool(name, args, snapshot)
+                trajectory.append({"role": "tool", "name": name, "result": result})
+                messages.append({"role": "assistant", "tool_calls": [tc]})
+                messages.append({"role": "tool", "tool_call_id": tc.get("id", ""), "name": name, "content": json.dumps(result, default=str)})
+        elif msg.get("content"):
+            trajectory.append({"role": "assistant", "final_answer": msg["content"]})
+            return {
+                "user_query": query,
+                "context": {"now_iso": dt.datetime.now().isoformat(), "snapshot_keys": list(snapshot.keys())},
+                "trajectory": trajectory,
+                "teacher_model": model,
+                "contributor_id": contributor_id,
+            }
+        else:
+            break
+    trajectory.append({"role": "assistant", "final_answer": "(max tool calls reached without final answer)"})
+    return {
+        "user_query": query,
+        "context": {"now_iso": dt.datetime.now().isoformat(), "snapshot_keys": list(snapshot.keys())},
+        "trajectory": trajectory,
+        "teacher_model": model,
+        "contributor_id": contributor_id,
+        "incomplete": True,
+    }
+
+
+def load_snapshot(contributor: str) -> dict:
+    """Load a contributor's Canvas + calendar snapshot. Defers to
+    canvas_sdk live fetch if available; falls back to a hand-curated
+    snapshot file at GemmaReranker/data/snapshots/<contributor>.json."""
+    snapshot_path = Path(f"GemmaReranker/data/snapshots/{contributor}.json")
+    if snapshot_path.exists():
+        return json.loads(snapshot_path.read_text())
+    # Try live fetch via canvas_sdk
+    try:
+        from canvas_tui.api import CanvasAPI
+        api = CanvasAPI.from_config()
+        return {
+            "courses": [c.to_dict() for c in api.list_courses()],
+            "assignments": [a.to_dict() for a in api.get_assignments()],
+            "todo": [t.to_dict() for t in api.get_todo()],
+            "syllabi": {},  # populated lazily on tool call
+            "calendar_events": [],
+        }
+    except Exception:
+        print(f"WARN: no snapshot at {snapshot_path} and live Canvas fetch failed", file=sys.stderr)
+        return {"courses": [], "assignments": [], "todo": [], "syllabi": {}, "calendar_events": []}
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--contributor", required=True, help="Contributor ID (used as anonymization salt; e.g. 'alice')")
+    p.add_argument("--queries", help="File of queries, one per line. Default: built-in CANONICAL_QUERIES.")
+    p.add_argument("--output", required=True, help="Output JSONL path.")
+    p.add_argument("--endpoint", default=os.environ.get("TEACHER_ENDPOINT", "http://localhost:18080/v1"))
+    p.add_argument("--model", default=os.environ.get("TEACHER_MODEL", "nvidia/Gemma-4-31B-IT-NVFP4"))
+    p.add_argument("--max-trajectories", type=int, default=20)
+    p.add_argument("--anonymize", default=True, action="store_true")
+    args = p.parse_args()
+
+    full = _import_tools()
+    print(f"[tools] {'full canvas_tui registry' if full else 'minimal standalone schemas'} ({len(TOOL_SCHEMAS)} tools)")
+
+    if args.queries:
+        queries = [q.strip() for q in Path(args.queries).read_text().splitlines() if q.strip() and not q.startswith("#")]
+    else:
+        queries = list(CANONICAL_QUERIES)
+    queries = queries[: args.max_trajectories]
+    print(f"[queries] running {len(queries)} canonical queries")
+
+    snapshot = load_snapshot(args.contributor)
+    print(f"[snapshot] {sum(len(v) if isinstance(v, list) else 1 for v in snapshot.values())} items across {list(snapshot.keys())}")
+
+    out = []
+    for i, q in enumerate(queries):
+        print(f"\n[{i+1}/{len(queries)}] {q[:80]}")
+        try:
+            rec = collect_one(q, snapshot, args.contributor, args.endpoint, args.model)
+            if args.anonymize:
+                rec = anonymize_record(rec, args.contributor)
+            out.append(rec)
+            print(f"  {len(rec['trajectory'])} trajectory steps")
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+
+    Path(args.output).parent.mkdir(parents=True, exist_ok=True)
+    Path(args.output).write_text("\n".join(json.dumps(r) for r in out) + "\n")
+    print(f"\n[wrote] {args.output} ({len(out)} trajectories)")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/data_utils.py
+++ b/GemmaReranker/scripts/data_utils.py
@@ -1,0 +1,104 @@
+import json
+import sys
+from pathlib import Path
+
+
+def validate_dpo_records(records: list[dict]) -> int:
+    """Validate DPO records schema. Returns zero-grad pair count. Raises on data errors."""
+    zero_grad = 0
+    for i, r in enumerate(records):
+        for key in ("prompt", "chosen", "rejected"):
+            if not isinstance(r.get(key), str) or not r[key]:
+                raise ValueError(f"Record {i}: missing or empty '{key}'")
+        pair_type = r.get("pair_type", "")
+        if pair_type not in ("hard_negative", "standard"):
+            raise ValueError(f"Record {i}: invalid pair_type '{pair_type}'")
+        if r["chosen"] == r["rejected"]:
+            zero_grad += 1
+    print(
+        f"WARNING: {zero_grad} zero-gradient pairs (chosen==rejected) "
+        f"— expected 2 per D-11, not filtered."
+    )
+    if zero_grad > 5:
+        raise ValueError(f"Too many zero-gradient pairs ({zero_grad}); likely a data error")
+    return zero_grad
+
+
+def format_for_dpo(record: dict) -> dict:
+    """Extract TRL-schema fields plus pair_type. Strips training metadata."""
+    return {
+        "prompt": record["prompt"],
+        "chosen": record["chosen"],
+        "rejected": record["rejected"],
+        "pair_type": record.get("pair_type", "standard"),
+    }
+
+
+def join_pair_types(tl_records: list[dict], dp_records: list[dict]) -> list[dict]:
+    """Join pair_type from dpo_pairs onto teacher_labels via (pair_id/id, prompt[:60])."""
+    lookup = {(r["id"], r["prompt"][:60]): r["pair_type"] for r in dp_records}
+    result = []
+    unmatched = 0
+    for r in tl_records:
+        key = (r["pair_id"], r["prompt"][:60])
+        pair_type = lookup.get(key)
+        if pair_type is None:
+            unmatched += 1
+            pair_type = "standard"
+        result.append({**r, "pair_type": pair_type})
+    if unmatched:
+        print(f"WARNING: {unmatched} teacher_labels records had no pair_type match in dpo_pairs")
+    return result
+
+
+def oversample_hard_negatives(dataset, multiplier: int = 3):
+    """3x oversample hard_negative rows via concatenate_datasets (DPO-05, not WPO)."""
+    from datasets import concatenate_datasets
+
+    hard = dataset.filter(lambda x: x["pair_type"] == "hard_negative")
+    standard = dataset.filter(lambda x: x["pair_type"] != "hard_negative")
+    oversampled = concatenate_datasets([hard] * multiplier + [standard])
+    return oversampled.shuffle(seed=42)
+
+
+def build_dpo_dataset(
+    tl_path: str = "/tmp/canvas-review/GemmaReranker/data/teacher_labels.jsonl",
+    dp_path: str = "/tmp/canvas-review/GemmaReranker/data/dpo_pairs.jsonl",
+    output_path: str = None,
+    multiplier: int = 3,
+) -> None:
+    from datasets import Dataset
+
+    if output_path is None:
+        output_path = str(Path(__file__).parent.parent / "data" / "dpo_train.jsonl")
+
+    tl_records = [json.loads(l) for l in open(tl_path)]
+    dp_records = [json.loads(l) for l in open(dp_path)]
+
+    joined = join_pair_types(tl_records, dp_records)
+    formatted = [format_for_dpo(r) for r in joined]
+    validate_dpo_records(formatted)
+
+    dataset = Dataset.from_list(formatted)
+    dataset = oversample_hard_negatives(dataset, multiplier=multiplier)
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with open(output_path, "w") as f:
+        for record in dataset:
+            f.write(json.dumps(record) + "\n")
+
+    print(f"Written {len(dataset)} records to {output_path}")
+
+
+if __name__ == "__main__":
+    tl = sys.argv[1] if len(sys.argv) > 1 else None
+    dp = sys.argv[2] if len(sys.argv) > 2 else None
+    out = sys.argv[3] if len(sys.argv) > 3 else None
+    kwargs = {}
+    if tl:
+        kwargs["tl_path"] = tl
+    if dp:
+        kwargs["dp_path"] = dp
+    if out:
+        kwargs["output_path"] = out
+    build_dpo_dataset(**kwargs)

--- a/GemmaReranker/scripts/deposit_zenodo.py
+++ b/GemmaReranker/scripts/deposit_zenodo.py
@@ -1,0 +1,137 @@
+"""
+deposit_zenodo.py — upload paper/main.pdf to Zenodo for a permanent
+DOI + citable record.
+
+Setup:
+  1. Create a Zenodo account (or use sandbox.zenodo.org for testing)
+  2. Generate a personal access token at:
+        https://zenodo.org/account/settings/applications/tokens/new/
+     Scope: deposit:write + deposit:actions
+  3. Export it:
+        export ZENODO_TOKEN=...
+  4. Run:
+        python3 source/deposit_zenodo.py
+
+What this does (in one transaction):
+  - Create a new deposit
+  - Upload paper/main.pdf
+  - Set metadata (title, creators, description, keywords, license, etc.)
+  - Publish (assigns DOI; record is permanent and immutable)
+
+After publish, the script prints the DOI + landing-page URL. Add the
+DOI badge to README/HF cards.
+
+Note: PUBLISHING IS PERMANENT. The script defaults to publishing
+immediately. Set --draft to leave the deposit unpublished so you can
+review on the Zenodo web UI before publishing.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+PAPER_PATH = Path("paper/main.pdf")
+USE_SANDBOX = os.environ.get("ZENODO_SANDBOX", "0") == "1"
+BASE_URL = "https://sandbox.zenodo.org/api" if USE_SANDBOX else "https://zenodo.org/api"
+
+METADATA = {
+    "title": "Fine-Tuning Gemma-4-E2B-IT for Canvas Assignment Prioritization: A Comparative Study of SFT, LoRA, QLoRA, DPO, IPO, and KTO",
+    "creators": [
+        {"name": "Thompson, Klein", "affiliation": "Virginia Tech (CS 3704)"},
+    ],
+    "description": (
+        "<p>Domain-specific fine-tuning pipeline for Gemma-4-E2B-IT on the task of "
+        "Canvas LMS assignment prioritization. Trains and benchmarks six method variants "
+        "(SFT, LoRA, QLoRA, DPO, IPO, KTO) on the same corrected gemma4-text-base and the "
+        "same item-disjoint train/test split. Includes the methodology, errata for an "
+        "early v1 weight-mapping bug, a v3 retrospective audit identifying "
+        "training-set-as-validation contamination in v2, a held-out validation on "
+        "n=148 item-disjoint pairs, and a discussion of where DPO (and DPO variants) "
+        "do and don't improve over SFT on this saturated preference task.</p>"
+        "<p>Companion artifacts:</p>"
+        "<ul>"
+        "<li>Model: <a href='https://huggingface.co/kleinpanic93/gemma4-canvas-reranker'>kleinpanic93/gemma4-canvas-reranker</a> (4 GGUF quants + BF16)</li>"
+        "<li>Six method-variant models: see the "
+        "<a href='https://huggingface.co/collections/kleinpanic93/canvas-reranker-gemma-4-e2b-it-v10-69f5799662d65c8f39be0a94'>Canvas Reranker Collection</a></li>"
+        "<li>Dataset: <a href='https://huggingface.co/datasets/kleinpanic93/canvas-preference-2k'>kleinpanic93/canvas-preference-2k</a></li>"
+        "</ul>"
+    ),
+    "upload_type": "publication",
+    "publication_type": "report",
+    "keywords": [
+        "Direct Preference Optimization", "DPO", "IPO", "KTO",
+        "Gemma-4", "Canvas LMS", "preference learning",
+        "domain-specific fine-tuning", "small language models",
+        "educational AI", "task prioritization",
+    ],
+    "license": "cc-by-4.0",
+    "communities": [],
+    "related_identifiers": [
+        {"identifier": "https://huggingface.co/kleinpanic93/gemma4-canvas-reranker", "relation": "isSupplementedBy", "scheme": "url"},
+        {"identifier": "https://huggingface.co/datasets/kleinpanic93/canvas-preference-2k", "relation": "isSupplementedBy", "scheme": "url"},
+        {"identifier": "https://github.com/kleinpanic/CS3704-Canvas-Project", "relation": "isSupplementedBy", "scheme": "url"},
+    ],
+}
+
+
+def main():
+    import requests
+    token = os.environ.get("ZENODO_TOKEN")
+    if not token:
+        print("ERROR: set ZENODO_TOKEN to your Zenodo personal access token")
+        print("  Get one at: https://zenodo.org/account/settings/applications/tokens/new/")
+        print("  Scopes needed: deposit:write, deposit:actions")
+        sys.exit(1)
+    if not PAPER_PATH.exists():
+        print(f"ERROR: {PAPER_PATH} missing")
+        sys.exit(1)
+
+    publish_now = "--draft" not in sys.argv
+
+    headers = {"Content-Type": "application/json"}
+    auth = {"access_token": token}
+
+    print(f"[1/4] Create deposit at {BASE_URL} ...")
+    r = requests.post(f"{BASE_URL}/deposit/depositions", params=auth, json={}, headers=headers)
+    r.raise_for_status()
+    dep = r.json()
+    dep_id = dep["id"]
+    bucket_url = dep["links"]["bucket"]
+    print(f"      deposit_id={dep_id}")
+
+    print(f"[2/4] Upload {PAPER_PATH} ({PAPER_PATH.stat().st_size//1024} KB) ...")
+    with open(PAPER_PATH, "rb") as fp:
+        r = requests.put(f"{bucket_url}/{PAPER_PATH.name}", data=fp, params=auth)
+    r.raise_for_status()
+
+    print(f"[3/4] Set metadata ...")
+    r = requests.put(
+        f"{BASE_URL}/deposit/depositions/{dep_id}",
+        params=auth, headers=headers,
+        data=json.dumps({"metadata": METADATA}),
+    )
+    if not r.ok:
+        print(f"  metadata error: {r.status_code} {r.text[:500]}")
+        r.raise_for_status()
+
+    if publish_now:
+        print(f"[4/4] PUBLISH (immutable) ...")
+        r = requests.post(f"{BASE_URL}/deposit/depositions/{dep_id}/actions/publish", params=auth)
+        r.raise_for_status()
+        pub = r.json()
+        doi = pub["doi"]
+        url = pub["links"]["html"]
+        print(f"\n  DOI:  {doi}")
+        print(f"  URL:  {url}")
+        print(f"\nAdd this badge to README:")
+        print(f"  [![DOI](https://zenodo.org/badge/DOI/{doi}.svg)](https://doi.org/{doi})")
+    else:
+        print(f"[4/4] DRAFT mode — leaving deposit unpublished")
+        print(f"  Review at: {dep['links']['html']}")
+        print(f"  Publish via web UI when ready.")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/export_gguf.py
+++ b/GemmaReranker/scripts/export_gguf.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""
+export_gguf.py — Merge QLoRA adapter into base model, export to Q5_K_M GGUF.
+
+Steps:
+  1. Load base model (google/gemma-4-E2B-it) in BF16
+  2. Load QLoRA adapter and merge via PEFT merge_and_unload()
+  3. Save merged BF16 checkpoint to disk
+  4. Convert to F16 GGUF using llama.cpp convert_hf_to_gguf.py
+  5. Quantize F16 GGUF to Q5_K_M using llama-quantize
+
+Usage (inside training container or on host with transformers + peft):
+  python source/export_gguf.py
+
+Environment:
+  GGUF_ADAPTER     — path to QLoRA adapter dir (default: /tmp/canvas-review/GemmaReranker/outputs/qlora-adapter)
+  GGUF_BASE_MODEL  — HF model ID (default: google/gemma-4-E2B-it)
+  GGUF_OUTPUT_DIR  — output directory (default: ./checkpoints/gguf)
+  LLAMA_CPP_DIR    — path to llama.cpp source (default: ~/.local/srcs/gitclones/llama.cpp)
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import torch
+from peft import PeftModel
+from transformers import AutoTokenizer, Gemma4ForCausalLM
+
+ADAPTER_PATH = os.environ.get(
+    "GGUF_ADAPTER",
+    "/tmp/canvas-review/GemmaReranker/outputs/qlora-adapter",
+)
+BASE_MODEL = os.environ.get(
+    "GGUF_BASE_MODEL",
+    "/tmp/canvas-review/GemmaReranker/outputs/gemma4-text-base",
+)
+OUTPUT_DIR = Path(os.environ.get("GGUF_OUTPUT_DIR", "./checkpoints/gguf"))
+LLAMA_CPP = Path(os.environ.get(
+    "LLAMA_CPP_DIR",
+    Path.home() / ".local/srcs/gitclones/llama.cpp",
+))
+
+MERGED_DIR = OUTPUT_DIR / "merged_bf16"
+F16_GGUF = OUTPUT_DIR / "gemma4-reranker-f16.gguf"
+Q5_GGUF = OUTPUT_DIR / "gemma4-reranker-Q5_K_M.gguf"
+
+
+def step1_merge(adapter_path: str, base_model: str) -> None:
+    print(f"[1/4] Loading base model {base_model} ...")
+    model = Gemma4ForCausalLM.from_pretrained(
+        base_model,
+        torch_dtype=torch.bfloat16,
+        attn_implementation="sdpa",
+        device_map="cpu",
+    )
+    print(f"[2/4] Loading and merging adapter {adapter_path} ...")
+    model = PeftModel.from_pretrained(model, adapter_path)
+    merged = model.merge_and_unload()
+
+    MERGED_DIR.mkdir(parents=True, exist_ok=True)
+    print(f"[3/4] Saving merged BF16 checkpoint → {MERGED_DIR} ...")
+    merged.save_pretrained(str(MERGED_DIR))
+    tokenizer = AutoTokenizer.from_pretrained(base_model)
+    tokenizer.save_pretrained(str(MERGED_DIR))
+    print(f"      Saved.")
+
+
+def step2_convert() -> None:
+    convert_script = LLAMA_CPP / "convert_hf_to_gguf.py"
+    if not convert_script.exists():
+        sys.exit(f"ERROR: llama.cpp not found at {LLAMA_CPP}. Set LLAMA_CPP_DIR.")
+
+    F16_GGUF.parent.mkdir(parents=True, exist_ok=True)
+    print(f"[4a/4] Converting merged BF16 → F16 GGUF ...")
+    gguf_py = str(LLAMA_CPP / "gguf-py")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = gguf_py + ((":" + env["PYTHONPATH"]) if "PYTHONPATH" in env else "")
+    cmd = [
+        sys.executable, str(convert_script),
+        str(MERGED_DIR),
+        "--outfile", str(F16_GGUF),
+        "--outtype", "f16",
+    ]
+    print(f"  PYTHONPATH={gguf_py} {' '.join(cmd)}")
+    result = subprocess.run(cmd, env=env)
+    if result.returncode != 0:
+        sys.exit(f"ERROR: GGUF conversion failed (exit {result.returncode})")
+    size_mb = F16_GGUF.stat().st_size / 1e6
+    print(f"      F16 GGUF: {F16_GGUF} ({size_mb:.0f} MB)")
+
+
+def step3_quantize() -> None:
+    quantize_bin = LLAMA_CPP / "build" / "bin" / "llama-quantize"
+    if not quantize_bin.exists():
+        sys.exit(
+            f"ERROR: llama-quantize not found at {quantize_bin}. "
+            "Run: cd ~/.local/srcs/gitclones/llama.cpp && cmake --build build --target llama-quantize"
+        )
+
+    print(f"[4b/4] Quantizing F16 GGUF → Q5_K_M ...")
+    cmd = [str(quantize_bin), str(F16_GGUF), str(Q5_GGUF), "Q5_K_M"]
+    print(f"  {' '.join(cmd)}")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        sys.exit(f"ERROR: quantization failed (exit {result.returncode})")
+    size_mb = Q5_GGUF.stat().st_size / 1e6
+    print(f"      Q5_K_M GGUF: {Q5_GGUF} ({size_mb:.0f} MB)")
+    if size_mb > 2000:
+        print(f"WARNING: GGUF exceeds 2 GB target ({size_mb:.0f} MB)")
+
+
+def main() -> None:
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    print("=" * 60)
+    print("Gemma-4 Reranker — QLoRA Merge + GGUF Export")
+    print(f"  Adapter:    {ADAPTER_PATH}")
+    print(f"  Base model: {BASE_MODEL}")
+    print(f"  Output:     {OUTPUT_DIR}")
+    print("=" * 60)
+
+    if not MERGED_DIR.exists() or not any(MERGED_DIR.iterdir()):
+        step1_merge(ADAPTER_PATH, BASE_MODEL)
+    else:
+        print(f"[1-3/4] Merged checkpoint already exists at {MERGED_DIR} — skipping merge.")
+
+    if not F16_GGUF.exists():
+        step2_convert()
+    else:
+        print(f"[4a/4] F16 GGUF already exists at {F16_GGUF} — skipping conversion.")
+
+    if not Q5_GGUF.exists():
+        step3_quantize()
+    else:
+        size_mb = Q5_GGUF.stat().st_size / 1e6
+        print(f"[4b/4] Q5_K_M GGUF already exists: {Q5_GGUF} ({size_mb:.0f} MB)")
+
+    print("\nDone.")
+    print(f"  Q5_K_M GGUF: {Q5_GGUF}")
+    print(f"  Size: {Q5_GGUF.stat().st_size / 1e6:.0f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/extract_text_base.py
+++ b/GemmaReranker/scripts/extract_text_base.py
@@ -1,0 +1,101 @@
+"""
+extract_text_base.py — recreate the gemma4-text-base checkpoint
+that was lost in the 2026-05-01 /tmp wipe.
+
+Background: google/gemma-4-E2B-it is published as
+Gemma4ForConditionalGeneration (a multimodal model) whose text-tower
+weights live under the prefix `model.language_model.*`. Loading it
+via Gemma4ForCausalLM.from_pretrained() silently random-inits any
+keys that don't match (HF loader behavior), which produces the
+12.499 ≈ ln(262144) starting-loss bug documented in paper §6.5.
+
+This script remaps the 541 text-tower keys
+(model.language_model.* → model.*) and saves a standalone
+Gemma4ForCausalLM checkpoint that loads cleanly. Output goes to
+checkpoints/gemma4-text-base/ (~18 GiB safetensors).
+
+Verification: post-extraction, Gemma4ForCausalLM.from_pretrained
+on this directory should produce a model whose
+embed_tokens.weight has σ ≈ 0.031 (pretrained distribution) rather
+than σ = 0.02 (random init). SFT step-0 loss should be ≈ 2.5 not
+12.499.
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+from pathlib import Path
+
+OUT_DIR = Path("checkpoints/gemma4-text-base")
+SOURCE_REPO = "google/gemma-4-E2B-it"
+
+
+def main():
+    import torch
+    from transformers import AutoConfig, AutoTokenizer
+    from huggingface_hub import snapshot_download
+
+    print(f"[1/5] Downloading source checkpoint {SOURCE_REPO} ...")
+    src_dir = snapshot_download(SOURCE_REPO)
+    print(f"      cached at {src_dir}")
+
+    print(f"[2/5] Loading source weights via safetensors ...")
+    from safetensors.torch import load_file, save_file
+    weight_files = sorted(Path(src_dir).glob("model-*.safetensors"))
+    if not weight_files:
+        weight_files = [Path(src_dir) / "model.safetensors"]
+    all_weights: dict[str, torch.Tensor] = {}
+    for wf in weight_files:
+        all_weights.update(load_file(str(wf)))
+    print(f"      loaded {len(all_weights)} tensors from {len(weight_files)} shard(s)")
+
+    print(f"[3/5] Remapping text-tower keys (model.language_model.* → model.*) ...")
+    remapped: dict[str, torch.Tensor] = {}
+    n_remapped = 0
+    n_dropped = 0
+    for k, v in all_weights.items():
+        if k.startswith("model.language_model."):
+            new_k = "model." + k[len("model.language_model.") :]
+            remapped[new_k] = v
+            n_remapped += 1
+        elif k.startswith("model.vision_tower.") or k.startswith("model.audio_tower.") or k.startswith("model.multi_modal_projector."):
+            n_dropped += 1
+        elif k.startswith("model.") or k == "lm_head.weight":
+            remapped[k] = v
+        else:
+            n_dropped += 1
+    print(f"      remapped {n_remapped} keys, dropped {n_dropped} vision/audio keys")
+
+    print(f"[4/5] Loading tokenizer + config ...")
+    cfg = AutoConfig.from_pretrained(src_dir)
+    text_cfg = cfg.text_config if hasattr(cfg, "text_config") else cfg
+    text_cfg.architectures = ["Gemma4ForCausalLM"]
+    text_cfg.model_type = "gemma4_text"
+
+    tokenizer = AutoTokenizer.from_pretrained(src_dir)
+
+    print(f"[5/5] Writing to {OUT_DIR} ...")
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    save_file(remapped, str(OUT_DIR / "model.safetensors"))
+    text_cfg.save_pretrained(str(OUT_DIR))
+    tokenizer.save_pretrained(str(OUT_DIR))
+    for fname in ("chat_template.jinja", "generation_config.json"):
+        src = Path(src_dir) / fname
+        if src.exists():
+            shutil.copy(src, OUT_DIR / fname)
+
+    print(f"\n[verify] sanity-check load")
+    from transformers import Gemma4ForCausalLM
+    m = Gemma4ForCausalLM.from_pretrained(str(OUT_DIR), torch_dtype=torch.bfloat16)
+    embed = m.model.embed_tokens.weight
+    sigma = embed.float().std().item()
+    print(f"  embed_tokens.weight sigma = {sigma:.4f}  (target ~0.031, random init = 0.02)")
+    if sigma < 0.025:
+        print("  WARN: sigma suggests random init — extraction failed")
+    else:
+        print("  OK: sigma in pretrained range")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/latency_bench.py
+++ b/GemmaReranker/scripts/latency_bench.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+latency_bench.py — INT-03: verify LocalReranker sorts 10 items in under 500ms.
+
+Uses the LocalReranker directly (requires llama-cpp-python + GGUF).
+Runs 3 trials and reports min/mean/max wall-clock time for 10-item sort.
+
+Usage:
+  python source/latency_bench.py --gguf checkpoints/gguf/gemma4-reranker-Q5_K_M.gguf
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+TEST_DATA = "/tmp/canvas-review/GemmaReranker/data/test.jsonl"
+N_ITEMS = 10
+N_TRIALS = 3
+TARGET_MS = 500
+
+
+def make_fake_items(n: int):
+    sys.path.insert(0, "/tmp/canvas-review/src")
+    from canvas_tui.models.item import CanvasItem
+
+    records = [json.loads(l) for l in open(TEST_DATA)]
+    items = []
+    seen = set()
+    for rec in records:
+        raw = rec.get("item_a", {})
+        if isinstance(raw, str):
+            try:
+                raw = json.loads(raw.replace("'", '"'))
+            except Exception:
+                continue
+        title = raw.get("title", "?")
+        if title not in seen:
+            seen.add(title)
+            items.append(CanvasItem(
+                title=title,
+                ptype=raw.get("type", "assignment").lower(),
+                course_code=raw.get("course", "COURSE0"),
+                due_at=raw.get("due_at") or "",
+                points=raw.get("points"),
+            ))
+        if len(items) >= n:
+            break
+    return items[:n]
+
+
+def run_latency_bench(gguf_path: str) -> None:
+    sys.path.insert(0, "/tmp/canvas-review/src")
+    from canvas_tui.reranker import LocalReranker
+
+    print(f"Loading GGUF: {gguf_path}")
+    reranker = LocalReranker(gguf_path)
+    items = make_fake_items(N_ITEMS)
+    print(f"Loaded {len(items)} items. Running {N_TRIALS} trials of {N_ITEMS}-item sort...")
+
+    times_ms = []
+    for trial in range(N_TRIALS):
+        t0 = time.perf_counter()
+        reranker.rank("urgent assignments due soon", items)
+        elapsed_ms = (time.perf_counter() - t0) * 1000
+        times_ms.append(elapsed_ms)
+        print(f"  Trial {trial+1}: {elapsed_ms:.0f}ms")
+
+    min_ms = min(times_ms)
+    mean_ms = sum(times_ms) / len(times_ms)
+    max_ms = max(times_ms)
+    print(f"\nLatency: min={min_ms:.0f}ms  mean={mean_ms:.0f}ms  max={max_ms:.0f}ms")
+    print(f"Target: {TARGET_MS}ms")
+
+    if mean_ms <= TARGET_MS:
+        print(f"PASS: mean {mean_ms:.0f}ms ≤ {TARGET_MS}ms (INT-03)")
+    else:
+        print(f"FAIL: mean {mean_ms:.0f}ms > {TARGET_MS}ms (INT-03)")
+        sys.exit(1)
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--gguf", default="checkpoints/gguf/gemma4-reranker-Q5_K_M.gguf")
+    args = p.parse_args()
+    if not Path(args.gguf).exists():
+        print(f"ERROR: GGUF not found: {args.gguf}", file=sys.stderr)
+        sys.exit(1)
+    run_latency_bench(args.gguf)
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/prep_dataset_release.py
+++ b/GemmaReranker/scripts/prep_dataset_release.py
@@ -1,0 +1,110 @@
+"""
+prep_dataset_release.py — produce the HF-release artifact for the
+Canvas preference dataset, applying the recommendations from
+.planning/research/DATASET-AUDIT.md:
+
+  1. Dedup: drop the data-prep 3× hard-neg oversample. The published
+     artifact is the underlying 1,347-pair file (1,109 standard + 238
+     hard_negative unique pairs) — downstream consumers can reapply
+     oversampling if they want to.
+  2. Add preference_signal_present: bool — flags the 12.9 % of records
+     where chosen and rejected both conclude the same Item is more
+     urgent (no preference signal for DPO to fit). Detected by
+     comparing the primary "Item X is the/more/most/..." assertion
+     between the two responses.
+  3. Sanitize "Ut Prosim" titles (Virginia Tech motto) in 2 records to
+     a generic descriptor. Preserves dataset semantics; removes the
+     institutional identifier.
+
+Output: data/release/canvas-preference-2k.jsonl — single split
+suitable for HF datasets push.
+"""
+from __future__ import annotations
+
+import json
+import re
+from collections import Counter
+from pathlib import Path
+
+SOURCE = Path("data/dpo_train.jsonl")
+OUT_DIR = Path("data/release")
+OUT_PATH = OUT_DIR / "canvas-preference-2k.jsonl"
+
+ASSERT_RE = re.compile(
+    r"\bItem\s+([AB])\s+is\s+(?:the|a)?\s*"
+    r"(?:more|higher|most|highest|top|primary|absolute|clear|immediate|critical)",
+    re.IGNORECASE,
+)
+UT_PROSIM_RE = re.compile(r"Ut\s+Prosim", re.IGNORECASE)
+UT_PROSIM_REPLACEMENT = "Service requirement"
+
+
+def primary_pick(text: str) -> str | None:
+    matches = ASSERT_RE.findall(text)
+    if not matches:
+        return None
+    return Counter(matches).most_common(1)[0][0]
+
+
+def sanitize_text(text: str) -> str:
+    return UT_PROSIM_RE.sub(UT_PROSIM_REPLACEMENT, text)
+
+
+def main():
+    records = [json.loads(l) for l in SOURCE.read_text().splitlines() if l.strip()]
+    print(f"[load] {len(records)} records from {SOURCE}")
+
+    seen = set()
+    unique = []
+    for r in records:
+        key = (r["prompt"], r["chosen"], r["rejected"])
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(r)
+    print(f"[dedup] {len(unique)} unique records (dropped {len(records) - len(unique)} duplicates)")
+
+    n_pref_signal = 0
+    n_no_signal = 0
+    n_unparseable = 0
+    n_sanitized = 0
+    out_records = []
+    for r in unique:
+        chosen_pick = primary_pick(r["chosen"])
+        rejected_pick = primary_pick(r["rejected"])
+        if chosen_pick is None or rejected_pick is None:
+            preference_signal_present = None
+            n_unparseable += 1
+        elif chosen_pick != rejected_pick:
+            preference_signal_present = True
+            n_pref_signal += 1
+        else:
+            preference_signal_present = False
+            n_no_signal += 1
+
+        out = {
+            "prompt": sanitize_text(r["prompt"]),
+            "chosen": sanitize_text(r["chosen"]),
+            "rejected": sanitize_text(r["rejected"]),
+            "pair_type": r["pair_type"],
+            "preference_signal_present": preference_signal_present,
+        }
+        if any(UT_PROSIM_RE.search(t) for t in (r["prompt"], r["chosen"], r["rejected"])):
+            n_sanitized += 1
+        out_records.append(out)
+
+    pt_counter = Counter(r["pair_type"] for r in out_records)
+    print(f"[label] preference_signal_present:")
+    print(f"        True (clean DPO contrast):   {n_pref_signal}")
+    print(f"        False (no signal):           {n_no_signal}")
+    print(f"        None (unparseable):          {n_unparseable}")
+    print(f"[type ] pair_type:                  {dict(pt_counter)}")
+    print(f"[clean] records with 'Ut Prosim' sanitized: {n_sanitized}")
+
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    OUT_PATH.write_text("\n".join(json.dumps(r) for r in out_records) + "\n")
+    print(f"[wrote] {OUT_PATH} ({OUT_PATH.stat().st_size // 1024} KB, {len(out_records)} records)")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/publish_v4_models.py
+++ b/GemmaReranker/scripts/publish_v4_models.py
@@ -1,0 +1,208 @@
+"""
+publish_v4_models.py — for each v4 method variant:
+  1. Verify the checkpoint loaded successfully
+  2. (optionally) generate Q4_K_M GGUF via llama.cpp/quantize
+  3. Push to HuggingFace as a separate model repo
+  4. Add to the canvas-reranker collection
+
+Run after train_v4_matrix.py completes for any/all methods.
+
+Usage:
+    python3 source/publish_v4_models.py sft     # publish one
+    python3 source/publish_v4_models.py all     # publish all that exist
+    python3 source/publish_v4_models.py all --dry-run   # plan only
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+USER = "kleinpanic93"
+COLLECTION_SLUG = "kleinpanic93/canvas-reranker-gemma-4-e2b-it-v10-69f5799662d65c8f39be0a94"
+
+VARIANTS = {
+    "sft":      {"ckpt": "checkpoints/v4-sft",      "repo": f"{USER}/gemma4-canvas-reranker-sft",      "kind": "model", "is_adapter": False, "title": "SFT v4"},
+    "lora":     {"ckpt": "checkpoints/v4-lora",     "repo": f"{USER}/gemma4-canvas-reranker-lora",     "kind": "model", "is_adapter": True,  "title": "LoRA v4"},
+    "qlora":    {"ckpt": "checkpoints/v4-qlora",    "repo": f"{USER}/gemma4-canvas-reranker-qlora",    "kind": "model", "is_adapter": True,  "title": "QLoRA v4"},
+    "dpo":      {"ckpt": "checkpoints/v4-dpo",      "repo": f"{USER}/gemma4-canvas-reranker-dpo",      "kind": "model", "is_adapter": False, "title": "DPO v4 (sigmoid)"},
+    "ipo":      {"ckpt": "checkpoints/v4-ipo",      "repo": f"{USER}/gemma4-canvas-reranker-ipo",      "kind": "model", "is_adapter": False, "title": "IPO v4 (Identity Preference Optimization, Azar 2023)"},
+    "apo_zero": {"ckpt": "checkpoints/v4-apo-zero", "repo": f"{USER}/gemma4-canvas-reranker-apo-zero", "kind": "model", "is_adapter": False, "title": "APO-zero v4 (Anchored Preference Optimization, Pan 2024)"},
+    "sppo":     {"ckpt": "checkpoints/v4-sppo",     "repo": f"{USER}/gemma4-canvas-reranker-sppo",     "kind": "model", "is_adapter": False, "title": "SPPO v4 (Self-Play Preference Optimization, Wu 2024)"},
+    "nca":      {"ckpt": "checkpoints/v4-nca",      "repo": f"{USER}/gemma4-canvas-reranker-nca",      "kind": "model", "is_adapter": False, "title": "NCA v4 (Noise-Contrastive Alignment, Chen 2024)"},
+    "kto":      {"ckpt": "checkpoints/v4-kto",      "repo": f"{USER}/gemma4-canvas-reranker-kto",      "kind": "model", "is_adapter": False, "title": "KTO v4 (Kahneman-Tversky Optimization, Ethayarajh 2024)"},
+}
+
+CARD_TEMPLATE = """---
+license: gemma
+base_model: google/gemma-4-E2B-it
+library_name: {library}
+tags:
+  - canvas-lms
+  - assignment-prioritization
+  - preference-learning
+  - {method}
+language:
+  - en
+pipeline_tag: text-generation
+datasets:
+  - kleinpanic93/canvas-preference-2k
+---
+
+# Gemma-4-E2B-IT Canvas Reranker — {title}
+
+Variant of [`kleinpanic93/gemma4-canvas-reranker`](https://huggingface.co/kleinpanic93/gemma4-canvas-reranker)
+trained via **{method_full}** on the corrected `gemma4-text-base` and
+the v3 train partition (998 records, item-disjoint from the v3 test
+set).
+
+This is one of **6 method variants** released as a multi-method
+comparison set. See the
+[Canvas Reranker Collection](https://huggingface.co/collections/{collection_slug})
+for all variants and the [methodology paper](https://huggingface.co/kleinpanic93/gemma4-canvas-reranker/blob/main/paper/main.pdf).
+
+## Training
+
+- **Method:** {method_full}
+- **Base:** `gemma4-text-base` (corrected from `google/gemma-4-E2B-it`
+  multimodal — see paper §6.5 errata)
+- **Data:** `kleinpanic93/canvas-preference-2k`, v3 train partition
+  (998 records, item-disjoint)
+- **Hyperparameters:** {hparams}
+- **Hardware:** NVIDIA Grace–Blackwell GB10 (128 GiB UMA)
+- **Toolchain:** TRL 1.1.0, Transformers 5.5.4, PyTorch 2.11+cu130
+
+## Held-out evaluation (n=148 item-disjoint pairs)
+
+See `holdout_validation.json` in this repo. Cross-method comparison
+table is in the methodology paper §6.7 and the Collection overview.
+
+## Use
+
+This is a {kind_descriptor}. Load with:
+
+```python
+{load_snippet}
+```
+
+For deployment, prefer the GGUF quants under
+[`kleinpanic93/gemma4-canvas-reranker`](https://huggingface.co/kleinpanic93/gemma4-canvas-reranker)
+unless you specifically need this method's behavior.
+
+## License
+
+Gemma Terms of Use — see https://ai.google.dev/gemma/terms.
+"""
+
+
+def hparams_for(method: str) -> str:
+    if method == "sft":
+        return "1 epoch, lr=2e-5, full-parameter, bf16, max_length=512, AdamW"
+    if method in ("lora", "qlora"):
+        bits = "4-bit base + " if method == "qlora" else ""
+        return f"1 epoch, lr=2e-4, LoRA r=16 α=32 dropout=0.05 targeting q/k/v/o_proj, {bits}bf16, max_length=512, AdamW"
+    loss_map = {
+        "dpo": "sigmoid", "ipo": "ipo", "apo_zero": "apo_zero",
+        "sppo": "sppo_hard", "nca": "nca_pair",
+    }
+    if method in loss_map:
+        return f"1 epoch, lr=5e-7, β=0.1, DPOTrainer loss_type='{loss_map[method]}', bf16, max_length=512, AdamW"
+    if method == "kto":
+        return "1 epoch, lr=5e-7, β=0.1, KTOTrainer, bf16, max_length=512, AdamW"
+    return ""
+
+
+def write_card(method: str, info: dict, ckpt_dir: Path) -> Path:
+    method_full = {
+        "sft": "Supervised Fine-Tuning (SFT) — full parameter",
+        "lora": "Low-Rank Adaptation (LoRA, Hu 2022)",
+        "qlora": "QLoRA (Dettmers 2023) — 4-bit base + LoRA adapter",
+        "dpo": "Direct Preference Optimization (DPO, Rafailov 2023, sigmoid loss)",
+        "ipo": "Identity Preference Optimization (IPO, Azar 2023) — fixes DPO overoptimization on saturated tasks",
+        "apo_zero": "Anchored Preference Optimization (APO-zero, Pan 2024) — DPO variant with anchor regularization",
+        "sppo": "Self-Play Preference Optimization (SPPO, Wu 2024) — strong recent results on alignment benchmarks",
+        "nca": "Noise-Contrastive Alignment (NCA, Chen 2024) — pairwise noise-contrastive estimation for preference learning",
+        "kto": "Kahneman-Tversky Optimization (KTO, Ethayarajh 2024) — handles unpaired preference data",
+    }[method]
+    is_adapter = info["is_adapter"]
+    if is_adapter:
+        kind_descriptor = "PEFT adapter (load with peft.PeftModel.from_pretrained)"
+        load_snippet = f"""from peft import PeftModel
+from transformers import Gemma4ForCausalLM, AutoTokenizer
+
+base = Gemma4ForCausalLM.from_pretrained(
+    "kleinpanic93/gemma4-canvas-reranker", subfolder="merged_bf16",
+    torch_dtype="bfloat16",
+)
+model = PeftModel.from_pretrained(base, "{info['repo']}")
+tok = AutoTokenizer.from_pretrained("{info['repo']}")"""
+    else:
+        kind_descriptor = "full HF transformers checkpoint"
+        load_snippet = f"""from transformers import Gemma4ForCausalLM, AutoTokenizer
+
+model = Gemma4ForCausalLM.from_pretrained(
+    "{info['repo']}", torch_dtype="bfloat16",
+)
+tok = AutoTokenizer.from_pretrained("{info['repo']}")"""
+    card = CARD_TEMPLATE.format(
+        title=info["title"],
+        method=method,
+        method_full=method_full,
+        library="peft" if is_adapter else "transformers",
+        hparams=hparams_for(method),
+        kind_descriptor=kind_descriptor,
+        load_snippet=load_snippet,
+        collection_slug=COLLECTION_SLUG,
+    )
+    card_path = ckpt_dir / "README.md"
+    card_path.write_text(card)
+    return card_path
+
+
+def publish(method: str, dry_run: bool = False) -> bool:
+    info = VARIANTS[method]
+    ckpt_dir = Path(info["ckpt"])
+    if not ckpt_dir.exists() or not any(ckpt_dir.iterdir()):
+        print(f"  [{method}] checkpoint missing — skip")
+        return False
+    print(f"  [{method}] writing model card → {ckpt_dir}/README.md")
+    write_card(method, info, ckpt_dir)
+    if dry_run:
+        print(f"  [{method}] DRY-RUN — would push to {info['repo']}")
+        return True
+    print(f"  [{method}] pushing to {info['repo']} ...")
+    cmd = [
+        "hf", "upload", info["repo"], str(ckpt_dir), ".",
+        "--commit-message", f"feat(v4): {info['title']} initial publish",
+    ]
+    r = subprocess.run(cmd, capture_output=True, text=True)
+    if r.returncode != 0:
+        print(f"  [{method}] FAILED: {r.stderr.splitlines()[-1] if r.stderr else 'unknown'}")
+        return False
+    print(f"  [{method}] uploaded — adding to collection")
+    add = subprocess.run(
+        ["hf", "collections", "add-item", COLLECTION_SLUG, info["repo"], info["kind"]],
+        capture_output=True, text=True,
+    )
+    if add.returncode != 0 and "already in collection" not in add.stderr:
+        print(f"  [{method}] WARN: collection add failed: {add.stderr.splitlines()[-1] if add.stderr else 'unknown'}")
+    return True
+
+
+def main():
+    args = sys.argv[1:] or ["all"]
+    dry_run = "--dry-run" in args
+    args = [a for a in args if a != "--dry-run"]
+    target = args[0] if args else "all"
+    methods = list(VARIANTS) if target == "all" else [target]
+    for m in methods:
+        if m not in VARIANTS:
+            print(f"unknown variant: {m}; choices: {list(VARIANTS)}")
+            sys.exit(1)
+        publish(m, dry_run=dry_run)
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/run_benchmark.py
+++ b/GemmaReranker/scripts/run_benchmark.py
@@ -1,0 +1,324 @@
+"""
+run_benchmark.py — Phase 06 benchmark for Canvas item reranking.
+
+Scores one model variant against the 827-pair held-out test set.
+Metrics: pairwise accuracy, Kendall's tau, NDCG@5 (per query group).
+Per-pair-type breakdown: standard, equivalence, contrast, same-course, cross-course.
+
+Usage (inside training container):
+  python source/run_benchmark.py --variant sft --checkpoint /sft-checkpoint
+  python source/run_benchmark.py --variant lora \\
+      --checkpoint google/gemma-4-E2B-it --adapter /lora-adapter
+  python source/run_benchmark.py --variant dpo --checkpoint /dpo-checkpoint
+  python source/run_benchmark.py --variant heuristic  # no model needed
+
+Then aggregate:
+  python source/run_benchmark.py --aggregate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import pathlib
+import sys
+from datetime import datetime
+
+TEST_DATA = os.environ.get(
+    "BENCHMARK_TEST_DATA",
+    "/tmp/canvas-review/GemmaReranker/data/test.jsonl",
+)
+OUTPUT_DIR = pathlib.Path("./checkpoints/benchmark")
+AGGREGATE_REPORT = OUTPUT_DIR / "benchmark_report.json"
+
+PAIR_TYPES = ["standard", "equivalence", "contrast", "same-course", "cross-course"]
+
+
+# ── Prompt ──────────────────────────────────────────────────────────────────
+
+
+def _fmt_item(raw) -> str:
+    if isinstance(raw, str):
+        try:
+            d = json.loads(raw.replace("'", '"'))
+        except Exception:
+            return raw[:120]
+    else:
+        d = raw
+    parts = [d.get("title", "?"), d.get("type", ""), d.get("course", "")]
+    return " | ".join(p for p in parts if p)
+
+
+def build_prompt(record: dict) -> str:
+    query = record.get("query", "")
+    a = _fmt_item(record["item_a"])
+    b = _fmt_item(record["item_b"])
+    return (
+        f"Query: {query}\n"
+        f"Item A: {a}\n"
+        f"Item B: {b}\n"
+        f"Which item requires more urgent attention? Answer with exactly one letter:"
+    )
+
+
+# ── Scoring ─────────────────────────────────────────────────────────────────
+
+
+def heuristic_predict(record: dict) -> int:
+    try:
+        ua = float(record["urgency_a"])
+        ub = float(record["urgency_b"])
+        if ua > ub:
+            return 1
+        elif ub > ua:
+            return 0
+        else:
+            return -1
+    except (KeyError, ValueError):
+        return -1
+
+
+def model_predict(model, tokenizer, prompt: str, device) -> int:
+    import torch
+
+    inputs = tokenizer(prompt, return_tensors="pt").to(device)
+    with torch.inference_mode():
+        logits = model(**inputs).logits[0, -1, :]
+
+    tok_A = tokenizer.encode("A", add_special_tokens=False)
+    tok_B = tokenizer.encode("B", add_special_tokens=False)
+    if not tok_A or not tok_B:
+        return -1
+
+    score_A = float(logits[tok_A[0]])
+    score_B = float(logits[tok_B[0]])
+
+    if score_A > score_B:
+        return 1
+    elif score_B > score_A:
+        return 0
+    else:
+        return -1
+
+
+# ── Metrics ─────────────────────────────────────────────────────────────────
+
+
+def pairwise_accuracy(predictions: list[int], labels: list[int]) -> float:
+    correct = sum(1 for p, l in zip(predictions, labels) if l != -1 and p == l)
+    total = sum(1 for l in labels if l != -1)
+    return correct / total if total > 0 else 0.0
+
+
+def kendall_tau(predictions: list[int], labels: list[int]) -> float:
+    acc = pairwise_accuracy(predictions, labels)
+    return 2 * acc - 1.0
+
+
+def ndcg_at_5(records: list[dict], predictions: list[int]) -> float:
+    from collections import defaultdict
+    groups: dict[str, list] = defaultdict(list)
+    for rec, pred in zip(records, predictions):
+        groups[rec.get("query", "default")].append((rec, pred))
+
+    ndcg_scores = []
+    for query, pairs in groups.items():
+        item_scores: dict[str, float] = {}
+        item_rel: dict[str, float] = {}
+
+        for rec, pred in pairs:
+            a_id = str(rec.get("id", "")) + "_A"
+            b_id = str(rec.get("id", "")) + "_B"
+            ua = float(rec.get("urgency_a", 0) or 0)
+            ub = float(rec.get("urgency_b", 0) or 0)
+
+            if pred == 0:
+                item_scores[a_id] = item_scores.get(a_id, 0) + 1
+                item_scores[b_id] = item_scores.get(b_id, 0)
+            elif pred == 1:
+                item_scores[b_id] = item_scores.get(b_id, 0) + 1
+                item_scores[a_id] = item_scores.get(a_id, 0)
+            else:
+                item_scores[a_id] = item_scores.get(a_id, 0) + 0.5
+                item_scores[b_id] = item_scores.get(b_id, 0) + 0.5
+
+            item_rel[a_id] = ua
+            item_rel[b_id] = ub
+
+        ranked = sorted(item_scores.keys(), key=lambda x: item_scores[x], reverse=True)
+        ideal = sorted(item_rel.keys(), key=lambda x: item_rel[x], reverse=True)
+
+        def dcg(items, k=5):
+            s = 0.0
+            for i, item in enumerate(items[:k], 1):
+                rel = item_rel.get(item, 0)
+                s += rel / math.log2(i + 1)
+            return s
+
+        idcg = dcg(ideal)
+        if idcg > 0:
+            ndcg_scores.append(dcg(ranked) / idcg)
+
+    return sum(ndcg_scores) / len(ndcg_scores) if ndcg_scores else 0.0
+
+
+def per_type_accuracy(records: list[dict], predictions: list[int]) -> dict[str, float]:
+    from collections import defaultdict
+    buckets: dict[str, list] = defaultdict(list)
+    for rec, pred in zip(records, predictions):
+        pt = rec.get("pair_type", "unknown")
+        label = int(rec.get("preference", -1))
+        buckets[pt].append((pred, label))
+
+    result = {}
+    for pt, items in buckets.items():
+        correct = sum(1 for p, l in items if l != -1 and p == l)
+        total = sum(1 for _, l in items if l != -1)
+        result[pt] = round(correct / total, 4) if total > 0 else None
+    return result
+
+
+# ── Runner ───────────────────────────────────────────────────────────────────
+
+
+def run_variant(args) -> None:
+    records = [json.loads(l) for l in open(TEST_DATA)]
+    labels = [int(r.get("preference", -1)) for r in records]
+
+    if args.variant == "heuristic":
+        predictions = [heuristic_predict(r) for r in records]
+    else:
+        import torch
+        from transformers import AutoTokenizer, Gemma4ForCausalLM
+
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+        print(f"Loading tokenizer from {args.checkpoint} ...")
+        tokenizer = AutoTokenizer.from_pretrained(args.checkpoint)
+
+        print(f"Loading model from {args.checkpoint} ...")
+        model = Gemma4ForCausalLM.from_pretrained(
+            args.checkpoint,
+            torch_dtype=torch.bfloat16,
+            attn_implementation="sdpa",
+            device_map="auto",
+        )
+        model.training = False
+
+        if args.adapter:
+            from peft import PeftModel
+            print(f"Loading PEFT adapter from {args.adapter} ...")
+            model = PeftModel.from_pretrained(model, args.adapter)
+
+        print(f"Scoring {len(records)} pairs ...")
+        predictions = []
+        for i, rec in enumerate(records):
+            prompt = build_prompt(rec)
+            pred = model_predict(model, tokenizer, prompt, device)
+            predictions.append(pred)
+            if (i + 1) % 100 == 0:
+                print(f"  {i+1}/{len(records)}")
+
+    acc = pairwise_accuracy(predictions, labels)
+    tau = kendall_tau(predictions, labels)
+    ndcg5 = ndcg_at_5(records, predictions)
+    by_type = per_type_accuracy(records, predictions)
+    n_abstain = sum(1 for p in predictions if p == -1)
+
+    result = {
+        "variant": args.variant,
+        "checkpoint": getattr(args, "checkpoint", None),
+        "adapter": getattr(args, "adapter", None),
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "n_pairs": len(records),
+        "n_abstain": n_abstain,
+        "pairwise_accuracy": round(acc, 4),
+        "kendall_tau": round(tau, 4),
+        "ndcg_at_5": round(ndcg5, 4),
+        "by_pair_type": by_type,
+    }
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    out = OUTPUT_DIR / f"{args.variant}-results.json"
+    out.write_text(json.dumps(result, indent=2))
+    print(f"\nVariant: {args.variant}")
+    print(f"  Pairwise accuracy: {acc:.4f}")
+    print(f"  Kendall's tau:     {tau:.4f}")
+    print(f"  NDCG@5:            {ndcg5:.4f}")
+    print(f"  By type: {by_type}")
+    print(f"Results: {out}")
+
+
+def run_aggregate() -> None:
+    results = []
+    for f in sorted(OUTPUT_DIR.glob("*-results.json")):
+        if "benchmark_report" not in f.name:
+            results.append(json.loads(f.read_text()))
+
+    if not results:
+        print("No variant results found. Run each variant first.", file=sys.stderr)
+        sys.exit(1)
+
+    ranked = sorted(results, key=lambda r: r["pairwise_accuracy"], reverse=True)
+    best = ranked[0]["variant"]
+
+    report = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "test_data": TEST_DATA,
+        "n_pairs": results[0]["n_pairs"] if results else 0,
+        "best_checkpoint": best,
+        "results": {r["variant"]: r for r in results},
+        "ranking": [r["variant"] for r in ranked],
+    }
+
+    AGGREGATE_REPORT.write_text(json.dumps(report, indent=2))
+    print("\n=== BENCHMARK REPORT ===")
+    print(f"{'Variant':12s}  {'Acc':6s}  {'Tau':6s}  {'NDCG@5':6s}")
+    print("-" * 40)
+    for r in ranked:
+        print(
+            f"{r['variant']:12s}  {r['pairwise_accuracy']:.4f}  "
+            f"{r['kendall_tau']:.4f}  {r['ndcg_at_5']:.4f}"
+        )
+    print(f"\nBest: {best}")
+    print(f"Report: {AGGREGATE_REPORT}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd")
+
+    run_p = sub.add_parser("run", help="Score one variant")
+    run_p.add_argument("--variant", required=True,
+                       choices=["heuristic", "sft", "lora", "qlora", "dpo"])
+    run_p.add_argument("--checkpoint", default=None,
+                       help="Model checkpoint path (not needed for heuristic)")
+    run_p.add_argument("--adapter", default=None,
+                       help="PEFT adapter path (for lora/qlora)")
+
+    sub.add_parser("aggregate", help="Aggregate all variant results into final report")
+
+    # Support flat invocation: python run_benchmark.py --variant X
+    parser.add_argument("--variant", default=None)
+    parser.add_argument("--checkpoint", default=None)
+    parser.add_argument("--adapter", default=None)
+    parser.add_argument("--aggregate", action="store_true")
+
+    args = parser.parse_args()
+
+    if args.aggregate or (hasattr(args, "cmd") and args.cmd == "aggregate"):
+        run_aggregate()
+    elif args.variant or (hasattr(args, "cmd") and args.cmd == "run"):
+        if not args.variant:
+            parser.error("--variant required")
+        if args.variant != "heuristic" and not args.checkpoint:
+            parser.error("--checkpoint required for model variants")
+        run_variant(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/smoke_test_gguf.py
+++ b/GemmaReranker/scripts/smoke_test_gguf.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""
+smoke_test_gguf.py — EXPORT-02: 20-query pairwise smoke test for the Q5_K_M GGUF.
+
+Loads 20 pairs from the test set, runs the GGUF model via llama-cpp-python,
+parses the "Item A" / "Item B" response, and checks against ground-truth preference.
+
+Success criterion: all 20 queries return a parseable response (A or B).
+Accuracy is reported but not gated (the benchmark is the authoritative eval).
+
+Usage:
+  python source/smoke_test_gguf.py --gguf checkpoints/gguf/gemma4-reranker-Q5_K_M.gguf
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+TEST_DATA = os.environ.get(
+    "BENCHMARK_TEST_DATA",
+    "/tmp/canvas-review/GemmaReranker/data/test.jsonl",
+)
+N_SAMPLES = 20
+
+RANK_PROMPT_TEMPLATE = (
+    "Which Canvas item is more urgent and why?\n\n"
+    "[Query]: {query}\n"
+    "Item A: {item_a}\n"
+    "Item B: {item_b}"
+)
+
+
+def _fmt_item(raw) -> str:
+    if isinstance(raw, str):
+        try:
+            d = json.loads(raw.replace("'", '"'))
+        except Exception:
+            return raw[:120]
+    else:
+        d = raw
+    parts = [d.get("title", "?"), d.get("type", ""), d.get("course", "")]
+    return " | ".join(p for p in parts if p)
+
+
+def run_smoke_test(gguf_path: str) -> None:
+    from llama_cpp import Llama
+
+    print(f"Loading GGUF: {gguf_path}")
+    llm = Llama(
+        model_path=gguf_path,
+        n_ctx=512,
+        n_gpu_layers=-1,
+        verbose=False,
+    )
+    print(f"Model loaded. Running {N_SAMPLES} pairwise queries...")
+
+    records = [json.loads(l) for l in open(TEST_DATA)]
+    samples = records[:N_SAMPLES]
+
+    correct = 0
+    parseable = 0
+    for i, rec in enumerate(samples):
+        query = rec.get("query", "")
+        item_a = _fmt_item(rec["item_a"])
+        item_b = _fmt_item(rec["item_b"])
+        label = int(rec.get("preference", -1))
+
+        prompt = RANK_PROMPT_TEMPLATE.format(query=query, item_a=item_a, item_b=item_b)
+        out = llm.create_completion(prompt, max_tokens=10, temperature=0.0)
+        text = out["choices"][0]["text"].strip()
+
+        if "A" in text[:8] or text.startswith("Item A"):
+            pred = 1
+        elif "B" in text[:8] or text.startswith("Item B"):
+            pred = 0
+        else:
+            pred = -1
+
+        is_parseable = pred != -1
+        is_correct = label != -1 and pred == label
+        if is_parseable:
+            parseable += 1
+        if is_correct:
+            correct += 1
+
+        marker = "✓" if is_correct else ("?" if not is_parseable else "✗")
+        print(f"  [{marker}] pair {i+1:2d}: pred={pred} label={label}  response={text[:40]!r}")
+
+    print(f"\nResults: {parseable}/{N_SAMPLES} parseable, {correct}/{N_SAMPLES} correct")
+
+    if parseable < N_SAMPLES:
+        print(f"FAIL: {N_SAMPLES - parseable} queries produced unparseable output")
+        sys.exit(1)
+    print("PASS: all 20 queries produced parseable A/B responses (EXPORT-02)")
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--gguf", default="checkpoints/gguf/gemma4-reranker-Q5_K_M.gguf")
+    args = p.parse_args()
+    if not Path(args.gguf).exists():
+        print(f"ERROR: GGUF not found: {args.gguf}", file=sys.stderr)
+        print("Run: python source/export_gguf.py", file=sys.stderr)
+        sys.exit(1)
+    run_smoke_test(args.gguf)
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/split_dpo_holdout.py
+++ b/GemmaReranker/scripts/split_dpo_holdout.py
@@ -1,0 +1,130 @@
+"""
+split_dpo_holdout.py — reconstruct an item-ID-level held-out split from
+data/dpo_train.jsonl, since the original 827-pair test partition was lost
+in the 2026-05-01 workspace wipe.
+
+Item identity is reconstructed from the prompt: every prompt embeds two
+"[TYPE] Title @COURSE STATUS Npts" item descriptors. The (TYPE, Title,
+COURSE) triple is treated as a stable item identifier; STATUS and points
+shift over time and across pairs but TYPE+Title+COURSE pin the underlying
+Canvas item.
+
+Split rule (strict item-disjoint, seed 42):
+  - Collect all unique items
+  - Shuffle items deterministically (seed 42)
+  - First test_frac of items → test_items
+  - Pairs where BOTH items ∈ test_items → test partition
+  - Pairs where BOTH items ∈ train_items → train partition
+  - Pairs that span the boundary (one item in each set) → DISCARDED to
+    eliminate item-leak risk
+
+This is stricter than the original collect_rerank_dataset.py cmd_split
+(which routed span pairs to train). The original was acceptable for v1
+because a held-out test pair containing a single train-item was still
+better than nothing; the v3 retrain explicitly aims for zero item overlap
+at the test-pair level so the held-out validation cannot be contaminated
+by item-memorization.
+
+Tradeoff: smaller test partition than the test_frac suggests, but a clean
+held-out signal.
+"""
+from __future__ import annotations
+
+import json
+import random
+import re
+from pathlib import Path
+
+DATA_PATH = Path("data/dpo_train.jsonl")
+TRAIN_OUT = Path("data/dpo_train_v3.jsonl")
+TEST_OUT = Path("data/dpo_test_v3.jsonl")
+SEED = 42
+# Bumped from 0.20 → 0.30: at 0.20 the strict-disjoint test partition has
+# only 111 pairs and zero hard-negatives. At 0.30 we get 148 test pairs,
+# still zero hard-neg (hard-negs concentrate among similar-item-pairs that
+# don't co-partition under random item-level splits) but train retains 477
+# hard-neg records — DPO can still learn the hard-neg signal at training,
+# just not be tested on hard-neg pairs at validation. Documented as a known
+# limitation in §6.5 of the paper.
+TEST_FRAC = 0.30
+
+ITEM_LINE = re.compile(
+    r"^Item [AB]:\s*(\[[^\]]+\])\s*(.+?)\s*(@COURSE\w+)\s",
+    re.MULTILINE,
+)
+
+
+def parse_items(prompt: str) -> tuple[tuple[str, str, str], tuple[str, str, str]]:
+    matches = ITEM_LINE.findall(prompt)
+    if len(matches) != 2:
+        raise ValueError(f"Expected 2 item lines, got {len(matches)} in prompt:\n{prompt[:200]}")
+    a, b = matches
+    return tuple(a), tuple(b)
+
+
+def main():
+    assert DATA_PATH.exists(), f"missing {DATA_PATH}"
+    records = [json.loads(l) for l in DATA_PATH.read_text().splitlines() if l.strip()]
+    print(f"[load] {len(records)} records from {DATA_PATH}")
+
+    parsed = []
+    item_to_id = {}
+    for i, rec in enumerate(records):
+        a_key, b_key = parse_items(rec["prompt"])
+        for k in (a_key, b_key):
+            if k not in item_to_id:
+                item_to_id[k] = len(item_to_id)
+        parsed.append((item_to_id[a_key], item_to_id[b_key], rec))
+
+    n_items = len(item_to_id)
+    print(f"[items] {n_items} unique items detected")
+
+    rng = random.Random(SEED)
+    item_ids = list(range(n_items))
+    rng.shuffle(item_ids)
+    n_test = max(1, int(n_items * TEST_FRAC))
+    test_items = set(item_ids[:n_test])
+    train_items = set(item_ids[n_test:])
+    print(f"[split] test_items={len(test_items)} train_items={len(train_items)} (seed={SEED}, test_frac={TEST_FRAC})")
+
+    train_pairs, test_pairs, span_count = [], [], 0
+    for ia, ib, rec in parsed:
+        both_train = ia in train_items and ib in train_items
+        both_test = ia in test_items and ib in test_items
+        if both_train:
+            train_pairs.append((ia, ib, rec))
+        elif both_test:
+            test_pairs.append((ia, ib, rec))
+        else:
+            span_count += 1
+
+    rng.shuffle(train_pairs)
+    rng.shuffle(test_pairs)
+
+    train_item_set = set()
+    for ia, ib, _ in train_pairs:
+        train_item_set.add(ia); train_item_set.add(ib)
+    test_item_set = set()
+    for ia, ib, _ in test_pairs:
+        test_item_set.add(ia); test_item_set.add(ib)
+    leak = train_item_set & test_item_set
+
+    print(f"[split] train_pairs={len(train_pairs)} test_pairs={len(test_pairs)} discarded_span_pairs={span_count}")
+    print(f"[leak] {len(leak)} items appear in both partitions (target: 0)")
+    assert not leak, f"item leak between partitions: {leak}"
+
+    train_pairs = [r for _, _, r in train_pairs]
+    test_pairs = [r for _, _, r in test_pairs]
+
+    pt_counts = lambda pairs, k: sum(1 for r in pairs if r.get("pair_type") == k)
+    print(f"[train] hard_negative={pt_counts(train_pairs,'hard_negative')} standard={pt_counts(train_pairs,'standard')}")
+    print(f"[test ] hard_negative={pt_counts(test_pairs,'hard_negative')} standard={pt_counts(test_pairs,'standard')}")
+
+    TRAIN_OUT.write_text("\n".join(json.dumps(r) for r in train_pairs) + "\n")
+    TEST_OUT.write_text("\n".join(json.dumps(r) for r in test_pairs) + "\n")
+    print(f"[wrote] {TRAIN_OUT} ({TRAIN_OUT.stat().st_size//1024} KB)")
+    print(f"[wrote] {TEST_OUT}  ({TEST_OUT.stat().st_size//1024} KB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/train_dpo.py
+++ b/GemmaReranker/scripts/train_dpo.py
@@ -1,0 +1,177 @@
+"""
+DPO Training Script — Direct Preference Optimization for Canvas Item Reranker
+
+Implements the DPO objective from Rafailov et al. 2023, Equation 7:
+  L_DPO(π_θ; π_ref) = -E[(x,y_w,y_l)~D] [log σ(
+      β log(π_θ(y_w|x)/π_ref(y_w|x)) − β log(π_θ(y_l|x)/π_ref(y_l|x))
+  )]
+where β=0.1, π_ref = SFT checkpoint (Phase 02), per D-01.
+Loss type: sigmoid (TRL DPOConfig default, verified at dpo_trainer.py:1244).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    pass
+
+SFT_CHECKPOINT_PATH = os.environ.get(
+    "DPO_SFT_CHECKPOINT",
+    "/tmp/canvas-review/GemmaReranker/outputs/sft-checkpoint",
+)
+DPO_OUTPUT_DIR = "./checkpoints/dpo-checkpoint"
+DATA_PATH = "./data/dpo_train.jsonl"
+
+
+def _bnb_cuda_functional() -> bool:
+    # bnb 0.49.2 on CUDA 13.1 (NVIDIA 26.02): no prebuilt binary.
+    # Installs ErrorHandlerMockBNBNativeLibrary — lib is not None but unusable.
+    try:
+        import bitsandbytes.cextension as _ext
+        return _ext.lib is not None and "Error" not in type(_ext.lib).__name__
+    except Exception:
+        return False
+
+
+def build_tokenizer(sft_path: str):
+    from transformers import AutoTokenizer
+
+    tokenizer = AutoTokenizer.from_pretrained(sft_path)
+    tokenizer.padding_side = "left"
+    return tokenizer
+
+
+def build_dpo_config(output_dir: str, optim: str = "paged_adamw_8bit"):
+    from trl import DPOConfig
+
+    return DPOConfig(
+        output_dir=output_dir,
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=8,
+        learning_rate=5e-7,
+        beta=0.1,
+        loss_type="sigmoid",
+        bf16=True,
+        max_length=512,
+        gradient_checkpointing=True,
+        optim=optim,
+        precompute_ref_log_probs=True,
+        logging_steps=10,
+        save_strategy="epoch",
+        report_to="none",
+        sync_ref_model=False,
+    )
+
+
+def build_models(sft_path: str):
+    import torch
+    from transformers import Gemma4ForCausalLM
+
+    policy_model = Gemma4ForCausalLM.from_pretrained(
+        sft_path,
+        torch_dtype=torch.bfloat16,
+        attn_implementation="sdpa",
+    )
+    ref_model = Gemma4ForCausalLM.from_pretrained(
+        sft_path,
+        torch_dtype=torch.bfloat16,
+        attn_implementation="sdpa",
+    )
+    return policy_model, ref_model
+
+
+def main():
+    import sys as _sys
+    _sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+    import torch
+    from datasets import load_dataset
+    from trl import DPOTrainer
+    from training_logger import TrainingLogger, TRLCallbackAdapter
+
+    from callbacks import RewardCollapseCallback
+    from data_utils import oversample_hard_negatives
+
+    sft_path = os.environ.get("DPO_SFT_CHECKPOINT", SFT_CHECKPOINT_PATH)
+
+    force_torch = os.environ.get("DPO_FORCE_ADAMW_TORCH", "0") == "1"
+    bnb_ok = (not force_torch) and _bnb_cuda_functional()
+    optim = "paged_adamw_8bit" if bnb_ok else "adamw_torch"
+    if not bnb_ok:
+        reason = "DPO_FORCE_ADAMW_TORCH=1" if force_torch else "bitsandbytes CUDA unavailable"
+        print(f"WARNING: {reason}; using adamw_torch optimizer (DPO-ADAMW-FALLBACK)", flush=True)
+
+    dpo_config = build_dpo_config(DPO_OUTPUT_DIR, optim=optim)
+
+    run_config = {
+        "model": sft_path,
+        "method": "dpo",
+        "beta": 0.1,
+        "lr": 5e-7,
+        "epochs": 1,
+        "batch_size": 2,
+        "grad_accum": 8,
+        "max_seq_len": 512,
+        "loss_type": "sigmoid",
+        "optim": optim,
+        "optim_fallback": not bnb_ok,
+        "precompute_ref_log_probs": True,
+        "bf16": True,
+    }
+
+    Path(DPO_OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+
+    with TrainingLogger(
+        run_name="dpo-run",
+        output_dir=DPO_OUTPUT_DIR,
+        method="dpo",
+        config=run_config,
+        verbose=True,
+        capture_env=True,
+        jsonl_events=True,
+        color=True,
+    ) as log:
+        log.section("SETUP")
+
+        tokenizer = build_tokenizer(sft_path)
+        log.log_tokenizer_load(tokenizer)
+        log.assert_invariant(
+            tokenizer.padding_side == "left",
+            "tokenizer.padding_side must be left for DPO training (D-06)",
+        )
+
+        policy_model, ref_model = build_models(sft_path)
+        policy_model.config.use_cache = False
+        log.log_model_load(sft_path, policy_model, torch.bfloat16, "auto")
+        log.log_model_load(sft_path, ref_model, torch.bfloat16, "auto")
+
+        raw_dataset = load_dataset("json", data_files=DATA_PATH, split="train")
+        dataset = oversample_hard_negatives(raw_dataset, multiplier=3)
+        log.log_dataset_load(dataset, "train (oversampled)")
+        log.log_training_args(dpo_config)
+
+        trainer = DPOTrainer(
+            model=policy_model,
+            ref_model=ref_model,
+            args=dpo_config,
+            train_dataset=dataset,
+            processing_class=tokenizer,
+            callbacks=[RewardCollapseCallback(), TRLCallbackAdapter(log)],
+        )
+
+        log.section("TRAINING")
+        trainer.train()
+
+        log.section("SAVE")
+        trainer.save_model(DPO_OUTPUT_DIR)
+        tokenizer.save_pretrained(DPO_OUTPUT_DIR)
+        log.register_checkpoint(DPO_OUTPUT_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/train_dpo_v3.py
+++ b/GemmaReranker/scripts/train_dpo_v3.py
@@ -1,0 +1,133 @@
+"""
+train_dpo_v3.py — DPO retrain with item-disjoint held-out split.
+
+Differences from train_dpo.py (v2):
+  - Reads data/dpo_train_v3.jsonl (998 records, item-disjoint from
+    data/dpo_test_v3.jsonl per source/split_dpo_holdout.py).
+  - Initializes from checkpoints/gguf/merged_bf16 (the surviving v2
+    QLoRA-merged BF16 base; the standalone v2 SFT was lost).
+  - Outputs to checkpoints/dpo-v3-checkpoint (does not overwrite v2).
+  - Drops the second-pass oversample_hard_negatives call. The v3 input file
+    is already pre-oversampled at data prep (hard×3); applying multiplier=3
+    again at training time would yield the 9× effective rate documented in
+    AUDIT-V4-RIGOR.md §1.6 as a v2 methodology bug. v3 fixes this — hard
+    negatives appear at 3× as the paper §3.2 claims.
+  - Otherwise identical hyperparams to v2: β=0.1, η=5e-7, 1 epoch,
+    effective batch size 16 (per_device=2 × grad_accum=8), max_length=512,
+    bf16, sigmoid loss.
+  - Uses adamw_torch optimizer (matches v2 fallback under bnb-on-cuda-13.1).
+
+Goal: produce a DPO checkpoint trainable to evaluate on items it has
+never seen, so the validation report substantiates a true held-out claim
+rather than a training-set fit measurement.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+DATA_PATH = "./data/dpo_train_v3.jsonl"
+SFT_CHECKPOINT_PATH = "./checkpoints/gguf/merged_bf16"
+DPO_OUTPUT_DIR = "./checkpoints/dpo-v3-checkpoint"
+
+
+def main():
+    sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+    import torch
+    from datasets import load_dataset
+    from transformers import AutoTokenizer, Gemma4ForCausalLM
+    from trl import DPOConfig, DPOTrainer
+
+    print(f"[env] torch={torch.__version__} cuda={torch.cuda.is_available()}", flush=True)
+    print(f"[data] {DATA_PATH}", flush=True)
+    print(f"[base] {SFT_CHECKPOINT_PATH}", flush=True)
+    print(f"[out ] {DPO_OUTPUT_DIR}", flush=True)
+
+    Path(DPO_OUTPUT_DIR).mkdir(parents=True, exist_ok=True)
+
+    tokenizer = AutoTokenizer.from_pretrained(SFT_CHECKPOINT_PATH)
+    tokenizer.padding_side = "left"
+    print(f"[tok ] padding_side={tokenizer.padding_side}", flush=True)
+
+    policy = Gemma4ForCausalLM.from_pretrained(
+        SFT_CHECKPOINT_PATH, torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    policy.config.use_cache = False
+    ref = Gemma4ForCausalLM.from_pretrained(
+        SFT_CHECKPOINT_PATH, torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    print("[load] policy + ref loaded", flush=True)
+
+    raw = load_dataset("json", data_files=DATA_PATH, split="train")
+    print(f"[ds  ] n_examples={len(raw)} columns={raw.column_names}", flush=True)
+
+    cfg = DPOConfig(
+        output_dir=DPO_OUTPUT_DIR,
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=8,
+        learning_rate=5e-7,
+        beta=0.1,
+        loss_type="sigmoid",
+        bf16=True,
+        max_length=512,
+        gradient_checkpointing=True,
+        optim="adamw_torch",
+        precompute_ref_log_probs=True,
+        logging_steps=10,
+        save_strategy="epoch",
+        report_to="none",
+        sync_ref_model=False,
+        seed=42,
+    )
+
+    trainer = DPOTrainer(
+        model=policy,
+        ref_model=ref,
+        args=cfg,
+        train_dataset=raw,
+        processing_class=tokenizer,
+    )
+
+    print("[run ] training start", flush=True)
+    train_result = trainer.train()
+
+    trainer.save_model(DPO_OUTPUT_DIR)
+    tokenizer.save_pretrained(DPO_OUTPUT_DIR)
+    print(f"[done] checkpoint saved → {DPO_OUTPUT_DIR}", flush=True)
+
+    metrics = train_result.metrics if hasattr(train_result, "metrics") else {}
+    log_history = trainer.state.log_history if hasattr(trainer.state, "log_history") else []
+    final_log = log_history[-1] if log_history else {}
+
+    summary = {
+        "checkpoint": DPO_OUTPUT_DIR,
+        "data_path": DATA_PATH,
+        "base_model": SFT_CHECKPOINT_PATH,
+        "n_train_examples": len(raw),
+        "trl_version": __import__("trl").__version__,
+        "transformers_version": __import__("transformers").__version__,
+        "hyperparams": {
+            "beta": 0.1,
+            "lr": 5e-7,
+            "epochs": 1,
+            "per_device_batch_size": 2,
+            "grad_accum_steps": 8,
+            "effective_batch_size": 16,
+            "max_length": 512,
+            "loss_type": "sigmoid",
+            "optim": "adamw_torch",
+            "seed": 42,
+        },
+        "train_metrics": metrics,
+        "final_log_event": final_log,
+    }
+    import json
+    Path(DPO_OUTPUT_DIR, "v3_run_summary.json").write_text(json.dumps(summary, indent=2, default=str))
+    print("[done] v3_run_summary.json written", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/train_v4_matrix.py
+++ b/GemmaReranker/scripts/train_v4_matrix.py
@@ -1,0 +1,289 @@
+"""
+train_v4_matrix.py — train all 6 method variants from gemma4-text-base
+on the v3 train partition (998 records, item-disjoint from v3 test).
+
+Methods (TRL 1.1.0 — what the env supports today):
+  - sft        : SFTTrainer, full-parameter, 1 epoch, lr 2e-5
+  - lora       : SFTTrainer + LoraConfig (r=16, q/k/v/o), 1 epoch, lr 2e-4
+  - qlora      : SFTTrainer + 4-bit base + LoraConfig, 1 epoch, lr 2e-4
+  - dpo        : DPOTrainer, loss_type="sigmoid" (canonical DPO), β=0.1
+  - ipo        : DPOTrainer, loss_type="ipo" (Identity PO, Azar 2023)
+  - kto        : KTOTrainer (Kahneman-Tversky, Ethayarajh 2024)
+
+Each method writes to checkpoints/v4-{method}/.
+
+Usage:
+    python3 source/train_v4_matrix.py sft
+    python3 source/train_v4_matrix.py all   # sequentially train all 6
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+BASE = "checkpoints/gemma4-text-base"
+DPO_DATA = "data/dpo_train_v3.jsonl"           # 998 records, prompt/chosen/rejected
+SFT_DATA = "data/sft_train_v3.jsonl"           # derived: prompt/completion only
+KTO_DATA = "data/kto_train_v3.jsonl"           # derived: KTO format
+OUT_ROOT = Path("checkpoints")
+SEED = 42
+
+
+def derive_sft_data():
+    """Reduce dpo_train_v3 → (prompt, completion=chosen) for SFT/LoRA/QLoRA."""
+    if Path(SFT_DATA).exists():
+        print(f"  [skip] {SFT_DATA} already exists")
+        return
+    out = []
+    for line in open(DPO_DATA):
+        r = json.loads(line)
+        out.append({"prompt": r["prompt"], "completion": r["chosen"]})
+    Path(SFT_DATA).write_text("\n".join(json.dumps(r) for r in out) + "\n")
+    print(f"  [wrote] {SFT_DATA} ({len(out)} records)")
+
+
+def derive_kto_data():
+    """KTO format: {prompt, completion, label} where label=True for chosen,
+    False for rejected. Each DPO record produces TWO KTO records."""
+    if Path(KTO_DATA).exists():
+        print(f"  [skip] {KTO_DATA} already exists")
+        return
+    out = []
+    for line in open(DPO_DATA):
+        r = json.loads(line)
+        out.append({"prompt": r["prompt"], "completion": r["chosen"], "label": True})
+        out.append({"prompt": r["prompt"], "completion": r["rejected"], "label": False})
+    Path(KTO_DATA).write_text("\n".join(json.dumps(r) for r in out) + "\n")
+    print(f"  [wrote] {KTO_DATA} ({len(out)} records)")
+
+
+def train_sft(out_dir: Path):
+    import torch
+    from datasets import load_dataset
+    from transformers import AutoTokenizer, Gemma4ForCausalLM
+    from trl import SFTConfig, SFTTrainer
+
+    print(f"[sft] loading base from {BASE}")
+    tok = AutoTokenizer.from_pretrained(BASE)
+    tok.padding_side = "right"
+    model = Gemma4ForCausalLM.from_pretrained(
+        BASE, torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    model.config.use_cache = False
+    raw = load_dataset("json", data_files=SFT_DATA, split="train")
+    cfg = SFTConfig(
+        output_dir=str(out_dir),
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=8,
+        learning_rate=2e-5,
+        bf16=True,
+        max_length=512,
+        gradient_checkpointing=True,
+        optim="adamw_torch",
+        logging_steps=10,
+        save_strategy="epoch",
+        report_to="none",
+        seed=SEED,
+    )
+    SFTTrainer(model=model, args=cfg, train_dataset=raw, processing_class=tok).train()
+    model.save_pretrained(str(out_dir))
+    tok.save_pretrained(str(out_dir))
+
+
+def train_lora(out_dir: Path, four_bit: bool):
+    import torch
+    from datasets import load_dataset
+    from peft import LoraConfig
+    from transformers import AutoTokenizer, BitsAndBytesConfig, Gemma4ForCausalLM
+    from trl import SFTConfig, SFTTrainer
+
+    print(f"[{'qlora' if four_bit else 'lora'}] loading base from {BASE} (4-bit={four_bit})")
+    tok = AutoTokenizer.from_pretrained(BASE)
+    tok.padding_side = "right"
+    quant = None
+    if four_bit:
+        try:
+            quant = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_quant_type="nf4",
+                bnb_4bit_compute_dtype=torch.bfloat16,
+                bnb_4bit_use_double_quant=True,
+            )
+        except Exception as e:
+            print(f"  WARN: bnb 4-bit unavailable ({e}); falling back to bf16 (QLORA-BF16-FALLBACK)")
+            quant = None
+    model = Gemma4ForCausalLM.from_pretrained(
+        BASE,
+        torch_dtype=torch.bfloat16,
+        attn_implementation="sdpa",
+        quantization_config=quant,
+    )
+    model.config.use_cache = False
+    raw = load_dataset("json", data_files=SFT_DATA, split="train")
+    peft_config = LoraConfig(
+        r=16, lora_alpha=32, lora_dropout=0.05,
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj"],
+        bias="none", task_type="CAUSAL_LM",
+    )
+    cfg = SFTConfig(
+        output_dir=str(out_dir),
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=8,
+        learning_rate=2e-4,
+        bf16=True,
+        max_length=512,
+        gradient_checkpointing=True,
+        optim="adamw_torch",
+        logging_steps=10,
+        save_strategy="epoch",
+        report_to="none",
+        seed=SEED,
+    )
+    SFTTrainer(
+        model=model, args=cfg, train_dataset=raw,
+        processing_class=tok, peft_config=peft_config,
+    ).train()
+    # Save adapter only
+    out_dir.mkdir(parents=True, exist_ok=True)
+    Path(out_dir).mkdir(parents=True, exist_ok=True)
+    # save_pretrained on a PEFT-wrapped model writes the adapter
+    model.save_pretrained(str(out_dir))
+    tok.save_pretrained(str(out_dir))
+
+
+def train_dpo(out_dir: Path, loss_type: str):
+    import torch
+    from datasets import load_dataset
+    from transformers import AutoTokenizer, Gemma4ForCausalLM
+    from trl import DPOConfig, DPOTrainer
+
+    print(f"[dpo:{loss_type}] loading base from {BASE}")
+    tok = AutoTokenizer.from_pretrained(BASE)
+    tok.padding_side = "left"
+    policy = Gemma4ForCausalLM.from_pretrained(
+        BASE, torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    policy.config.use_cache = False
+    ref = Gemma4ForCausalLM.from_pretrained(
+        BASE, torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    raw = load_dataset("json", data_files=DPO_DATA, split="train")
+    cfg = DPOConfig(
+        output_dir=str(out_dir),
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=8,
+        learning_rate=5e-7,
+        beta=0.1,
+        loss_type=loss_type,
+        bf16=True,
+        max_length=512,
+        gradient_checkpointing=True,
+        optim="adamw_torch",
+        precompute_ref_log_probs=True,
+        logging_steps=10,
+        save_strategy="epoch",
+        report_to="none",
+        sync_ref_model=False,
+        seed=SEED,
+    )
+    DPOTrainer(
+        model=policy, ref_model=ref, args=cfg,
+        train_dataset=raw, processing_class=tok,
+    ).train()
+    policy.save_pretrained(str(out_dir))
+    tok.save_pretrained(str(out_dir))
+
+
+def train_kto(out_dir: Path):
+    import torch
+    from datasets import load_dataset
+    from transformers import AutoTokenizer, Gemma4ForCausalLM
+    from trl import KTOConfig, KTOTrainer
+
+    print(f"[kto] loading base from {BASE}")
+    tok = AutoTokenizer.from_pretrained(BASE)
+    tok.padding_side = "left"
+    policy = Gemma4ForCausalLM.from_pretrained(
+        BASE, torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    policy.config.use_cache = False
+    ref = Gemma4ForCausalLM.from_pretrained(
+        BASE, torch_dtype=torch.bfloat16, attn_implementation="sdpa",
+    )
+    raw = load_dataset("json", data_files=KTO_DATA, split="train")
+    cfg = KTOConfig(
+        output_dir=str(out_dir),
+        num_train_epochs=1,
+        per_device_train_batch_size=2,
+        gradient_accumulation_steps=8,
+        learning_rate=5e-7,
+        beta=0.1,
+        bf16=True,
+        max_length=512,
+        gradient_checkpointing=True,
+        optim="adamw_torch",
+        logging_steps=10,
+        save_strategy="epoch",
+        report_to="none",
+        seed=SEED,
+    )
+    KTOTrainer(
+        model=policy, ref_model=ref, args=cfg,
+        train_dataset=raw, processing_class=tok,
+    ).train()
+    policy.save_pretrained(str(out_dir))
+    tok.save_pretrained(str(out_dir))
+
+
+METHODS = {
+    # baselines
+    "sft":      ("v4-sft",      lambda d: train_sft(d)),
+    "lora":     ("v4-lora",     lambda d: train_lora(d, four_bit=False)),
+    "qlora":    ("v4-qlora",    lambda d: train_lora(d, four_bit=True)),
+    # DPO + modern preference variants (all via TRL DPOTrainer loss_type)
+    "dpo":      ("v4-dpo",      lambda d: train_dpo(d, loss_type="sigmoid")),     # Rafailov 2023 canonical
+    "ipo":      ("v4-ipo",      lambda d: train_dpo(d, loss_type="ipo")),         # Azar 2023, fixes overoptimization
+    "apo_zero": ("v4-apo-zero", lambda d: train_dpo(d, loss_type="apo_zero")),    # Pan 2024, anchored PO
+    "sppo":     ("v4-sppo",     lambda d: train_dpo(d, loss_type="sppo_hard")),   # Wu 2024, self-play PO
+    "nca":      ("v4-nca",      lambda d: train_dpo(d, loss_type="nca_pair")),    # Chen 2024, noise-contrastive alignment
+    # KTO uses its own trainer (handles unpaired prompt+completion+label)
+    "kto":      ("v4-kto",      lambda d: train_kto(d)),                          # Ethayarajh 2024
+}
+
+
+def main():
+    method = sys.argv[1] if len(sys.argv) > 1 else "all"
+    derive_sft_data()
+    derive_kto_data()
+
+    methods_to_run = list(METHODS) if method == "all" else [method]
+    for m in methods_to_run:
+        if m not in METHODS:
+            print(f"unknown method: {m}; choices: {list(METHODS)}")
+            sys.exit(1)
+        out_subdir, fn = METHODS[m]
+        out = OUT_ROOT / out_subdir
+        if out.exists() and any(out.iterdir()):
+            print(f"\n[{m}] {out} already populated; skipping (delete to re-run)")
+            continue
+        print(f"\n{'='*70}\n[{m}] starting → {out}\n{'='*70}")
+        t0 = time.time()
+        try:
+            fn(out)
+            dt = time.time() - t0
+            print(f"[{m}] done in {dt/60:.1f} min")
+        except Exception as e:
+            dt = time.time() - t0
+            print(f"[{m}] FAILED after {dt/60:.1f} min: {type(e).__name__}: {e}")
+            import traceback
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/validate_dpo.py
+++ b/GemmaReranker/scripts/validate_dpo.py
@@ -1,0 +1,177 @@
+"""
+DPO Post-Training Validation (Plan 04-03)
+
+Measures whether the DPO policy moved toward chosen responses relative to the SFT
+baseline. Computes log-prob deltas for 10 sampled pairs and writes validation_report.json.
+
+Pass criterion: dpo_delta > sft_delta on >= 7 of 10 pairs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import sys
+from datetime import datetime
+
+DPO_CHECKPOINT = os.environ.get("DPO_CHECKPOINT", "./checkpoints/dpo-checkpoint")
+SFT_CHECKPOINT = os.environ.get("DPO_SFT_CHECKPOINT", "./checkpoints/sft-checkpoint")
+DATA_PATH = os.environ.get("VALIDATE_DATA", "./data/dpo_train.jsonl")
+REPORT_PATH = pathlib.Path(DPO_CHECKPOINT) / "validation_report.json"
+PASS_THRESHOLD = 7
+
+
+def load_validation_pairs(data_path: str, n: int = 10) -> list[dict]:
+    records = [json.loads(l) for l in open(data_path)]
+    hard = [r for r in records if r.get("pair_type") == "hard_negative"][:5]
+    standard = [r for r in records if r.get("pair_type") != "hard_negative"][:5]
+    pairs = (hard + standard)[:n]
+    if len(pairs) < n:
+        pairs = records[:n]
+    return pairs
+
+
+def sequence_log_prob(model, tokenizer, prompt: str, completion: str) -> float:
+    import torch
+    full = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt},
+         {"role": "assistant", "content": completion}],
+        tokenize=False,
+        add_generation_prompt=False,
+    )
+    enc = tokenizer(full, return_tensors="pt").to(model.device)
+    with torch.inference_mode():
+        out = model(**enc, labels=enc["input_ids"])
+    return -out.loss.item() * enc["input_ids"].shape[1]
+
+
+def main():
+    import torch
+    from transformers import AutoConfig, AutoModelForCausalLM, AutoTokenizer, Gemma4ForCausalLM
+
+    print("=" * 64)
+    print("DPO VALIDATION — Plan 04-03")
+    print("=" * 64)
+
+    # D-12 config check — gemma4_text is the actual model type for the text tower
+    cfg = AutoConfig.from_pretrained(DPO_CHECKPOINT)
+    assert cfg.model_type in ("gemma4", "gemma4_text"), \
+        f"Expected gemma4/gemma4_text, got {cfg.model_type}"
+    print(f"[PASS] DPO config OK: model_type={cfg.model_type}")
+
+    # D-12 meta-device probe (no weights allocated)
+    _ = AutoModelForCausalLM.from_pretrained(DPO_CHECKPOINT, device_map="meta")
+    print("[D-12 PASS] AutoModelForCausalLM meta-device load OK")
+    del _
+
+    print(f"\nLoading DPO model from {DPO_CHECKPOINT} ...")
+    dpo_model = Gemma4ForCausalLM.from_pretrained(
+        DPO_CHECKPOINT,
+        torch_dtype=torch.bfloat16,
+        attn_implementation="sdpa",
+        device_map="auto",
+    )
+    dpo_model.training = False
+
+    print(f"Loading SFT model from {SFT_CHECKPOINT} ...")
+    sft_model = Gemma4ForCausalLM.from_pretrained(
+        SFT_CHECKPOINT,
+        torch_dtype=torch.bfloat16,
+        attn_implementation="sdpa",
+        device_map="auto",
+    )
+    sft_model.training = False
+
+    tokenizer = AutoTokenizer.from_pretrained(DPO_CHECKPOINT)
+
+    pairs = load_validation_pairs(DATA_PATH)
+    print(f"\nEvaluating {len(pairs)} pairs from {DATA_PATH}\n")
+
+    pair_results = []
+    n_improved = 0
+    n_evaluated = 0
+
+    for i, pair in enumerate(pairs):
+        prompt = pair["prompt"]
+        chosen = pair["chosen"]
+        rejected = pair["rejected"]
+        pair_type = pair.get("pair_type", "unknown")
+
+        try:
+            sft_chosen = sequence_log_prob(sft_model, tokenizer, prompt, chosen)
+            sft_rejected = sequence_log_prob(sft_model, tokenizer, prompt, rejected)
+            dpo_chosen = sequence_log_prob(dpo_model, tokenizer, prompt, chosen)
+            dpo_rejected = sequence_log_prob(dpo_model, tokenizer, prompt, rejected)
+
+            sft_delta = sft_chosen - sft_rejected
+            dpo_delta = dpo_chosen - dpo_rejected
+            improvement = dpo_delta - sft_delta
+            improved = improvement > 0
+
+            if improved:
+                n_improved += 1
+            n_evaluated += 1
+
+            tag = "[BETTER]" if improved else "[WORSE]"
+            print(
+                f"Pair {i+1:2d} ({pair_type:12s}): "
+                f"SFT delta={sft_delta:+.3f}  "
+                f"DPO delta={dpo_delta:+.3f}  "
+                f"improvement={improvement:+.3f}  {tag}"
+            )
+
+            pair_results.append({
+                "pair": i + 1,
+                "pair_type": pair_type,
+                "sft_delta": round(sft_delta, 4),
+                "dpo_delta": round(dpo_delta, 4),
+                "improvement": round(improvement, 4),
+                "improved": improved,
+            })
+
+        except RuntimeError as e:
+            if "out of memory" in str(e).lower():
+                print(f"Pair {i+1}: OOM — skipped")
+            else:
+                raise
+
+    verdict = "PASS" if n_improved >= PASS_THRESHOLD else "FAIL"
+    print(f"\nRESULT: {n_improved}/{n_evaluated} pairs show DPO improvement  [{verdict}]")
+
+    # D-12 generation smoke test
+    print("\n[D-12 SMOKE] Testing generation ...")
+    test_prompt = (
+        "Which Canvas item is more urgent?\n"
+        "Item A: [EXAM] Midterm 2 @CS2505 Tomorrow 200pts\n"
+        "Item B: [ASGN] HW3 @CS2505 Due in 2 weeks 50pts\n"
+        "Which is more urgent and why?"
+    )
+    inputs = tokenizer(test_prompt, return_tensors="pt").to(dpo_model.device)
+    with torch.inference_mode():
+        out = dpo_model.generate(**inputs, max_new_tokens=80, do_sample=False)
+    n_prompt = inputs["input_ids"].shape[1]
+    response = tokenizer.decode(out[0][n_prompt:], skip_special_tokens=True)
+    print(f"[D-12 SMOKE] Response preview: {response[:120]}")
+    assert len(response.strip()) > 10, "Model produced near-empty response — checkpoint may be corrupt"
+    print("[D-12 SMOKE] PASS — checkpoint generates coherent output")
+
+    report = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "dpo_checkpoint": DPO_CHECKPOINT,
+        "sft_checkpoint": SFT_CHECKPOINT,
+        "n_pairs_evaluated": n_evaluated,
+        "n_improved": n_improved,
+        "pass_threshold": PASS_THRESHOLD,
+        "verdict": verdict,
+        "pairs": pair_results,
+        "smoke_test_response_preview": response[:120],
+    }
+    REPORT_PATH.write_text(json.dumps(report, indent=2))
+    print(f"\nValidation report written: {REPORT_PATH}")
+
+    sys.exit(0 if verdict == "PASS" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/GemmaReranker/scripts/validate_dpo_holdout.py
+++ b/GemmaReranker/scripts/validate_dpo_holdout.py
@@ -1,0 +1,230 @@
+"""
+validate_dpo_holdout.py — held-out validation of DPO v3 vs the merged BF16
+reference, on data/dpo_test_v3.jsonl (item-disjoint from training, per
+source/split_dpo_holdout.py).
+
+Two complementary measurements:
+
+  1. Logprob-delta improvement (the same metric validate_dpo.py used for
+     v2, but on actually-held-out data this time): for each test pair,
+     compare delta_v3 = logprob_v3(chosen) - logprob_v3(rejected) against
+     delta_ref = logprob_ref(chosen) - logprob_ref(rejected). DPO wins
+     when delta_v3 > delta_ref.
+
+  2. Pairwise prediction accuracy via training-prompt-format generation:
+     feed the trained prompt template "Which Canvas item is more urgent
+     and why?\n\n[Query]: {q}\nItem A: {a}\nItem B: {b}", greedy-decode
+     the response, scan for the first occurrence of "Item A" or "Item B"
+     and compare to which the chosen response argues for.
+
+Both measurements report point estimates plus Wilson 95% confidence
+intervals — directly addressing the audit P2 finding that v2 reported
+no uncertainty quantification.
+
+Outputs checkpoints/dpo-v3-checkpoint/holdout_validation.json.
+"""
+from __future__ import annotations
+
+import json
+import math
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+
+DPO_CHECKPOINT = "./checkpoints/dpo-v3-checkpoint"
+REF_CHECKPOINT = "./checkpoints/gguf/merged_bf16"
+TEST_PATH = "./data/dpo_test_v3.jsonl"
+REPORT_PATH = Path(DPO_CHECKPOINT) / "holdout_validation.json"
+
+
+def wilson_ci(k: int, n: int, z: float = 1.96) -> tuple[float, float]:
+    if n == 0:
+        return (0.0, 0.0)
+    p = k / n
+    denom = 1 + z * z / n
+    center = (p + z * z / (2 * n)) / denom
+    halfwidth = (z / denom) * math.sqrt(p * (1 - p) / n + z * z / (4 * n * n))
+    return (max(0.0, center - halfwidth), min(1.0, center + halfwidth))
+
+
+def chosen_picks(chosen_text: str) -> str | None:
+    m = re.search(r"\bItem\s*([AB])\b", chosen_text)
+    return m.group(1).upper() if m else None
+
+
+def sequence_log_prob(model, tokenizer, prompt: str, completion: str) -> float:
+    import torch
+    full = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt},
+         {"role": "assistant", "content": completion}],
+        tokenize=False,
+        add_generation_prompt=False,
+    )
+    enc = tokenizer(full, return_tensors="pt").to(model.device)
+    with torch.inference_mode():
+        out = model(**enc, labels=enc["input_ids"])
+    return -out.loss.item() * enc["input_ids"].shape[1]
+
+
+def generate_prediction(model, tokenizer, prompt: str, max_new_tokens: int = 32) -> str:
+    """
+    Greedy-decode a response in the SAME chat-template format that
+    sequence_log_prob uses, so the two metrics measure under the same
+    serialization regime (audit follow-up: codex + gemini both flagged the
+    raw-prompt-vs-chat-template inconsistency in the original v3 run).
+    """
+    import torch
+    chat_prompt = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        tokenize=False,
+        add_generation_prompt=True,
+    )
+    enc = tokenizer(chat_prompt, return_tensors="pt").to(model.device)
+    with torch.inference_mode():
+        out = model.generate(
+            **enc,
+            max_new_tokens=max_new_tokens,
+            do_sample=False,
+            pad_token_id=tokenizer.pad_token_id or tokenizer.eos_token_id,
+        )
+    n_prompt = enc["input_ids"].shape[1]
+    return tokenizer.decode(out[0][n_prompt:], skip_special_tokens=True)
+
+
+def binomial_p_one_sided(k: int, n: int, p: float) -> float:
+    from math import comb
+    return round(sum(comb(n, i) * p**i * (1-p)**(n-i) for i in range(k, n + 1)), 6)
+
+
+def main():
+    import torch
+    from transformers import AutoTokenizer, Gemma4ForCausalLM
+
+    print("=" * 70)
+    print("DPO v3 HELD-OUT VALIDATION")
+    print(f"  test:       {TEST_PATH}")
+    print(f"  v3 ckpt:    {DPO_CHECKPOINT}")
+    print(f"  ref ckpt:   {REF_CHECKPOINT}")
+    print("=" * 70)
+
+    pairs = [json.loads(l) for l in open(TEST_PATH) if l.strip()]
+    print(f"\n[load] {len(pairs)} held-out pairs from {TEST_PATH}")
+
+    print(f"\n[load] DPO v3 model {DPO_CHECKPOINT} ...")
+    dpo = Gemma4ForCausalLM.from_pretrained(
+        DPO_CHECKPOINT, torch_dtype=torch.bfloat16, attn_implementation="sdpa", device_map="auto",
+    )
+    dpo.train(False)
+
+    print(f"[load] reference model {REF_CHECKPOINT} ...")
+    ref = Gemma4ForCausalLM.from_pretrained(
+        REF_CHECKPOINT, torch_dtype=torch.bfloat16, attn_implementation="sdpa", device_map="auto",
+    )
+    ref.train(False)
+
+    tokenizer = AutoTokenizer.from_pretrained(DPO_CHECKPOINT)
+
+    n_improved = 0
+    n_pairwise_correct_dpo = 0
+    n_pairwise_correct_ref = 0
+    n_dpo_abstain = 0
+    n_ref_abstain = 0
+    detailed = []
+
+    for i, pair in enumerate(pairs):
+        prompt = pair["prompt"]
+        chosen = pair["chosen"]
+        rejected = pair["rejected"]
+        gold = chosen_picks(chosen)
+
+        ref_chosen = sequence_log_prob(ref, tokenizer, prompt, chosen)
+        ref_rejected = sequence_log_prob(ref, tokenizer, prompt, rejected)
+        dpo_chosen = sequence_log_prob(dpo, tokenizer, prompt, chosen)
+        dpo_rejected = sequence_log_prob(dpo, tokenizer, prompt, rejected)
+        ref_delta = ref_chosen - ref_rejected
+        dpo_delta = dpo_chosen - dpo_rejected
+        improvement = dpo_delta - ref_delta
+        improved = improvement > 0
+        if improved:
+            n_improved += 1
+
+        ref_pred = chosen_picks(generate_prediction(ref, tokenizer, prompt))
+        dpo_pred = chosen_picks(generate_prediction(dpo, tokenizer, prompt))
+        if dpo_pred is None:
+            n_dpo_abstain += 1
+        elif dpo_pred == gold:
+            n_pairwise_correct_dpo += 1
+        if ref_pred is None:
+            n_ref_abstain += 1
+        elif ref_pred == gold:
+            n_pairwise_correct_ref += 1
+
+        detailed.append({
+            "pair": i + 1,
+            "gold": gold,
+            "ref_pred": ref_pred,
+            "dpo_pred": dpo_pred,
+            "ref_delta": round(ref_delta, 4),
+            "dpo_delta": round(dpo_delta, 4),
+            "improvement": round(improvement, 4),
+            "improved": improved,
+        })
+
+        if (i + 1) % 25 == 0:
+            print(f"  [{i+1:3d}/{len(pairs)}] improved={n_improved} "
+                  f"dpo_acc={n_pairwise_correct_dpo}/{i+1-n_dpo_abstain}  "
+                  f"ref_acc={n_pairwise_correct_ref}/{i+1-n_ref_abstain}")
+
+    n = len(pairs)
+    n_dpo_scored = n - n_dpo_abstain
+    n_ref_scored = n - n_ref_abstain
+
+    impr_lo, impr_hi = wilson_ci(n_improved, n)
+    dpo_acc = n_pairwise_correct_dpo / n_dpo_scored if n_dpo_scored else 0.0
+    dpo_lo, dpo_hi = wilson_ci(n_pairwise_correct_dpo, n_dpo_scored)
+    ref_acc = n_pairwise_correct_ref / n_ref_scored if n_ref_scored else 0.0
+    ref_lo, ref_hi = wilson_ci(n_pairwise_correct_ref, n_ref_scored)
+
+    summary = {
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        "test_data": TEST_PATH,
+        "n_test_pairs": n,
+        "logprob_delta": {
+            "n_improved": n_improved,
+            "rate": round(n_improved / n, 4),
+            "wilson_95ci": [round(impr_lo, 4), round(impr_hi, 4)],
+            "binomial_p_one_sided": binomial_p_one_sided(n_improved, n, 0.5),
+        },
+        "pairwise_prediction": {
+            "dpo_correct": n_pairwise_correct_dpo,
+            "dpo_scored": n_dpo_scored,
+            "dpo_abstain": n_dpo_abstain,
+            "dpo_accuracy": round(dpo_acc, 4),
+            "dpo_wilson_95ci": [round(dpo_lo, 4), round(dpo_hi, 4)],
+            "ref_correct": n_pairwise_correct_ref,
+            "ref_scored": n_ref_scored,
+            "ref_abstain": n_ref_abstain,
+            "ref_accuracy": round(ref_acc, 4),
+            "ref_wilson_95ci": [round(ref_lo, 4), round(ref_hi, 4)],
+        },
+        "verdict_threshold": "DPO logprob improvement on > 50% of held-out pairs (lower CI bound > 0.5)",
+        "verdict": "PASS" if impr_lo > 0.5 else ("INCONCLUSIVE" if n_improved / n > 0.5 else "FAIL"),
+        "pairs": detailed,
+    }
+    REPORT_PATH.write_text(json.dumps(summary, indent=2))
+    print(f"\n{'='*70}")
+    print(f"  HELD-OUT RESULTS  (n={n})")
+    print(f"{'='*70}")
+    print(f"  Logprob improvement:  {n_improved}/{n}  ({n_improved/n*100:.1f}%)  "
+          f"[95% CI: {impr_lo*100:.1f}%, {impr_hi*100:.1f}%]")
+    print(f"  DPO pairwise acc:     {n_pairwise_correct_dpo}/{n_dpo_scored}  ({dpo_acc*100:.1f}%)  "
+          f"[95% CI: {dpo_lo*100:.1f}%, {dpo_hi*100:.1f}%]")
+    print(f"  Ref pairwise acc:     {n_pairwise_correct_ref}/{n_ref_scored}  ({ref_acc*100:.1f}%)  "
+          f"[95% CI: {ref_lo*100:.1f}%, {ref_hi*100:.1f}%]")
+    print(f"  Verdict:              {summary['verdict']}")
+    print(f"  Report:               {REPORT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/README.md
+++ b/README.md
@@ -7,6 +7,25 @@ A maintainable, team-ready **Canvas LMS productivity client** with a Textual TUI
 [![Pages](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/pages.yml?branch=main&label=Pages)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/pages.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![Python](https://img.shields.io/badge/python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![HF Model](https://img.shields.io/badge/🤗_HF-gemma4--canvas--reranker-yellow)](https://huggingface.co/kleinpanic93/gemma4-canvas-reranker)
+[![HF Dataset](https://img.shields.io/badge/🤗_HF-canvas--preference--2k-yellow)](https://huggingface.co/datasets/kleinpanic93/canvas-preference-2k)
+[![HF Collection](https://img.shields.io/badge/🤗_Collection-Canvas_Reranker_v1.0-yellow)](https://huggingface.co/collections/kleinpanic93/canvas-reranker-gemma-4-e2b-it-v10-69f5799662d65c8f39be0a94)
+<!-- Zenodo DOI badge appears here once paper is deposited via source/deposit_zenodo.py -->
+
+## ML/AI components
+
+The reranker subsystem (`GemmaReranker/`) trains and evaluates 9 fine-tuning
+methods (SFT, LoRA, QLoRA, DPO, IPO, APO-zero, SPPO, NCA, KTO) on a
+Canvas preference dataset. v1 ships as a fast preference-hint model
+([`kleinpanic93/gemma4-canvas-reranker`](https://huggingface.co/kleinpanic93/gemma4-canvas-reranker))
+in 4 GGUF quants (Q4_K_M / Q5_K_M / Q8_0 / f16) plus the BF16 transformers
+weights. v2 (in design) builds a **specialized calendar+study agent** that
+uses the v1 model as one tool alongside Canvas API + calendar (Google Cal /
+Outlook / calcurses) tool calls and neuroscience-grounded study planning
+heuristics (spaced repetition, deep-work block sizing, exam bracketing). See
+[GemmaReranker/README.md](GemmaReranker/README.md) for the full ML pipeline
+and [`src/canvas_tui/agent/`](src/canvas_tui/agent/) for the consumer-side
+agent code.
 
 ---
 

--- a/extension/src/lib/reranker.js
+++ b/extension/src/lib/reranker.js
@@ -1,0 +1,180 @@
+/**
+ * canvas-tui browser extension — reranker client (Phase 01.1, JS port).
+ *
+ * Mirrors src/canvas_tui/reranker.py from the Python TUI side. Same
+ * RANK_PROMPT_TEMPLATE, same SHA, same serializeItem semantics, so a
+ * model trained on the canonical pipeline scores items consistently
+ * across both consumers.
+ *
+ * Backends:
+ *   NullReranker         — no-op pass-through. Default when
+ *                          settings.useAiReranker === false.
+ *   OllamaReranker       — HTTP POST to http://localhost:11434
+ *                          (Ollama default). Best MV3-friendly
+ *                          choice — no in-extension WASM, no model
+ *                          bundling. User must install Ollama and
+ *                          pull a kleinpanic93/gemma4-canvas-reranker
+ *                          quant locally. Falls back to NullReranker
+ *                          if the endpoint is unreachable.
+ *
+ * Per the v3 held-out validation in the upstream paper §6.6, DPO and
+ * the QLoRA-merged BF16 reference produce identical predictions.
+ * Recommend Ollama-pull `kleinpanic93/gemma4-canvas-reranker:Q4_K_M`
+ * (3.18 GiB) for the extension — smallest quant that preserves the
+ * 98% pairwise accuracy on standard pairs.
+ */
+
+export const RANK_PROMPT_TEMPLATE =
+  "Which Canvas item is more urgent and why?\n\n" +
+  "[Query]: {query}\n" +
+  "Item A: {item_a}\n" +
+  "Item B: {item_b}";
+
+let _shaCache = null;
+export async function getRankPromptFormatSha() {
+  if (_shaCache !== null) return _shaCache;
+  const data = new TextEncoder().encode(RANK_PROMPT_TEMPLATE);
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  _shaCache = Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return _shaCache;
+}
+
+const _BADGE_MAP = {
+  assignment: "ASGN",
+  quiz: "QUIZ",
+  exam: "EXAM",
+  discussion: "DISC",
+  event: "EVNT",
+  announcement: "NOTE",
+};
+
+async function _anonymizeCourse(courseCode) {
+  const data = new TextEncoder().encode((courseCode || "").trim());
+  const buf = await crypto.subtle.digest("SHA-256", data);
+  const arr = new Uint8Array(buf);
+  const intVal = (arr[0] << 24) | (arr[1] << 16) | (arr[2] << 8) | arr[3];
+  const positive = intVal >>> 0;
+  return `COURSE${(positive % 9000) + 1000}`;
+}
+
+function _dueLabel(dueIso) {
+  if (!dueIso) return null;
+  const dt = new Date(dueIso);
+  if (isNaN(dt.getTime())) return null;
+  const deltaH = (dt.getTime() - Date.now()) / 3600000;
+  if (deltaH < -1) return "OVERDUE";
+  if (deltaH < 24) return "Today";
+  if (deltaH < 48) return "Tomorrow";
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getUTCDate()).padStart(2, "0");
+  const hh = String(dt.getUTCHours()).padStart(2, "0");
+  const mi = String(dt.getUTCMinutes()).padStart(2, "0");
+  return `Due ${mm}/${dd} ${hh}:${mi}`;
+}
+
+export async function serializeItem(item) {
+  const parts = [];
+  const ptype = (item.ptype || "?").toLowerCase();
+  parts.push(`[${_BADGE_MAP[ptype] || ptype.slice(0, 4).toUpperCase()}]`);
+  parts.push((item.title || "(untitled)").slice(0, 45));
+  if (item.course_code) {
+    parts.push(`@${await _anonymizeCourse(item.course_code)}`);
+  }
+  if (item.status_flags && item.status_flags.includes("submitted")) {
+    parts.push("DONE");
+  } else {
+    const label = _dueLabel(item.due_iso);
+    if (label) parts.push(label);
+  }
+  if (item.points && Number(item.points) > 0) {
+    parts.push(`${Math.round(Number(item.points))}pts`);
+  }
+  return parts.join(" ");
+}
+
+export class NullReranker {
+  name = "null";
+  async rank(_query, items) {
+    return [...items];
+  }
+}
+
+export class OllamaReranker {
+  name = "ollama";
+  constructor({
+    endpoint = "http://localhost:11434",
+    model = "gemma4-canvas-reranker:Q4_K_M",
+    timeoutMs = 5000,
+  } = {}) {
+    this.endpoint = endpoint;
+    this.model = model;
+    this.timeoutMs = timeoutMs;
+  }
+  async _chat(prompt) {
+    const ctrl = new AbortController();
+    const t = setTimeout(() => ctrl.abort(), this.timeoutMs);
+    try {
+      const resp = await fetch(`${this.endpoint}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: this.model,
+          messages: [{ role: "user", content: prompt }],
+          stream: false,
+          options: { temperature: 0, num_predict: 8 },
+        }),
+        signal: ctrl.signal,
+      });
+      if (!resp.ok) throw new Error(`ollama HTTP ${resp.status}`);
+      const data = await resp.json();
+      return data?.message?.content ?? "";
+    } finally {
+      clearTimeout(t);
+    }
+  }
+  async _scoreItem(query, itemSerialized, refSerialized) {
+    const promptA = RANK_PROMPT_TEMPLATE
+      .replace("{query}", query)
+      .replace("{item_a}", itemSerialized)
+      .replace("{item_b}", refSerialized);
+    const promptB = RANK_PROMPT_TEMPLATE
+      .replace("{query}", query)
+      .replace("{item_a}", refSerialized)
+      .replace("{item_b}", itemSerialized);
+    const [textA, textB] = await Promise.all([this._chat(promptA), this._chat(promptB)]);
+    const pickA = /\bItem\s*([AB])\b/i.exec(textA)?.[1]?.toUpperCase();
+    const pickB = /\bItem\s*([AB])\b/i.exec(textB)?.[1]?.toUpperCase();
+    const lpA = pickA === "A" ? 1 : pickA === "B" ? -1 : 0;
+    const lpB = pickB === "A" ? 1 : pickB === "B" ? -1 : 0;
+    return lpA - lpB;
+  }
+  async rank(query, items) {
+    if (!items || items.length === 0) return [];
+    const ref = "[ASGN] Reference Assignment @COURSE0000 Due 12/31 23:59 50pts";
+    const serialized = await Promise.all(items.map((i) => serializeItem(i)));
+    const scores = await Promise.all(
+      serialized.map((s, idx) => this._scoreItem(query, s, ref).then((sc) => [sc, items[idx]]))
+    );
+    scores.sort((a, b) => b[0] - a[0]);
+    return scores.map(([, item]) => item);
+  }
+}
+
+export async function makeReranker({
+  useAi = false,
+  ollamaEndpoint = "http://localhost:11434",
+  ollamaModel = "gemma4-canvas-reranker:Q4_K_M",
+} = {}) {
+  if (!useAi) return new NullReranker();
+  try {
+    const probe = await fetch(`${ollamaEndpoint}/api/tags`, { signal: AbortSignal.timeout(1000) });
+    if (probe.ok) {
+      return new OllamaReranker({ endpoint: ollamaEndpoint, model: ollamaModel });
+    }
+  } catch (_) {
+    // fall through
+  }
+  return new NullReranker();
+}

--- a/extension/src/lib/reranker.js
+++ b/extension/src/lib/reranker.js
@@ -19,9 +19,16 @@
  *
  * Per the v3 held-out validation in the upstream paper §6.6, DPO and
  * the QLoRA-merged BF16 reference produce identical predictions.
- * Recommend Ollama-pull `kleinpanic93/gemma4-canvas-reranker:Q4_K_M`
- * (3.18 GiB) for the extension — smallest quant that preserves the
- * 98% pairwise accuracy on standard pairs.
+ *
+ * Quant choice (per source/benchmark_quants.py on n=148 held-out):
+ *   - Q5_K_M (3.4 GiB) — 98.0% accuracy, recommended default
+ *   - Q4_K_M (3.18 GiB) — 93.2% accuracy, ~5pp lower than Q5; use only
+ *     if you need the smaller binary and accept the accuracy hit
+ *
+ * Default backend below pulls Q4_K_M to favor the small-binary
+ * extension footprint, but consumers should consider switching to
+ * Q5_K_M (`gemma4-canvas-reranker:Q5_K_M`) if accuracy on standard
+ * pairs matters more than ~200 MiB of disk.
  */
 
 export const RANK_PROMPT_TEMPLATE =
@@ -82,12 +89,13 @@ export async function serializeItem(item) {
   if (item.course_code) {
     parts.push(`@${await _anonymizeCourse(item.course_code)}`);
   }
-  if (item.status_flags && item.status_flags.includes("submitted")) {
-    parts.push("DONE");
-  } else {
-    const label = _dueLabel(item.due_iso);
-    if (label) parts.push(label);
-  }
+  // Mirror src/canvas_tui/models/item.py:serialize_item exactly: the
+  // training-side serializer does NOT consume status_flags. Submitted/
+  // missing items must be filtered out by the consumer before calling
+  // serializeItem; otherwise they get serialized identically to open
+  // items.
+  const label = _dueLabel(item.due_iso);
+  if (label) parts.push(label);
   if (item.points && Number(item.points) > 0) {
     parts.push(`${Math.round(Number(item.points))}pts`);
   }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,13 @@ dependencies = [
 
 [project.optional-dependencies]
 keyring = ["keyring>=23.0"]
+ai = [
+    # On-device GGUF inference for canvas_tui.reranker.LocalReranker.
+    # Pull a quant from huggingface.co/kleinpanic93/gemma4-canvas-reranker
+    # (Q4_K_M ~3.2 GiB recommended for resource-constrained machines;
+    # Q5_K_M ~3.4 GiB is the published default).
+    "llama-cpp-python>=0.3",
+]
 dev = [
     "black",
     "build",

--- a/src/canvas_tui/agent/prompts/system.md
+++ b/src/canvas_tui/agent/prompts/system.md
@@ -1,0 +1,99 @@
+# Canvas Life Manager — System Prompt
+
+You are a personal AI calendar + study assistant for a college student.
+You have tool access to their Canvas LMS, their calendar (Google Calendar /
+Outlook / calcurses depending on what's configured), and a fast preference-
+ranker model fine-tuned on Canvas urgency data.
+
+Your job is to plan the student's week and help them actually finish what
+they've committed to — both school work and life events. You are not a
+priority-toy that just sorts assignments by point value; that's trivial code.
+You reason about the student's actual constraints (sleep, fixed events,
+deadline structure, syllabus shape, exam prep, credit hours) and translate
+that into concrete calendar actions.
+
+## Hard rules
+
+- **Sleep is non-negotiable.** Don't schedule study work past midnight unless
+  the student explicitly opts in. Default protected window: 23:00 → 07:00.
+- **Don't double-book.** Always check `calendar.list_events` for the proposed
+  block window before creating an event.
+- **Never silently delete.** Modifications to existing calendar entries
+  surface as `modify` actions the user must confirm; you can suggest but not
+  apply.
+- **Honor non-school events.** Personal entries on the calendar (work shift,
+  doctor's appointment, social commitment, gym, family) are equal-priority
+  fixed obstacles, not things to schedule around as an afterthought.
+
+## Neuroscience-grounded scheduling principles
+
+These are the heuristics that should drive your planning. Apply them
+unless the student's stated preferences override.
+
+1. **Spaced repetition for exams.** For an exam in N days, distribute prep
+   into ≥3 sessions spaced 2-5 days apart (Cepeda et al. 2008; Karpicke
+   2007). Concentrate the *first* session 7-14 days before the exam if
+   possible — the long initial gap is what produces durable retention.
+   Crammed prep the night before is the worst possible schedule
+   neurally; flag it and suggest the spaced alternative.
+
+2. **Deep-work blocks: 60-90 minutes.** Most cognitive work degrades
+   sharply after ~90 min without a break. Default block size: 90 min for
+   high-concentration work (writing, problem sets, exam prep), 45 min
+   for review/reading, 25 min "Pomodoro" for shallow tasks (admin,
+   reading instructor announcements, etc.). Insert ≥15 min breaks
+   between deep blocks.
+
+3. **Morning-favored deep work.** Most people are cognitively peakest in
+   the first 2-3 hours after waking. Schedule the hardest assignments
+   into morning blocks when possible; reserve afternoons for review,
+   admin, and discussion-based work.
+
+4. **Context-switching tax: ~10 min recovery per switch.** Group tasks
+   from the same course into adjacent blocks when possible. Never
+   schedule micro-fragments (<25 min blocks) for substantive work.
+
+5. **Credit-hour weighting.** A 4-credit class with a heavy final
+   project deserves more weekly time investment than a 1-credit
+   pass-fail seminar with the same nominal due-date. Use
+   `canvas.get_course` to read credit hours when present.
+
+6. **Syllabus shape matters.** Ask `canvas.get_syllabus(course_id)`
+   when planning multi-week schedules. If a course has no per-week
+   homework but a single end-of-semester project, allocate weekly
+   "project work" blocks ramping up; don't wait until the project
+   description appears as a Canvas TODO.
+
+7. **Exam-day bracket.** Block 30-60 min low-load review before an
+   exam (not deep cramming). Block 30 min decompression after
+   (no other deep work).
+
+## Output format
+
+When proposing schedule changes, output a JSON list of actions:
+
+```json
+[
+  {"action": "create_event", "calendar": "primary",
+   "title": "CS 3704 — Project 4 work", "start": "2026-05-04T09:00",
+   "end": "2026-05-04T10:30", "rationale": "90-min morning deep block; 3-day stretch before due"},
+  {"action": "modify_event", "id": "<existing-id>",
+   "title_to": "...", "start_to": "...", "end_to": "...",
+   "rationale": "shift back 1hr to avoid overlap with gym block"},
+  {"action": "suggest_skip",
+   "title": "Reading Quiz 4", "rationale": "5pts, no grade impact, conflicts with exam prep"}
+]
+```
+
+For *priority queries* ("what should I do first right now?"), use the
+fast `reranker.priority_hint(item_a, item_b)` tool to rank the top
+items, then explain the ordering with the principles above. Don't just
+return the model's pick; the model is heuristic-trained and you have
+richer context.
+
+## What you don't do
+
+- Don't generate fake assignment metadata. Always read from the tools.
+- Don't make claims about specific grades, GPA, or academic outcomes.
+- Don't reschedule events the user explicitly marked as fixed.
+- Don't pretend to know the student's habits — ask them once and remember.

--- a/src/canvas_tui/agent/tools/__init__.py
+++ b/src/canvas_tui/agent/tools/__init__.py
@@ -1,0 +1,31 @@
+"""Tool registry for the canvas-tui agent.
+
+Each tool exports:
+  - SCHEMA: JSON-schema dict describing the function (Ollama / Gemma 4
+    function-calling format)
+  - call(args: dict) -> dict | list | str: actual implementation
+
+The agent loop reads SCHEMA to advertise tools to the model, parses the
+model's tool_call requests, dispatches to the matching call(), and
+appends the result back to the conversation.
+"""
+from __future__ import annotations
+
+from . import calendar_tools, canvas_tools, reranker_tools, study_tools
+
+REGISTRY: dict = {}
+for module in (canvas_tools, calendar_tools, reranker_tools, study_tools):
+    for name in module.__all__:
+        fn_obj = getattr(module, name)
+        REGISTRY[fn_obj.NAME] = fn_obj
+
+
+def get_schemas() -> list[dict]:
+    """Return the list of tool schemas in Ollama-compatible format."""
+    return [{"type": "function", "function": fn.SCHEMA} for fn in REGISTRY.values()]
+
+
+def dispatch(tool_name: str, args: dict):
+    """Execute a tool call by name. Raises KeyError if unknown."""
+    fn = REGISTRY[tool_name]
+    return fn.call(args)

--- a/src/canvas_tui/agent/tools/calendar_tools.py
+++ b/src/canvas_tui/agent/tools/calendar_tools.py
@@ -1,0 +1,132 @@
+"""Calendar tools — list, create, modify across Google Cal / Outlook / calcurses.
+
+The actual calendar backend is selected by Config.calendar_backend. All tools
+here delegate to a single CalendarAdapter that abstracts the four backends.
+"""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+__all__ = ["ListEvents", "FindFreeBlocks", "CreateEvent", "ModifyEvent", "DeleteEvent"]
+
+
+def _adapter():
+    from canvas_tui.agent.backends.calendar_adapter import CalendarAdapter
+    return CalendarAdapter.from_config()
+
+
+class ListEvents:
+    NAME = "calendar.list_events"
+    SCHEMA = {
+        "name": NAME,
+        "description": "List calendar events in a window (default: next 14 days).",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "calendar_id": {"type": "string", "default": "primary"},
+                "start_iso": {"type": "string", "description": "ISO8601 lower bound, default = now."},
+                "end_iso": {"type": "string", "description": "ISO8601 upper bound, default = +14d."},
+                "include_all_day": {"type": "boolean", "default": True},
+            },
+            "required": [],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> list[dict]:
+        return _adapter().list_events(**args)
+
+
+class FindFreeBlocks:
+    NAME = "calendar.find_free_blocks"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Find blocks of free time in the calendar matching constraints. Use this BEFORE "
+            "create_event to make sure you're not double-booking. Honors quiet hours, work "
+            "hours, and the user's existing events."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "min_minutes": {"type": "integer", "default": 90, "description": "Minimum block length."},
+                "horizon_days": {"type": "integer", "default": 7},
+                "earliest_hour": {"type": "integer", "default": 7, "description": "Don't propose before this hour (24h)."},
+                "latest_hour": {"type": "integer", "default": 22, "description": "Don't propose ending after this hour."},
+                "calendar_id": {"type": "string", "default": "primary"},
+                "exclude_weekends": {"type": "boolean", "default": False},
+            },
+            "required": [],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> list[dict]:
+        return _adapter().find_free_blocks(**args)
+
+
+class CreateEvent:
+    NAME = "calendar.create_event"
+    SCHEMA = {
+        "name": NAME,
+        "description": "Create a calendar event. Always check find_free_blocks first.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "title": {"type": "string"},
+                "start_iso": {"type": "string"},
+                "end_iso": {"type": "string"},
+                "description": {"type": "string"},
+                "calendar_id": {"type": "string", "default": "primary"},
+                "rationale": {"type": "string", "description": "Brief reason for this scheduling decision (logged in event description)."},
+            },
+            "required": ["title", "start_iso", "end_iso"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> dict:
+        return _adapter().create_event(**args)
+
+
+class ModifyEvent:
+    NAME = "calendar.modify_event"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Propose modification to an existing event. Returns a 'pending' object the user "
+            "must confirm via the TUI before it's applied; never silently mutates the user's "
+            "calendar."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "event_id": {"type": "string"},
+                "title": {"type": "string"},
+                "start_iso": {"type": "string"},
+                "end_iso": {"type": "string"},
+                "rationale": {"type": "string"},
+            },
+            "required": ["event_id"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> dict:
+        return _adapter().propose_modification(**args)
+
+
+class DeleteEvent:
+    NAME = "calendar.delete_event"
+    SCHEMA = {
+        "name": NAME,
+        "description": "Propose deletion of an event. Always returns a pending action; never silently deletes.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "event_id": {"type": "string"},
+                "rationale": {"type": "string"},
+            },
+            "required": ["event_id", "rationale"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> dict:
+        return _adapter().propose_deletion(**args)

--- a/src/canvas_tui/agent/tools/canvas_tools.py
+++ b/src/canvas_tui/agent/tools/canvas_tools.py
@@ -1,0 +1,110 @@
+"""Canvas-side tools — read-only access to courses, assignments, syllabi, TODOs."""
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["ListCourses", "GetAssignments", "GetTodo", "GetSyllabus", "GetCourse"]
+
+
+class ListCourses:
+    NAME = "canvas.list_courses"
+    SCHEMA = {
+        "name": NAME,
+        "description": "List all the student's enrolled courses for the current term.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "active_only": {"type": "boolean", "description": "If True (default), only courses with a current enrollment."},
+            },
+            "required": [],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> list[dict]:
+        from canvas_tui.api import CanvasAPI
+        api = CanvasAPI.from_config()
+        active = args.get("active_only", True)
+        return [c.to_dict() for c in api.list_courses(active_only=active)]
+
+
+class GetAssignments:
+    NAME = "canvas.get_assignments"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Get assignments for one course or all courses, with optional time-window filter. "
+            "Returns title, type, points, due_iso, status_flags, course_code."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "course_id": {"type": ["integer", "null"], "description": "Course ID, or null for all courses."},
+                "horizon_days": {"type": "integer", "default": 14, "description": "Window: due in next N days."},
+                "include_submitted": {"type": "boolean", "default": False},
+            },
+            "required": [],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> list[dict]:
+        from canvas_tui.api import CanvasAPI
+        api = CanvasAPI.from_config()
+        items = api.get_assignments(
+            course_id=args.get("course_id"),
+            horizon_days=args.get("horizon_days", 14),
+            include_submitted=args.get("include_submitted", False),
+        )
+        return [it.to_dict() for it in items]
+
+
+class GetTodo:
+    NAME = "canvas.get_todo"
+    SCHEMA = {
+        "name": NAME,
+        "description": "Fetch the student's Canvas TODO list (the official 'what needs your attention' feed).",
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    }
+    @staticmethod
+    def call(args: dict) -> list[dict]:
+        from canvas_tui.api import CanvasAPI
+        api = CanvasAPI.from_config()
+        return [t.to_dict() for t in api.get_todo()]
+
+
+class GetSyllabus:
+    NAME = "canvas.get_syllabus"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Fetch a course's syllabus (HTML stripped to text). Use to understand the "
+            "course shape: weekly schedule, exam dates, project structure, weighting."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {"course_id": {"type": "integer"}},
+            "required": ["course_id"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> str:
+        from canvas_tui.api import CanvasAPI
+        api = CanvasAPI.from_config()
+        return api.get_syllabus(args["course_id"])
+
+
+class GetCourse:
+    NAME = "canvas.get_course"
+    SCHEMA = {
+        "name": NAME,
+        "description": "Get one course's metadata (name, code, credit hours if exposed, term, instructor).",
+        "parameters": {
+            "type": "object",
+            "properties": {"course_id": {"type": "integer"}},
+            "required": ["course_id"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> dict:
+        from canvas_tui.api import CanvasAPI
+        api = CanvasAPI.from_config()
+        return api.get_course(args["course_id"]).to_dict()

--- a/src/canvas_tui/agent/tools/reranker_tools.py
+++ b/src/canvas_tui/agent/tools/reranker_tools.py
@@ -1,0 +1,56 @@
+"""Fast preference-hint tool — wraps the published Gemma-4 reranker GGUF.
+
+The agent uses this only as a *fast first-pass priority hint* when it
+needs to rank Canvas items by heuristic urgency without spending a full
+reasoning turn. The agent's broader context (syllabus, credit hours,
+calendar constraints) overrides the model's pick.
+"""
+from __future__ import annotations
+
+__all__ = ["PriorityHint"]
+
+
+class PriorityHint:
+    NAME = "reranker.priority_hint"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Get a fast priority hint for which of two Canvas items is more urgent "
+            "by the trained heuristic. Returns the predicted winner ('A' or 'B') "
+            "and the model's natural-language rationale. The agent should treat "
+            "this as a heuristic input, not the final answer — richer context "
+            "(calendar, syllabus, credit hours) overrides."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Natural-language ranking criterion."},
+                "item_a": {"type": "string", "description": "Item A in the trained format: '[TYPE] Title @COURSEcode STATUS Npts'"},
+                "item_b": {"type": "string"},
+            },
+            "required": ["query", "item_a", "item_b"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> dict:
+        from canvas_tui.reranker import LocalReranker, RANK_PROMPT_FORMAT_SHA, RANK_PROMPT_TEMPLATE
+        from canvas_tui.config import Config
+        cfg = Config.load()
+        if not cfg.use_ai_reranker or not cfg.model_path:
+            return {"winner": None, "rationale": "reranker not configured (cfg.use_ai_reranker=False or empty model_path)"}
+        rr = LocalReranker(cfg.model_path, expected_sha=RANK_PROMPT_FORMAT_SHA)
+        rr._ensure_loaded()
+        prompt = RANK_PROMPT_TEMPLATE.format(
+            query=args["query"], item_a=args["item_a"], item_b=args["item_b"],
+        )
+        out = rr._llm.create_chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=200, temperature=0.0,
+        )
+        text = out["choices"][0]["message"]["content"]
+        import re
+        m = re.search(r"\bItem\s*([AB])\b", text)
+        return {
+            "winner": m.group(1).upper() if m else None,
+            "rationale": text,
+        }

--- a/src/canvas_tui/agent/tools/study_tools.py
+++ b/src/canvas_tui/agent/tools/study_tools.py
@@ -1,0 +1,127 @@
+"""Study-planning helpers — pure-code implementations of the
+neuroscience-grounded heuristics in the system prompt. Exposed as tools
+so the model can ask for a spaced-repetition schedule without having to
+do the date arithmetic itself.
+"""
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+__all__ = ["SpacedSchedule", "DeepBlockSize", "ExamBracket"]
+
+
+class SpacedSchedule:
+    NAME = "study.spaced_schedule"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Compute spaced-repetition session dates for an exam, applying the "
+            "Cepeda et al. 2008 / Karpicke 2007 spacing rules. Returns 3-5 "
+            "session datetimes with the first session 7-14 days before the exam."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "exam_iso": {"type": "string", "description": "ISO8601 exam datetime."},
+                "n_sessions": {"type": "integer", "default": 4, "description": "Target number of sessions (3-5 typical)."},
+                "minutes_per_session": {"type": "integer", "default": 90},
+                "preferred_hour": {"type": "integer", "default": 9, "description": "Preferred start hour (24h, default 9am for morning peak cognition)."},
+            },
+            "required": ["exam_iso"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> list[dict]:
+        exam = dt.datetime.fromisoformat(args["exam_iso"].replace("Z", "+00:00"))
+        n = max(3, min(5, args.get("n_sessions", 4)))
+        minutes = args.get("minutes_per_session", 90)
+        hour = args.get("preferred_hour", 9)
+        # Spacing: first session 7-14 days before; each subsequent halves the gap
+        # roughly (expanding-spacing schedule). For n=4: -10, -5, -3, -1 days.
+        gaps_by_n = {3: [10, 4, 1], 4: [10, 5, 2, 1], 5: [14, 7, 3, 2, 1]}
+        gaps = gaps_by_n[n]
+        sessions = []
+        for g in gaps:
+            t = (exam - dt.timedelta(days=g)).replace(hour=hour, minute=0, second=0, microsecond=0)
+            sessions.append({
+                "start_iso": t.isoformat(),
+                "end_iso": (t + dt.timedelta(minutes=minutes)).isoformat(),
+                "label": f"Exam prep session — {g}d before",
+                "minutes": minutes,
+            })
+        return sessions
+
+
+class DeepBlockSize:
+    NAME = "study.recommend_block_size"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Recommend the right block size (in minutes) for a task type, based on "
+            "deep-work + cognitive-load research. Returns the recommended duration "
+            "and a brief rationale."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "task_type": {
+                    "type": "string",
+                    "enum": ["writing", "problem_set", "exam_prep", "reading", "review", "admin", "discussion", "project_work"],
+                },
+            },
+            "required": ["task_type"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> dict:
+        rec = {
+            "writing":      (90, "deep cognitive work — peak ~90min, hard cap before fatigue"),
+            "problem_set":  (90, "sustained reasoning — 60-90min blocks; 25min for trivial sets"),
+            "exam_prep":    (90, "comprehensive recall + practice — 90min with 15min breaks"),
+            "reading":      (45, "moderate cognitive load — 45min blocks, more frequent breaks"),
+            "review":       (45, "lighter than first-pass learning"),
+            "admin":        (25, "Pomodoro-style — short shallow work"),
+            "discussion":   (60, "structured dialogue — 60min canonical class length"),
+            "project_work": (90, "deep work — 90min blocks, group adjacent if possible"),
+        }
+        minutes, rationale = rec[args["task_type"]]
+        return {"minutes": minutes, "rationale": rationale}
+
+
+class ExamBracket:
+    NAME = "study.exam_bracket"
+    SCHEMA = {
+        "name": NAME,
+        "description": (
+            "Generate the 'exam-day bracket' — a 30-60min low-load review block "
+            "before the exam (no heavy cramming) and a 30min decompression block "
+            "after (no other deep work)."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "exam_start_iso": {"type": "string"},
+                "exam_end_iso": {"type": "string"},
+                "review_minutes": {"type": "integer", "default": 45},
+            },
+            "required": ["exam_start_iso", "exam_end_iso"],
+        },
+    }
+    @staticmethod
+    def call(args: dict) -> list[dict]:
+        start = dt.datetime.fromisoformat(args["exam_start_iso"].replace("Z", "+00:00"))
+        end = dt.datetime.fromisoformat(args["exam_end_iso"].replace("Z", "+00:00"))
+        review = args.get("review_minutes", 45)
+        return [
+            {
+                "label": "Exam-day light review (no new material)",
+                "start_iso": (start - dt.timedelta(minutes=review + 15)).isoformat(),
+                "end_iso":   (start - dt.timedelta(minutes=15)).isoformat(),
+            },
+            {
+                "label": "Decompress (no other deep work)",
+                "start_iso": end.isoformat(),
+                "end_iso":   (end + dt.timedelta(minutes=30)).isoformat(),
+            },
+        ]

--- a/src/canvas_tui/models/__init__.py
+++ b/src/canvas_tui/models/__init__.py
@@ -5,7 +5,7 @@ Re-exports all model classes for convenience.
 from __future__ import annotations
 
 from .course import CourseInfo
-from .item import CanvasItem
+from .item import CanvasItem, serialize_item
 from .modal import ModalContext
 
-__all__ = ["CanvasItem", "CourseInfo", "ModalContext"]
+__all__ = ["CanvasItem", "CourseInfo", "ModalContext", "serialize_item"]

--- a/src/canvas_tui/models/item.py
+++ b/src/canvas_tui/models/item.py
@@ -2,8 +2,56 @@
 
 from __future__ import annotations
 
+import datetime as _dt
+import hashlib
 from dataclasses import dataclass, field
 from typing import Any
+
+# Match scripts/generate_rerank_data.py:352-353 exactly so the SHA over
+# RANK_PROMPT_TEMPLATE in canvas_tui.reranker stays equal to the
+# TRAINING_PROMPT_FORMAT_SHA the GemmaReranker pipeline computed.
+_BADGE_MAP: dict[str, str] = {
+    "assignment": "ASGN",
+    "quiz": "QUIZ",
+    "exam": "EXAM",
+    "discussion": "DISC",
+    "event": "EVNT",
+    "announcement": "NOTE",
+}
+
+
+def _anonymize_course(course_code: str) -> str:
+    """Map a real course code (e.g. 'CS 3704') to the anonymized
+    'COURSE\\d{4}' format the model was trained on.
+
+    Deterministic SHA-256 → 4-digit modulo. Matches the v2 anonymization
+    scheme used by the data-prep pipeline so consumers get the same
+    `@COURSE####` strings that appeared at training time.
+    """
+    h = int(hashlib.sha256(course_code.strip().encode("utf-8")).hexdigest()[:8], 16)
+    return f"COURSE{(h % 9000) + 1000}"
+
+
+def _due_label(due_iso: str) -> str | None:
+    """Convert an ISO8601 due timestamp to one of the four trained
+    status tokens: OVERDUE / Today / Tomorrow / 'Due MM/DD HH:MM'.
+    Returns None if `due_iso` is empty or unparseable (caller should
+    omit the status field in that case)."""
+    if not due_iso:
+        return None
+    try:
+        dt = _dt.datetime.fromisoformat(due_iso.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    now = _dt.datetime.now(_dt.timezone.utc)
+    delta_h = (dt.astimezone(_dt.timezone.utc) - now).total_seconds() / 3600.0
+    if delta_h < -1:
+        return "OVERDUE"
+    if delta_h < 24:
+        return "Today"
+    if delta_h < 48:
+        return "Tomorrow"
+    return f"Due {dt.strftime('%m/%d %H:%M')}"
 
 
 @dataclass
@@ -83,3 +131,38 @@ class CanvasItem:
             status_flags=d.get("status_flags", []),
             raw_plannable=d.get("raw_plannable", {}),
         )
+
+
+def serialize_item(item: CanvasItem) -> str:
+    """Serialize a CanvasItem to the trained format the published
+    `kleinpanic93/gemma4-canvas-reranker` model expects.
+
+    Format: ``[BADGE] Title @COURSE#### STATUS NNNpts``
+
+    The course code is anonymized via SHA-256 → 4-digit modulo so that
+    the consumer never sends a real institution-level course identifier
+    to the model — matches the training-time anonymization scheme.
+
+    Status is derived from `due_iso` (and `status_flags` for DONE):
+        - DONE if "submitted" in status_flags
+        - OVERDUE if past due
+        - Today / Tomorrow / Due MM/DD HH:MM otherwise
+
+    Returns a single-line string suitable for embedding in
+    RANK_PROMPT_TEMPLATE (see canvas_tui.reranker).
+    """
+    parts: list[str] = []
+    ptype = (item.ptype or "?").lower()
+    parts.append(f"[{_BADGE_MAP.get(ptype, ptype[:4].upper())}]")
+    parts.append((item.title or "(untitled)")[:45])
+    if item.course_code:
+        parts.append(f"@{_anonymize_course(item.course_code)}")
+    if "submitted" in (item.status_flags or []):
+        parts.append("DONE")
+    else:
+        label = _due_label(item.due_iso)
+        if label:
+            parts.append(label)
+    if item.points:
+        parts.append(f"{float(item.points):.0f}pts")
+    return " ".join(parts)

--- a/src/canvas_tui/models/item.py
+++ b/src/canvas_tui/models/item.py
@@ -36,7 +36,15 @@ def _due_label(due_iso: str) -> str | None:
     """Convert an ISO8601 due timestamp to one of the four trained
     status tokens: OVERDUE / Today / Tomorrow / 'Due MM/DD HH:MM'.
     Returns None if `due_iso` is empty or unparseable (caller should
-    omit the status field in that case)."""
+    omit the status field in that case).
+
+    Date-format normalization: this function emits the absolute date
+    in UTC (`dt.astimezone(UTC).strftime(...)`) so the JS port's
+    `getUTCMonth/Date/Hours/Minutes` produces identical output. This
+    is a deliberate divergence from the training-time serializer which
+    used the source datetime's own timezone — see the docstring on
+    `serialize_item` for the rationale.
+    """
     if not due_iso:
         return None
     try:
@@ -44,14 +52,15 @@ def _due_label(due_iso: str) -> str | None:
     except ValueError:
         return None
     now = _dt.datetime.now(_dt.timezone.utc)
-    delta_h = (dt.astimezone(_dt.timezone.utc) - now).total_seconds() / 3600.0
+    dt_utc = dt.astimezone(_dt.timezone.utc)
+    delta_h = (dt_utc - now).total_seconds() / 3600.0
     if delta_h < -1:
         return "OVERDUE"
     if delta_h < 24:
         return "Today"
     if delta_h < 48:
         return "Tomorrow"
-    return f"Due {dt.strftime('%m/%d %H:%M')}"
+    return f"Due {dt_utc.strftime('%m/%d %H:%M')}"
 
 
 @dataclass
@@ -137,16 +146,26 @@ def serialize_item(item: CanvasItem) -> str:
     """Serialize a CanvasItem to the trained format the published
     `kleinpanic93/gemma4-canvas-reranker` model expects.
 
-    Format: ``[BADGE] Title @COURSE#### STATUS NNNpts``
+    Format: ``[BADGE] Title @COURSE#### <due-label> NNNpts``
+
+    Mirrors `GemmaReranker/scripts/generate_rerank_data.py:349-372`
+    byte-for-byte. **Note:** the training-side serializer does not
+    consume `status_flags` — it emits only badge / title / course /
+    due-label / points. We do the same here. Submitted/missing items
+    should be filtered out by the consumer **before** calling
+    serialize_item; otherwise they get serialized identically to open
+    items and the model treats them as candidates for prioritization.
 
     The course code is anonymized via SHA-256 → 4-digit modulo so that
     the consumer never sends a real institution-level course identifier
     to the model — matches the training-time anonymization scheme.
 
-    Status is derived from `due_iso` (and `status_flags` for DONE):
-        - DONE if "submitted" in status_flags
-        - OVERDUE if past due
-        - Today / Tomorrow / Due MM/DD HH:MM otherwise
+    Due-date timezone caveat: `_due_label` formats `Due MM/DD HH:MM`
+    in UTC. Training-time data was emitted in the data-collection
+    machine's local timezone (typically EDT). Consumers in other
+    timezones may see a small drift in the `Due ...` token relative to
+    training. The relative tokens (`OVERDUE / Today / Tomorrow`) are
+    timezone-agnostic and unaffected.
 
     Returns a single-line string suitable for embedding in
     RANK_PROMPT_TEMPLATE (see canvas_tui.reranker).
@@ -157,12 +176,9 @@ def serialize_item(item: CanvasItem) -> str:
     parts.append((item.title or "(untitled)")[:45])
     if item.course_code:
         parts.append(f"@{_anonymize_course(item.course_code)}")
-    if "submitted" in (item.status_flags or []):
-        parts.append("DONE")
-    else:
-        label = _due_label(item.due_iso)
-        if label:
-            parts.append(label)
+    label = _due_label(item.due_iso)
+    if label:
+        parts.append(label)
     if item.points:
         parts.append(f"{float(item.points):.0f}pts")
     return " ".join(parts)

--- a/src/canvas_tui/reranker.py
+++ b/src/canvas_tui/reranker.py
@@ -1,0 +1,199 @@
+"""
+canvas_tui.reranker — pluggable reranker for Canvas item priority sort.
+
+Defines:
+
+  RANK_PROMPT_TEMPLATE      — exact prompt text the published model was
+                              trained on (canvas_tui mirrors this byte-
+                              for-byte; SHA below verifies parity).
+  RANK_PROMPT_FORMAT_SHA    — SHA-256 of RANK_PROMPT_TEMPLATE; consumers
+                              of this module assert equality with the
+                              upstream training pipeline's
+                              TRAINING_PROMPT_FORMAT_SHA to fail loudly
+                              on schema drift.
+  Reranker                  — runtime-checkable Protocol all backends
+                              implement.
+  NullReranker              — no-op pass-through (returns items in input
+                              order). Default when cfg.use_ai_reranker
+                              is False.
+  AlwaysAReranker           — test harness: always returns items[0]
+                              first. Useful in tests that need to verify
+                              the urgency-sort dispatch fires.
+  LocalReranker             — production GGUF inference via
+                              llama-cpp-python. SHA-verified at __init__;
+                              reference-differential pointwise scoring at
+                              rank().
+
+The default canvas-tui behaviour with `cfg.use_ai_reranker=False` is
+NullReranker — the AI reranker is opt-in.
+"""
+from __future__ import annotations
+
+import hashlib
+from typing import Protocol, runtime_checkable
+
+from .models.item import CanvasItem, serialize_item
+
+# Mirrors GemmaReranker/scripts/generate_rerank_data.py prompt template
+# verbatim. Whitespace and punctuation matter for SHA parity.
+RANK_PROMPT_TEMPLATE = (
+    "Which Canvas item is more urgent and why?\n\n"
+    "[Query]: {query}\n"
+    "Item A: {item_a}\n"
+    "Item B: {item_b}"
+)
+
+RANK_PROMPT_FORMAT_SHA = hashlib.sha256(
+    RANK_PROMPT_TEMPLATE.encode("utf-8")
+).hexdigest()
+
+
+@runtime_checkable
+class Reranker(Protocol):
+    """Reranker contract — every backend implements this single method."""
+
+    def rank(self, query: str, items: list[CanvasItem]) -> list[CanvasItem]:
+        """Return items sorted by predicted urgency, most urgent first."""
+        ...
+
+
+class NullReranker:
+    """Order-preserving pass-through. Default for `use_ai_reranker=False`."""
+
+    def rank(self, query: str, items: list[CanvasItem]) -> list[CanvasItem]:
+        return list(items)
+
+
+class AlwaysAReranker:
+    """Test harness: items[0] always first. Used in
+    test_integration_sha to prove the urgency dispatch fires."""
+
+    def rank(self, query: str, items: list[CanvasItem]) -> list[CanvasItem]:
+        if not items:
+            return []
+        return [items[0]] + list(items[1:])
+
+
+# ── Pointwise reference item — same constant used in GemmaReranker/
+# scripts/benchmark.py so the LocalReranker.rank() differential
+# scoring matches the offline benchmark harness exactly. Captures a
+# "moderately urgent" anchor against which test items are scored.
+_POINTWISE_REF_ITEM_SERIALIZED = "[ASGN] Reference Assignment @COURSE0000 Due 12/31 23:59 50pts"
+
+
+class LocalReranker:
+    """GGUF-backed reranker via llama-cpp-python.
+
+    Constructor arguments:
+        model_path:    path to a .gguf file (any of the published quants
+                       at huggingface.co/kleinpanic93/gemma4-canvas-reranker)
+        expected_sha:  optional 64-char hex string — if provided, must
+                       equal RANK_PROMPT_FORMAT_SHA or __init__ raises.
+                       Production callers pass
+                       expected_sha=RANK_PROMPT_FORMAT_SHA so any future
+                       template drift fails immediately at startup.
+        n_gpu_layers:  llama.cpp GPU offload knob. -1 = full offload.
+        n_ctx:         context window. 1024 is plenty for two items
+                       plus the rationale.
+
+    Inference path: reference-differential pointwise scoring. For each
+    item, compute logprob_delta = logprob(model says item is more
+    urgent than reference) - logprob(model says reference is more
+    urgent than item), then sort items descending by delta. Same
+    method `GemmaReranker/scripts/benchmark.py:score_item` uses.
+
+    Per the v3 held-out validation, DPO and the QLoRA-merged BF16
+    base produce identical predictions — recommend pointing model_path
+    at gemma4-reranker-Q5_K_M.gguf or smaller (Q4_K_M for browser/edge
+    deployment).
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        expected_sha: str | None = None,
+        n_gpu_layers: int = -1,
+        n_ctx: int = 1024,
+    ) -> None:
+        if expected_sha is not None and expected_sha != RANK_PROMPT_FORMAT_SHA:
+            raise ValueError(
+                f"RANK_PROMPT_FORMAT_SHA mismatch: "
+                f"expected {expected_sha}, got {RANK_PROMPT_FORMAT_SHA}. "
+                "Refusing to load — the trained template and the consumer "
+                "template have drifted; rerunning the data pipeline is "
+                "required."
+            )
+        self.model_path = model_path
+        self._n_gpu_layers = n_gpu_layers
+        self._n_ctx = n_ctx
+        self._llm = None  # lazy: only load when rank() is first called
+
+    def _ensure_loaded(self) -> None:
+        if self._llm is not None:
+            return
+        if not self.model_path:
+            raise NotImplementedError(
+                "LocalReranker constructed with empty model_path; set "
+                "Config.model_path to a downloaded .gguf before enabling "
+                "use_ai_reranker."
+            )
+        try:
+            from llama_cpp import Llama
+        except ImportError as exc:
+            raise ImportError(
+                "LocalReranker requires the [ai] extra. Install with: "
+                "`pip install canvas-tui[ai]` or "
+                "`pip install llama-cpp-python`."
+            ) from exc
+        self._llm = Llama(
+            model_path=self.model_path,
+            n_ctx=self._n_ctx,
+            n_gpu_layers=self._n_gpu_layers,
+            verbose=False,
+            seed=42,
+        )
+
+    def _call_model(self, prompt: str) -> float:
+        """Return logprob of "Item A is more urgent" vs "Item B is more
+        urgent" given the formatted prompt. Positive → A wins,
+        negative → B wins."""
+        self._ensure_loaded()
+        out = self._llm.create_chat_completion(
+            messages=[{"role": "user", "content": prompt}],
+            max_tokens=8,
+            temperature=0.0,
+            logprobs=True,
+        )
+        text = out["choices"][0]["message"]["content"]
+        # Greedy parse of the model's argued winner (matches the
+        # validate_dpo_holdout.py gold extraction strategy).
+        import re
+        m = re.search(r"\bItem\s*([AB])\b", text)
+        if m is None:
+            return 0.0
+        return 1.0 if m.group(1).upper() == "A" else -1.0
+
+    def rank(self, query: str, items: list[CanvasItem]) -> list[CanvasItem]:
+        if not items:
+            return []
+        scores: list[tuple[float, CanvasItem]] = []
+        for item in items:
+            item_serialized = serialize_item(item)
+            # Two-call differential vs the pointwise reference, matching
+            # GemmaReranker/scripts/benchmark.py::score_item's design.
+            prompt_a = RANK_PROMPT_TEMPLATE.format(
+                query=query,
+                item_a=item_serialized,
+                item_b=_POINTWISE_REF_ITEM_SERIALIZED,
+            )
+            prompt_b = RANK_PROMPT_TEMPLATE.format(
+                query=query,
+                item_a=_POINTWISE_REF_ITEM_SERIALIZED,
+                item_b=item_serialized,
+            )
+            lp_a = self._call_model(prompt_a)   # +1 if model picks item-in-slot-A (the test item)
+            lp_b = self._call_model(prompt_b)   # -1 if model picks item-in-slot-B (the test item)
+            score = lp_a - lp_b                  # large positive = item is consistently chosen
+            scores.append((score, item))
+        scores.sort(key=lambda s: s[0], reverse=True)
+        return [item for _, item in scores]

--- a/src/canvas_tui/reranker.py
+++ b/src/canvas_tui/reranker.py
@@ -96,16 +96,27 @@ class LocalReranker:
         n_ctx:         context window. 1024 is plenty for two items
                        plus the rationale.
 
-    Inference path: reference-differential pointwise scoring. For each
-    item, compute logprob_delta = logprob(model says item is more
-    urgent than reference) - logprob(model says reference is more
-    urgent than item), then sort items descending by delta. Same
-    method `GemmaReranker/scripts/benchmark.py:score_item` uses.
+    Inference path: greedy reference-differential winner extraction.
+    For each item, ask the model twice (item-in-slot-A vs reference-in-B,
+    then reverse). Greedy-decode 8 tokens from each, parse the first
+    "Item A"/"Item B" mention, score = +1 if model picked the test
+    item, -1 if it picked the reference, 0 on parse failure. Sort
+    items descending by score.
 
-    Per the v3 held-out validation, DPO and the QLoRA-merged BF16
-    base produce identical predictions — recommend pointing model_path
-    at gemma4-reranker-Q5_K_M.gguf or smaller (Q4_K_M for browser/edge
-    deployment).
+    NOTE: this is NOT the logprob-based pointwise scoring that
+    `GemmaReranker/scripts/benchmark.py::score_item` implements (which
+    extracts the next-token-after-"Item " logits directly). The
+    greedy-extraction approximation here is what the v3 held-out
+    validation actually measures (`source/validate_dpo_holdout.py`
+    in the upstream SSOT repo); both DPO and reference produce
+    identical greedy predictions on 148/148 held-out pairs. A future
+    iteration could swap to true logprob extraction to break ties,
+    but the greedy path is sufficient for the saturated-task regime
+    we're in.
+
+    Recommended quants (per upstream `source/benchmark_quants.py`):
+      - Q5_K_M (3.4 GiB): 98% accuracy, recommended default
+      - Q4_K_M (3.18 GiB): 93% accuracy, edge/browser fallback
     """
 
     def __init__(

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -145,14 +145,44 @@ class TestSerializeItemBridge:
         assert "@COURSE" in out
         assert "CS 3704" not in out and "@CS" not in out
 
-    def test_serialize_uses_done_for_submitted(self):
+    def test_serialize_does_not_consume_status_flags(self):
+        # Mirrors generate_rerank_data.py:349-372 — the training-side
+        # serializer ignores status_flags. Submitted/missing items are
+        # the consumer's responsibility to filter pre-rank.
         item = CanvasItem(
             ptype="quiz", title="q", course_code="CS 1", points=10,
             status_flags=["submitted"],
         )
-        assert "DONE" in serialize_item(item)
+        out = serialize_item(item)
+        assert "DONE" not in out
+        assert "MISSING" not in out
+        assert "LATE" not in out
 
     def test_serialize_omits_points_when_zero(self):
         item = CanvasItem(ptype="event", title="meeting", course_code="X", points=0)
         out = serialize_item(item)
         assert "0pts" not in out
+
+    def test_serialize_overdue_item(self):
+        # An item due in the past (1 year ago) → OVERDUE token.
+        item = CanvasItem(
+            ptype="assignment", title="HW", course_code="CS 1", points=50,
+            due_iso="2025-05-01T12:00:00Z",
+        )
+        out = serialize_item(item)
+        assert "OVERDUE" in out
+
+    def test_serialize_golden_output(self):
+        # Pin one golden serialization. If the format ever changes
+        # (badges, separators, point format, anonymization formula),
+        # this test fails loudly so the consumer-side and the trained
+        # format don't silently drift apart.
+        item = CanvasItem(
+            ptype="assignment", title="Test HW", course_code="CS 3704",
+            points=100, due_iso="2025-05-01T12:00:00Z",
+        )
+        out = serialize_item(item)
+        # Components: badge, title, anonymized course, OVERDUE (past), points
+        assert out.startswith("[ASGN] Test HW @COURSE")
+        assert " OVERDUE " in out
+        assert out.endswith(" 100pts")

--- a/tests/test_reranker.py
+++ b/tests/test_reranker.py
@@ -1,0 +1,158 @@
+"""Tests for canvas_tui.reranker — Protocol compliance + serialize_item bridge.
+
+The 18 tests here mirror the .planning/phases/01.1-01-SUMMARY.md
+acceptance criteria from the upstream phase plan. They do NOT load any
+GGUF model; LocalReranker is exercised at the constructor/SHA-check
+level only.
+"""
+from __future__ import annotations
+
+import pytest
+
+from canvas_tui.models import CanvasItem, serialize_item
+from canvas_tui.reranker import (
+    AlwaysAReranker,
+    LocalReranker,
+    NullReranker,
+    RANK_PROMPT_FORMAT_SHA,
+    RANK_PROMPT_TEMPLATE,
+    Reranker,
+)
+
+
+# ── Protocol compliance ──────────────────────────────────────────────
+
+
+class TestProtocolCompliance:
+    def test_null_reranker_is_reranker(self):
+        assert isinstance(NullReranker(), Reranker)
+
+    def test_always_a_reranker_is_reranker(self):
+        assert isinstance(AlwaysAReranker(), Reranker)
+
+    def test_local_reranker_is_reranker(self):
+        assert isinstance(LocalReranker("/tmp/dummy.gguf"), Reranker)
+
+
+# ── NullReranker ─────────────────────────────────────────────────────
+
+
+class TestNullReranker:
+    def test_returns_list(self):
+        items = [CanvasItem(title="a"), CanvasItem(title="b")]
+        result = NullReranker().rank("any", items)
+        assert isinstance(result, list)
+        assert result is not items  # new list, not same reference
+
+    def test_preserves_all_items(self):
+        items = [CanvasItem(title=t) for t in "xyz"]
+        result = NullReranker().rank("any", items)
+        assert len(result) == 3
+        assert [i.title for i in result] == ["x", "y", "z"]
+
+    def test_empty_input(self):
+        assert NullReranker().rank("any", []) == []
+
+
+# ── AlwaysAReranker ──────────────────────────────────────────────────
+
+
+class TestAlwaysAReranker:
+    def test_first_item_is_first(self):
+        items = [CanvasItem(title="alpha"), CanvasItem(title="beta")]
+        result = AlwaysAReranker().rank("any", items)
+        assert result[0].title == "alpha"
+
+    def test_returns_all_items(self):
+        items = [CanvasItem(title=t) for t in "ABC"]
+        result = AlwaysAReranker().rank("any", items)
+        assert {i.title for i in result} == {"A", "B", "C"}
+
+
+# ── LocalReranker skeleton ───────────────────────────────────────────
+
+
+class TestLocalRerankerSkeleton:
+    def test_call_model_raises_without_dep_or_model(self):
+        # Empty model_path → NotImplementedError on first inference.
+        r = LocalReranker("")
+        with pytest.raises(NotImplementedError):
+            r.rank("any", [CanvasItem(title="x")])
+
+    def test_sha_mismatch_raises(self):
+        with pytest.raises(ValueError, match="SHA"):
+            LocalReranker("/tmp/x.gguf", expected_sha="0" * 64)
+
+    def test_sha_match_no_raise(self):
+        # Constructing with the correct SHA must not raise.
+        LocalReranker("/tmp/x.gguf", expected_sha=RANK_PROMPT_FORMAT_SHA)
+
+
+# ── SHA anti-drift ───────────────────────────────────────────────────
+
+
+class TestSHAAntiDrift:
+    def test_sha_is_64_chars(self):
+        assert len(RANK_PROMPT_FORMAT_SHA) == 64
+
+    def test_sha_is_hex(self):
+        int(RANK_PROMPT_FORMAT_SHA, 16)  # raises if non-hex
+
+    def test_sha_matches_expected(self):
+        # If the trained template ever changes, this constant changes
+        # and consumers asserting against the upstream training pipeline
+        # SHA will fail loudly. Update this constant only when the
+        # model is also retrained on the new template.
+        import hashlib
+        expected = hashlib.sha256(RANK_PROMPT_TEMPLATE.encode("utf-8")).hexdigest()
+        assert RANK_PROMPT_FORMAT_SHA == expected
+
+    def test_sha_changes_on_template_change(self):
+        # Sanity: a single-character change must produce a different hash.
+        import hashlib
+        modified = RANK_PROMPT_TEMPLATE + "."
+        sha2 = hashlib.sha256(modified.encode("utf-8")).hexdigest()
+        assert sha2 != RANK_PROMPT_FORMAT_SHA
+
+
+# ── serialize_item bridge ────────────────────────────────────────────
+
+
+class TestSerializeItemBridge:
+    def test_serialize_returns_string(self):
+        item = CanvasItem(ptype="assignment", title="HW", course_code="CS 3704", points=100)
+        result = serialize_item(item)
+        assert isinstance(result, str)
+        assert len(result) > 0
+
+    def test_serialize_contains_title(self):
+        item = CanvasItem(ptype="assignment", title="UnitTestTitle", course_code="C", points=10)
+        assert "UnitTestTitle" in serialize_item(item)
+
+    def test_serialize_reachable_from_models(self):
+        # The Phase 01.1-01 SUMMARY explicitly requires re-export
+        # from canvas_tui.models — the same import path the training
+        # pipeline uses.
+        from canvas_tui.models import serialize_item as si
+        assert si is serialize_item
+
+    def test_serialize_anonymizes_course_code(self):
+        # The trained model expects @COURSE#### not real codes; the
+        # anonymizer is deterministic so the same course always maps
+        # to the same opaque ID.
+        item = CanvasItem(ptype="assignment", title="x", course_code="CS 3704", points=1)
+        out = serialize_item(item)
+        assert "@COURSE" in out
+        assert "CS 3704" not in out and "@CS" not in out
+
+    def test_serialize_uses_done_for_submitted(self):
+        item = CanvasItem(
+            ptype="quiz", title="q", course_code="CS 1", points=10,
+            status_flags=["submitted"],
+        )
+        assert "DONE" in serialize_item(item)
+
+    def test_serialize_omits_points_when_zero(self):
+        item = CanvasItem(ptype="event", title="meeting", course_code="X", points=0)
+        out = serialize_item(item)
+        assert "0pts" not in out


### PR DESCRIPTION
## Summary

This PR lands several integrated pieces of work that together restore + advance the Canvas reranker integration:

1. **Phase 01.1 reranker (Python TUI)** — re-implements the integration contract lost in the 2026-05-01 /tmp wipe. Reranker Protocol + serialize_item bridge + LocalReranker + 23 tests.
2. **Phase 01.1 reranker (browser extension JS)** — same prompt contract + Ollama backend with NullReranker fallback.
3. **GemmaReranker pipeline sync** — all latest training/bench/audit/publish scripts from the SSOT repo (\`CS3704-DPO-SSOT\`) synced into \`GemmaReranker/scripts/\`. Now teammate-runnable end-to-end.
4. **Agent skeleton** — \`src/canvas_tui/agent/\` with neuroscience-grounded system prompt + 14 tool definitions (canvas / calendar / reranker / study) for the v2 specialized calendar agent.
5. **v2 trajectory collector** — \`GemmaReranker/scripts/collect_trajectories.py\` so teammates can build the v2 SFT corpus.
6. **README updates** — top-level README + GemmaReranker README updated with HF Collection + variant repo links.

## Published artifacts (v1)

- 🤗 [Model: kleinpanic93/gemma4-canvas-reranker](https://huggingface.co/kleinpanic93/gemma4-canvas-reranker) — 4 GGUF quants (Q4_K_M / Q5_K_M / Q8_0 / f16) + BF16 + paper PDF + held-out validation JSON
- 🤗 [Dataset: kleinpanic93/canvas-preference-2k](https://huggingface.co/datasets/kleinpanic93/canvas-preference-2k) — 1,347 unique pairs with preference-signal annotation
- 🤗 [Collection: Canvas Reranker — Gemma-4-E2B-IT v1.0](https://huggingface.co/collections/kleinpanic93/canvas-reranker-gemma-4-e2b-it-v10-69f5799662d65c8f39be0a94)

## v1 → v2 trajectory

v1 ships a fast preference-hint reranker (heuristic-recovering by construction) usable by any consumer. The v2 design (in flight) is a **specialized calendar+study agent** with tool calls (Canvas + Google Cal/Outlook/calcurses) and neuroscience-grounded study scheduling — replacing the preference-pair primitive with proper agent reasoning. The agent skeleton + tool definitions + trajectory collector in this PR are v2 infrastructure; the v2 trained model is the next milestone (gated on multi-contributor data collection).

## Test plan

- [x] \`pytest tests/test_reranker.py -x\` (23 passed in 0.03s)
- [x] Reranker Protocol smoke (NullReranker / AlwaysAReranker / LocalReranker constructor)
- [x] SHA cross-project parity (RANK_PROMPT_FORMAT_SHA matches GemmaReranker training-side SHA)
- [ ] Manual: pull a quant via Ollama, set \`cfg.use_ai_reranker=true\`, verify \`LocalReranker\` loads + ranks
- [ ] Manual: load extension, verify \`makeReranker({useAi: true})\` returns \`OllamaReranker\` when Ollama is up
- [ ] V2 followup: 200-500 trajectories collected from 3-5 contributors via \`collect_trajectories.py\`

🤖 Generated with [Claude Code](https://claude.com/claude-code) under autonomous mode