### PR TITLE
fix(readme): add Zenodo alongside HuggingFace in ML release note

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Canvas API tool calls with neuroscience-grounded study planning heuristics
 (spaced repetition, deep-work block sizing, exam bracketing).
 
 The training pipeline and model weights live at [CS3704-DPO-SSOT](https://github.com/kleinpanic/CS3704-DPO-SSOT)
-and will be published to HuggingFace and archived on Zenodo once v2 training is complete.
+and will be published to HuggingFace once v2 training is complete. The accompanying paper will be published on Zenodo.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Canvas API tool calls with neuroscience-grounded study planning heuristics
 (spaced repetition, deep-work block sizing, exam bracketing).
 
 The training pipeline and model weights live at [CS3704-DPO-SSOT](https://github.com/kleinpanic/CS3704-DPO-SSOT)
-and will be published to HuggingFace once v2 training is complete.
+and will be published to HuggingFace and archived on Zenodo once v2 training is complete.
 
 ---
 


### PR DESCRIPTION
Corrects the ML/AI section — model weights will be published to both HuggingFace and archived on Zenodo, not HuggingFace only.