### PR TITLE
test: add test suite for share_my_canvas.py

### DIFF
--- a/scripts/data-collection/share_my_canvas.py
+++ b/scripts/data-collection/share_my_canvas.py
@@ -79,13 +79,21 @@ def _anon_course(code: str) -> str:
 
 
 def anonymize(obj: object, salt: str) -> object:
+    def _walk(o):
+        if isinstance(o, dict):
+            return {k: _walk(v) for k, v in o.items()}
+        if isinstance(o, list):
+            return [_walk(v) for v in o]
+        if isinstance(o, int):
+            s = str(o)
+            if re.match(r"[1-9]\d{6,8}$", s):
+                return _hash(salt, s)
+        if isinstance(o, str):
+            o = re.sub(r"\b([1-9]\d{6,8})\b", lambda m: _hash(salt, m.group(1)), o)
+        return o
+
+    obj = _walk(obj)
     text = json.dumps(obj, default=str)
-    # Canvas numeric IDs
-    text = re.sub(
-        r"\b([1-9]\d{6,8})\b",
-        lambda m: _hash(salt, m.group(1)),
-        text,
-    )
     # Course codes like "CS 3704", "ENGL2204"
     text = re.sub(
         r"\b([A-Z]{2,5})\s*(\d{3,4}[A-Z]?)\b",

--- a/tests/test_share_my_canvas.py
+++ b/tests/test_share_my_canvas.py
@@ -1,0 +1,154 @@
+"""
+Tests for scripts/data-collection/share_my_canvas.py
+
+Verifies the anonymization logic, output format, and error handling
+without making any real Canvas API calls.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import unittest.mock as mock
+from pathlib import Path
+
+import pytest
+
+# Add data-collection dir to path
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "data-collection"))
+
+import share_my_canvas  # noqa: E402
+
+
+# ── Anonymization ─────────────────────────────────────────────────────────────
+
+def test_hash_is_deterministic():
+    h1 = share_my_canvas._hash("salt", "12345678")
+    h2 = share_my_canvas._hash("salt", "12345678")
+    assert h1 == h2
+
+
+def test_hash_differs_by_salt():
+    h1 = share_my_canvas._hash("salt_a", "12345678")
+    h2 = share_my_canvas._hash("salt_b", "12345678")
+    assert h1 != h2
+
+
+def test_hash_format():
+    result = share_my_canvas._hash("x", "999")
+    assert result.startswith("ID")
+    assert result[2:].isdigit()
+
+
+def test_anon_course_mapping():
+    share_my_canvas._COURSE_MAP.clear()
+    share_my_canvas._COURSE_CTR[0] = 0
+    c1 = share_my_canvas._anon_course("CS 3704")
+    c2 = share_my_canvas._anon_course("ENGL 2204")
+    c3 = share_my_canvas._anon_course("CS 3704")  # repeat
+    assert c1 == "COURSE1"
+    assert c2 == "COURSE2"
+    assert c1 == c3  # same course → same anon code
+
+
+def test_anonymize_strips_canvas_ids():
+    share_my_canvas._COURSE_MAP.clear()
+    share_my_canvas._COURSE_CTR[0] = 0
+    obj = {"id": 12345678, "name": "Test Assignment"}
+    result = share_my_canvas.anonymize(obj, "testsalt")
+    out = json.dumps(result)
+    assert "12345678" not in out
+    assert "ID" in out
+
+
+def test_anonymize_strips_course_codes():
+    share_my_canvas._COURSE_MAP.clear()
+    share_my_canvas._COURSE_CTR[0] = 0
+    obj = {"course": "CS 3704 Software Engineering"}
+    result = share_my_canvas.anonymize(obj, "salt")
+    out = json.dumps(result)
+    assert "CS 3704" not in out
+    assert "COURSE" in out
+
+
+def test_anonymize_preserves_dates():
+    share_my_canvas._COURSE_MAP.clear()
+    share_my_canvas._COURSE_CTR[0] = 0
+    obj = {"due_at": "2026-05-10T23:59:00Z", "points": 100}
+    result = share_my_canvas.anonymize(obj, "salt")
+    assert result["due_at"] == "2026-05-10T23:59:00Z"
+    assert result["points"] == 100
+
+
+# ── CLI / env guard ───────────────────────────────────────────────────────────
+
+def test_missing_token_exits(monkeypatch):
+    monkeypatch.delenv("CANVAS_TOKEN", raising=False)
+    with pytest.raises(SystemExit) as exc:
+        share_my_canvas._token()
+    assert exc.value.code == 1
+
+
+def test_token_returned_from_env(monkeypatch):
+    monkeypatch.setenv("CANVAS_TOKEN", "test-abc-123")
+    assert share_my_canvas._token() == "test-abc-123"
+
+
+# ── collect() — mocked HTTP ───────────────────────────────────────────────────
+
+FAKE_COURSES = [
+    {"id": 98765432, "name": "CS 3704 Software Engineering", "course_code": "CS3704"},
+]
+FAKE_ASSIGNMENTS = [
+    {"name": "Homework 1", "due_at": "2026-05-15T23:59:00Z",
+     "points_possible": 100, "submission_types": ["online_upload"]},
+]
+FAKE_TODOS = [
+    {"type": "submitting", "assignment": {"name": "Homework 1", "due_at": "2026-05-15T23:59:00Z"},
+     "course_id": 98765432},
+]
+
+
+def _mock_get(path, params=None):
+    if path == "/courses":
+        return FAKE_COURSES
+    if "/assignments" in path:
+        return FAKE_ASSIGNMENTS
+    if path == "/users/self/todo_items":
+        return FAKE_TODOS
+    return []
+
+
+def test_collect_produces_anonymized_records(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANVAS_TOKEN", "fake-token")
+    monkeypatch.setattr(share_my_canvas, "_get", _mock_get)
+    share_my_canvas._COURSE_MAP.clear()
+    share_my_canvas._COURSE_CTR[0] = 0
+
+    records = share_my_canvas.collect("testuser")
+
+    assert len(records) >= 1
+    dumped = json.dumps(records)
+    assert "98765432" not in dumped, "Canvas ID should be anonymized"
+    assert "CS 3704" not in dumped, "Course code should be anonymized"
+    assert "testuser" in dumped, "Contributor ID should be present"
+
+
+def test_collect_writes_jsonl(monkeypatch, tmp_path):
+    monkeypatch.setenv("CANVAS_TOKEN", "fake-token")
+    monkeypatch.setattr(share_my_canvas, "_get", _mock_get)
+    share_my_canvas._COURSE_MAP.clear()
+    share_my_canvas._COURSE_CTR[0] = 0
+
+    out_file = tmp_path / "testuser.jsonl"
+    records = share_my_canvas.collect("testuser")
+    with open(out_file, "w") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+    lines = out_file.read_text().strip().splitlines()
+    assert len(lines) >= 1
+    for line in lines:
+        obj = json.loads(line)
+        assert "type" in obj
+        assert "contributor_id" in obj

--- a/tests/test_share_my_canvas.py
+++ b/tests/test_share_my_canvas.py
@@ -7,9 +7,7 @@ without making any real Canvas API calls.
 from __future__ import annotations
 
 import json
-import os
 import sys
-import unittest.mock as mock
 from pathlib import Path
 
 import pytest


### PR DESCRIPTION
Adds 11 tests covering anonymization logic, env guard, CLI error on missing token, and mocked Canvas API collection. Zero real HTTP calls.

Fixes a bug in anonymize() where integer Canvas IDs serialized as bare JSON numbers produced invalid JSON after regex substitution. Fix: recursive object-tree walk hashes int IDs in-place before json.dumps().

#no-coverage-check — canvas_tui coverage is pre-existing at 39%; this PR only adds tests for scripts/data-collection/share_my_canvas.py which is outside that measurement scope.