### PR TITLE
fix: remove private endpoint from collect_trajectories, simplify docs

### DIFF
--- a/CONTRIBUTING-DATA.md
+++ b/CONTRIBUTING-DATA.md
@@ -1,107 +1,36 @@
-# Contributing Trajectory Data
+# Contributing Your Canvas Data
 
-This guide is for CS3704 teammates who want to add their Canvas interaction data to the v2 training dataset. You do **not** need to understand the ML pipeline — just run a script and share the output.
+## What you need
 
----
+- Your VT Canvas API token
+- Python 3.11+
+- The repo cloned with `pip install -e .` run from the root
 
-## What this does
+## Steps
 
-`scripts/collect_trajectories.py` calls a teacher LLM with your Canvas data attached as context, records how it reasons through calendar and assignment questions, and saves those reasoning traces as anonymized JSONL. Your real name, course IDs, and assignment names never appear in the output — they're hashed or replaced with placeholders before write.
+**1. Get your Canvas token**
 
----
+Go to canvas.vt.edu → Account → Settings → Approved Integrations → New Access Token.
 
-## Quick start (5 minutes)
-
-### Step 1 — Get your Canvas API token
-
-1. Log into [canvas.vt.edu](https://canvas.vt.edu)
-2. Click your profile picture → **Account** → **Settings**
-3. Scroll to **Approved Integrations** → **+ New Access Token**
-4. Give it a name (e.g. `cs3704-data`), no expiry needed, click **Generate Token**
-5. Copy the token — you'll only see it once
-
-### Step 2 — Clone the repo and install
+**2. Run the collection script**
 
 ```bash
-git clone https://github.com/kleinpanic/CS3704-Canvas-Project.git
-cd CS3704-Canvas-Project
-pip install -e .
-```
-
-### Step 3 — Run the collector
-
-Replace `yourhandle` with your PID or GitHub username (used only for attribution, never stored alongside your data).
-
-**Option A — Using your own OpenAI key** (easiest, costs ~$0.02 per run with gpt-4o-mini):
-
-```bash
-export CANVAS_TOKEN=<your Canvas token from Step 1>
+export CANVAS_TOKEN=your_token_here
 export CANVAS_BASE_URL=https://canvas.vt.edu
 export TEACHER_ENDPOINT=https://api.openai.com/v1
-export OPENAI_API_KEY=<your OpenAI key>
+export OPENAI_API_KEY=your_openai_key
 
 python3 scripts/collect_trajectories.py \
-    --contributor yourhandle \
-    --output data/trajectories/collab/yourhandle_trajectories.jsonl \
-    --model gpt-4o-mini \
-    --max-trajectories 20
+    --contributor yourpid \
+    --output data/trajectories/collab/yourpid.jsonl
 ```
 
-**Option B — On the VT campus network or VPN** (uses the lab's Spark, no API key needed):
+Replace `yourpid` with your VT PID or any handle. Your name and course info are anonymized before the file is written.
 
-```bash
-export CANVAS_TOKEN=<your Canvas token>
-export CANVAS_BASE_URL=https://canvas.vt.edu
+**3. Submit your file**
 
-python3 scripts/collect_trajectories.py \
-    --contributor yourhandle \
-    --output data/trajectories/collab/yourhandle_trajectories.jsonl \
-    --max-trajectories 20
-```
+Option A — open a PR adding `data/trajectories/collab/yourpid.jsonl`.
 
-### Step 4 — Submit your data
+Option B — email the file to rodie105@gmail.com with subject `[CS3704] data - yourpid`.
 
-**Path A — GitHub PR** (preferred if you know git):
-
-1. Fork the repo, add your `data/trajectories/collab/yourhandle_trajectories.jsonl`, open a PR to `main`
-2. You don't need signed commits for data-only PRs — just push and open the PR
-
-**Path B — Email** (if you don't want to deal with GitHub):
-
-Email `rodie105@gmail.com` with subject `[CS3704] trajectory data - yourhandle` and attach your `.jsonl` file. Klein will add it manually with your contributor ID.
-
----
-
-## What gets anonymized
-
-The script runs `anonymize_record()` before writing anything:
-
-| Original | Replaced with |
-|---|---|
-| Course names/codes | `COURSE1`, `COURSE2`, … |
-| Assignment titles | deterministic hash |
-| Your name in Canvas | deterministic hash |
-| Dates | kept (needed for scheduling queries) |
-
-Your Canvas token is **never** written to the output file.
-
----
-
-## Troubleshooting
-
-**`ModuleNotFoundError: canvas_tui`** — run `pip install -e .` from the repo root first.
-
-**`ConnectionRefusedError` on spark.local** — you're off-campus without VPN. Use Option A (OpenAI key) or email the request to Klein.
-
-**`401 Unauthorized` from Canvas** — your token expired or was copied wrong. Regenerate it in Canvas Settings.
-
-**Script runs but output file is empty** — Canvas returned no courses for the current term. Check that your token points to an active enrollment.
-
----
-
-## Requirements
-
-- Python 3.11+
-- `requests` (installed by `pip install -e .`)
-- A VT Canvas account with active courses
-- Either: OpenAI API key **or** access to `spark.local:18080` (campus network / VPN)
+That's it. Klein handles the rest.

--- a/scripts/collect_trajectories.py
+++ b/scripts/collect_trajectories.py
@@ -2,10 +2,9 @@
 collect_trajectories.py — teammate-runnable v2 trajectory collector.
 
 Purpose: build the v2 calendar-agent training dataset by replaying a fixed
-set of canonical user queries against a teacher LLM (Nemotron-120B at
-Spark slot0:18080 by default) with the canvas-tui agent's tool surface
-exposed for function-calling. Captures the full tool-call trajectory
-(tool calls + tool results + final answer) per query.
+set of canonical user queries against a teacher LLM with the canvas-tui
+agent's tool surface exposed for function-calling. Captures the full
+tool-call trajectory (tool calls + tool results + final answer) per query.
 
 This is the v2 analogue of the v1 generate_dataset.py / collect_rerank_
 dataset.py preference collectors. Same anonymization pipeline; same
@@ -15,11 +14,15 @@ Usage (from repo root, with canvas_sdk installed and a Canvas API token):
 
     export CANVAS_TOKEN=...
     export CANVAS_BASE_URL=https://canvas.vt.edu
-    export TEACHER_ENDPOINT=http://spark.local:18080/v1   # optional
+    export TEACHER_ENDPOINT=https://api.openai.com/v1
+    export OPENAI_API_KEY=...
     python3 scripts/collect_trajectories.py \
         --contributor alice \
         --output data/trajectories/collab/alice_trajectories.jsonl \
         --max-trajectories 20
+
+TEACHER_ENDPOINT must be set — any OpenAI-compatible API works
+(OpenAI, Together AI, Groq, Ollama, etc.).
 
 The output JSONL is the v2 SFT corpus. Each line is one trajectory:
     {user_query, context, trajectory[], teacher_model, contributor_id}
@@ -181,7 +184,7 @@ def anonymize_record(rec: dict, contributor_salt: str) -> dict:
     return json.loads(text)
 
 
-# ── Teacher interaction (Nemotron-120B at slot0:18080 by default) ────────────
+# ── Teacher interaction ───────────────────────────────────────────────────────
 
 def call_teacher(messages: list[dict], tools: list[dict], endpoint: str, model: str) -> dict:
     """Make one tool-aware call to the teacher. Returns the full response
@@ -333,8 +336,16 @@ def main():
     p.add_argument("--contributor", required=True, help="Contributor ID (used as anonymization salt; e.g. 'alice')")
     p.add_argument("--queries", help="File of queries, one per line. Default: built-in CANONICAL_QUERIES.")
     p.add_argument("--output", required=True, help="Output JSONL path.")
-    p.add_argument("--endpoint", default=os.environ.get("TEACHER_ENDPOINT", "http://localhost:18080/v1"))
-    p.add_argument("--model", default=os.environ.get("TEACHER_MODEL", "nvidia/Gemma-4-31B-IT-NVFP4"))
+    _ep = os.environ.get("TEACHER_ENDPOINT")
+    if not _ep:
+        print("ERROR: TEACHER_ENDPOINT is not set.\n"
+              "Set it to any OpenAI-compatible API, e.g.:\n"
+              "  export TEACHER_ENDPOINT=https://api.openai.com/v1\n"
+              "  export OPENAI_API_KEY=...\n"
+              "See CONTRIBUTING-DATA.md for full setup instructions.")
+        sys.exit(1)
+    p.add_argument("--endpoint", default=_ep)
+    p.add_argument("--model", default=os.environ.get("TEACHER_MODEL", "gpt-4o-mini"))
     p.add_argument("--max-trajectories", type=int, default=20)
     p.add_argument("--anonymize", default=True, action="store_true")
     args = p.parse_args()


### PR DESCRIPTION
#no-coverage-check

Removes private server URL that leaked to classmates running the script. Simplifies CONTRIBUTING-DATA.md to 3 steps.