### PR TITLE
fix(scripts): anonymize course_code to prevent CRN exposure

### DIFF
--- a/scripts/share_my_canvas.py
+++ b/scripts/share_my_canvas.py
@@ -202,10 +202,15 @@ def collect(contributor: str) -> list[dict]:
         if not asgn_records:
             continue  # skip courses with nothing plannable
 
+        # Anonymize course_code explicitly — VT CRN format (CS_3704_21936_202601)
+        # is not caught by the regex in anonymize() because underscores block \b.
+        _raw_code = course.get("course_code", "")
+        _m = re.search(r"[A-Z]{2,5}\s*\d{3,4}[A-Z]?", _raw_code)
+        _code_key = _m.group(0) if _m else _raw_code
         records.append({
             "type": "course_snapshot",
             "course_name": cname,
-            "course_code": course.get("course_code", ""),
+            "course_code": _anon_course(_code_key) if _code_key else "",
             "term": term,
             "assignments": asgn_records,
             "contributor_id": contributor,


### PR DESCRIPTION
## Summary

- Fixes a privacy bug where VT CRN-format course codes (`CS_3704_21936_202601`) were written raw into `course_snapshot` records despite the anonymization pass
- Root cause: `anonymize()` uses `\b` regex anchors that don't fire when underscores surround the course prefix — so `CS_3704_21936_202601` was never matched
- Fix: explicitly extract the short code (`CS 3704`) before building the record and map it through `_anon_course()`, consistent with how `course_name` gets anonymized

## Test plan

- [ ] Verify `course_code` values in output JSONL are `@COURSE1`, `@COURSE2`, etc. — not raw CRNs
- [ ] Verify `course_name` and `course_code` map to the same `@COURSE` token for the same course
- [ ] Re-run `share_my_canvas.py` on a test account and confirm no raw course codes in output

## Context

Found during cross-AI review of PR #76 (Williammm23 contribution). 31 of 34 records in that contribution exposed raw VT CRN codes. This fix must be merged before Will re-submits his contribution.