### PR TITLE
chore: CODEOWNERS + tighter stale PR policy

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,8 @@ jobs:
           stale-pr-message: "This PR has gone stale due to inactivity. Update it if it is still active."
           close-issue-message: "Closing stale issue after extended inactivity."
           close-pr-message: "Closing stale PR after extended inactivity."
-          days-before-stale: 21
+          days-before-stale: 14
           days-before-close: 7
           exempt-issue-labels: "security,pinned"
           exempt-pr-labels: "security,pinned"
+          start-date: "2026-01-01"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,19 @@
+# Canvas TUI ownership
+
+# Code owner review required for these paths
+/.github/workflows/       @kleinpanic
+/pyproject.toml           @kleinpanic
+/CHANGELOG.md             @kleinpanic
+
+# Extension
+/extension/               @Williammm23
+
+# SDK
+/sdk/                     @kleinpanic
+
+# Docs
+/docs-site/               @pjie22
+/docs/                    @pjie22
+
+# Tests
+/tests/                   @802797liu


### PR DESCRIPTION
## Changes

- **CODEOWNERS**: Added ownership routing:
  - Workflows/pyproject.toml/CHANGELOG → kleinpanic
  - Extension → Williammm23
  - SDK → kleinpanic
  - Docs → pjie22
  - Tests → 802797liu

- **Stale workflow**: Tightened from 21→14 days before stale, added start-date to avoid flagging pre-2026 items

## Testing
- [x] CI passes
- [x] Branch name policy passes
- [x] No breaking changes

## Checklist
- [x] PR is small enough for admin merge
- [x] no-coverage-check tag available