### PR TITLE
chore: bump version to 1.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-tui"
-version = "1.1.0"
+version = "1.1.1"
 description = "Canvas LMS TUI client for the CS3704 Canvas project"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Bumps pyproject.toml version from 1.1.0 to 1.1.1. Part of the v1.1.1 release process.