### PR TITLE
docs: CS3704-REFACTOR project initialization and codebase mapping

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,61 @@
+# CS3704-REFACTOR - Canvas SDK Refactoring Project
+
+## What This Is
+
+Brownfield Python monorepo containing a Canvas LMS TUI application (`canvas_tui`) and a Canvas SDK (`canvas_sdk`). The project is being refactored to improve code organization, consolidate duplicate API clients, improve test coverage, and enhance CI/CD.
+
+## Core Value
+
+Consolidate the two parallel Canvas API clients into a single, well-tested SDK that serves both the TUI and any future consumers, with comprehensive test coverage and robust CI/CD.
+
+## Requirements
+
+### Validated
+
+(None yet — ship to validate)
+
+### Active
+
+- [ ] Move `sdk/canvas_sdk/` into `src/canvas_sdk/` to consolidate monorepo structure
+- [ ] Consolidate the two parallel Canvas API clients (src/canvas_tui/api.py and sdk/canvas_sdk/canvas.py)
+- [ ] Improve SDK test coverage with unit and integration tests
+- [ ] Enhance CI/CD pipeline with automated testing and deployment
+
+### Out of Scope
+
+- [Breaking changes to TUI public API] — TUI refactoring is out of scope for this phase; consolidate SDK first
+- [New features] — No new Canvas API features; this is a structural refactor
+- [Documentation rewrite] — Existing docs are sufficient; focus on code structure
+
+## Context
+
+**Current codebase structure:**
+- `src/canvas_tui/` — Terminal UI application with its own Canvas API client (`api.py`)
+- `sdk/canvas_sdk/` — Official Canvas SDK with class-based API clients (`canvas.py`, `canvas_object.py`)
+- `tests/` — Pytest-based test suite for TUI components
+- `extension/` — Browser extension with its own `canvas-client.js`
+- Parallel Canvas API clients create maintenance burden and potential inconsistencies
+
+**Key technical observations:**
+1. `src/canvas_tui/api.py` has ~344 lines with custom retry logic, rate-limit handling, caching
+2. `sdk/canvas_sdk/canvas.py` has ~1310 lines with a `Requester` class and `PaginatedList` pattern
+3. Duplicate Canvas API functionality across both clients
+4. SDK tests only cover `agent_tools/` subdirectory; broader SDK coverage needed
+
+## Constraints
+
+- **Tech Stack**: Python 3.13+, pytest, requests library — maintain compatibility
+- **Backward Compatibility**: TUI must continue to function after SDK consolidation
+- **Git History**: Preserve commit history during file moves via `git mv`
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Move SDK into src/ | Consolidate monorepo, single import path | — Pending |
+| Consolidate API clients | Eliminate duplicate code, single source of truth | — Pending |
+| Focus on test coverage | Ensure refactored code is well-tested | — Pending |
+
+---
+
+*Last updated: 2026-05-05 after initialization*

--- a/.planning/codebase/ARCHITECTURE.md
+++ b/.planning/codebase/ARCHITECTURE.md
@@ -1,0 +1,121 @@
+# Architecture
+
+**Analysis Date:** 2026-05-05
+
+## Pattern Overview
+
+**Overall:** Layered Python Monorepo with Two Entry Points
+
+**Key Characteristics:**
+- Two independent executables share the Canvas SDK: TUI (`canvas-tui` CLI) and SDK (pip-installed)
+- SDK is the canonical source for Canvas API data models and operations
+- TUI adds a Textual-based terminal UI layer on top of the SDK
+- Extension (`extension/`) is a separate JavaScript browser extension
+- Monorepo with separate package manifests: `pyproject.toml` (TUI) and `sdk/pyproject.toml` (SDK)
+
+## Layers
+
+**SDK Layer (`sdk/canvas_sdk/`):**
+- Purpose: Canonical Canvas API client — handles auth, HTTP, pagination, data models
+- Contains: `canvas.py` (entry), `requester.py` (HTTP), `canvas_object.py` (data models), 50+ API endpoint modules
+- Depends on: `requests`, `urllib3`
+- Used by: TUI, external consumers via pip install
+
+**TUI Layer (`src/canvas_tui/`):**
+- Purpose: Terminal UI application built on Textual
+- Contains: Screens (`screens/`), widgets (`widgets/`), agent tools (`agent/tools/`), adapters (`adapters/`)
+- Depends on: SDK (imports `canvas_sdk.*`), Textual, caching layer
+- Used by: End user CLI (`canvas-tui`)
+
+**Duplicate API Client (`src/canvas_tui/api.py`):**
+- Purpose: TUI-specific Canvas API client with custom retry + caching (standalone, does NOT use SDK)
+- Contains: `CanvasAPI` class (~344 lines) — handles retries, rate limits, caching
+- Note: This is the duplicate client that Phase 2 of the refactor consolidates into the SDK
+- Location: `src/canvas_tui/api.py` — planned for deletion in Phase 3
+
+## Data Flow
+
+**TUI Execution (current, pre-refactor):**
+
+1. User runs `canvas-tui` → `src/canvas_tui/app.py` → Textual app boots
+2. `app.py` instantiates `CanvasAPI` from `src/canvas_tui/api.py` (direct API client, not SDK)
+3. `CanvasAPI.get()` fetches from Canvas REST API with retry + rate-limit awareness
+4. Response cached in `src/canvas_tui/cache.py` (disk-backed SQLite)
+5. TUI screens render data from `CanvasAPI` + local state
+
+**SDK Execution (target, post-refactor):**
+
+1. User runs `canvas-tui` → `src/canvas_tui/app.py` → Textual app boots
+2. `app.py` instantiates `Canvas` from `canvas_sdk.canvas` (consolidated SDK)
+3. `Canvas` uses `requester.py` for HTTP operations
+4. `client.py` (consolidated from `api.py`) handles retry + rate-limit + caching
+5. TUI screens render data from `Canvas` + local state
+
+**Key Abstraction: PaginatedList**
+
+- `canvas_sdk/paginated_list.py` — Lazy paginated iteration over Canvas API list endpoints
+- Pattern: Generator yielding items one-by-one, auto-fetches next page as needed
+- Used by: All SDK endpoint methods (courses, assignments, users, etc.)
+
+## Key Abstractions
+
+**CanvasAPI (TUI layer):**
+- Purpose: TUI-specific HTTP client with caching + retry
+- Location: `src/canvas_tui/api.py`
+- Pattern: Custom class wrapping `requests.Session`
+- Note: Planned for removal in Phase 3 (consolidate into SDK)
+
+**Canvas + Requester (SDK layer):**
+- Purpose: SDK entry point + low-level HTTP transport
+- Locations: `sdk/canvas_sdk/canvas.py`, `sdk/canvas_sdk/requester.py`
+- Pattern: `Canvas` class orchestrates; `Requester` handles HTTP
+
+**PaginatedList:**
+- Purpose: Lazy pagination for Canvas list endpoints
+- Location: `sdk/canvas_sdk/paginated_list.py`
+- Pattern: Iterator protocol, auto-fetches pages on demand
+
+**CanvasObject:**
+- Purpose: Base class for all Canvas data model classes
+- Location: `sdk/canvas_sdk/canvas_object.py`
+- Pattern: Dataclass-like with `_setattrs` for API response hydration
+
+## Entry Points
+
+**TUI CLI:**
+- Location: `src/canvas_tui/__main__.py` (via `canvas-tui` entry point)
+- Triggers: User runs `canvas-tui` in terminal
+- Responsibilities: Parse CLI args, launch Textual app
+
+**SDK Import:**
+- Location: `sdk/canvas_sdk/__init__.py`
+- Triggers: `from canvas_sdk.canvas import Canvas` in any Python code
+- Responsibilities: Package exports for pip-installable SDK
+
+## Error Handling
+
+**Strategy:** Exception hierarchy in `canvas_sdk/exceptions.py`
+
+**Patterns:**
+- `RequiredFieldMissing`, `BadRequest`, `Unauthorized`, `Forbidden`, `ResourceDoesNotExist`, `RateLimitExceeded`, `UnprocessableEntity`, `InvalidAccessToken`, `CanvasException`
+- TUI's `api.py` raises generic `Exception` with string messages (pre-consolidation)
+- SDK raises typed subclasses from `canvas_sdk.exceptions`
+
+## Cross-Cutting Concerns
+
+**Logging:**
+- Uses Python `logging` module (logger instances in each module)
+- No structured logging framework
+
+**Caching:**
+- TUI: `src/canvas_tui/cache.py` — disk-backed SQLite cache with TTL
+- SDK: Memory-only `_cache` list in `Requester` class (no persistent cache)
+
+**Retry:**
+- TUI `api.py`: Uses `urllib3.util.retry.Retry` configured with `status_forcelist=(429,500,502,503,504)`
+- SDK `requester.py`: Custom `_retry_request()` method with manual retry logic (not urllib3)
+
+---
+
+*Architecture analysis: 2026-05-05*
+*Update when major patterns change*

--- a/.planning/codebase/CONCERNS.md
+++ b/.planning/codebase/CONCERNS.md
@@ -1,0 +1,122 @@
+# Codebase Concerns
+
+**Analysis Date:** 2026-05-05
+
+## Tech Debt
+
+**Duplicate Canvas API clients:**
+- Issue: Two independent Canvas API clients exist — `src/canvas_tui/api.py` (~344 lines) and `sdk/canvas_sdk/requester.py` + `canvas.py` (~1310 lines)
+- Why: TUI originally built without SDK; SDK added later but TUI not migrated
+- Impact: Maintenance burden, potential inconsistencies, duplicate retry/caching logic
+- Fix approach: Phase 2 consolidation creates `canvas_sdk/client.py` combining best patterns; Phase 3 deletes `api.py`
+
+**Inconsistent retry logic:**
+- Issue: TUI `api.py` uses `urllib3.Retry`; SDK `requester.py` uses manual retry loop
+- Files: `src/canvas_tui/api.py` (lines ~50-80), `sdk/canvas_sdk/requester.py` (manual `_retry_request`)
+- Why: Different authors at different times
+- Fix approach: Unify in Phase 2 `client.py` using `urllib3.Retry` (more robust)
+
+**Inconsistent caching:**
+- Issue: TUI has disk-backed SQLite cache (`src/canvas_tui/cache.py`); SDK has memory-only `_cache` list in `Requester`
+- Files: `src/canvas_tui/cache.py`, `sdk/canvas_sdk/requester.py` (line ~65)
+- Why: Different use cases (offline TUI vs API client)
+- Fix approach: `canvas_sdk/cache.py` in Phase 2 with thread-safe atomic writes
+
+**SDK test isolation gap:**
+- Issue: SDK tests only cover `agent_tools/` subdirectory; core SDK modules (`canvas.py`, `requester.py`, `paginated_list.py`) have no tests
+- Files: `sdk/canvas_sdk/agent_tools/tests/` (only this dir has tests)
+- Why: Tests added incrementally, core modules not covered
+- Fix approach: Phase 4 adds unit tests for `client.py`, `cache.py`, `config.py`, `paginated_list.py` (≥80% coverage)
+
+## Known Bugs
+
+**No known bugs currently tracked.** If bugs are discovered during refactoring, add them here.
+
+## Security Considerations
+
+**Canvas token in environment variable:**
+- Risk: `CANVAS_TOKEN` stored as plain text environment variable (visible via `ps eww`)
+- Current mitigation: `keyring` extra available for secure storage
+- Recommendations: Default to keyring in production; document secure setup
+
+**RateMyProfessors scraping:**
+- Risk: RMP integration (`src/canvas_tui/rmp/client.py`) has no official API — scraping may break
+- Current mitigation: None (RMP may block or change structure)
+- Recommendations: Consider RateMyProfessors official API or alternative data source
+
+## Performance Bottlenecks
+
+**Paginated list iteration:**
+- Problem: `PaginatedList` fetches one page at a time; large course with 500+ items = 5-10 sequential requests
+- File: `sdk/canvas_sdk/paginated_list.py`
+- Cause: Simple next-page detection via `Link` header
+- Improvement path: Prefetch/cache pages (Phase 2 `client.py` caching helps)
+
+**TUI cache SQLite writes:**
+- Problem: Cache writes are synchronous on each API response
+- File: `src/canvas_tui/cache.py` (SQLite `execute()` called in main request path)
+- Cause: Synchronous writes block response
+- Improvement path: Phase 2 `canvas_sdk/cache.py` with async write queue
+
+## Fragile Areas
+
+**SDK `canvas.py` — large entry point:**
+- Why fragile: 1310-line `Canvas` class with all endpoint access methods
+- Common failures: Easy to accidentally break API compatibility for one endpoint
+- Safe modification: Test all endpoint methods after any change
+- Test coverage: None currently (Phase 4 adds tests)
+
+**TUI `api.py` — duplicate client:**
+- Why fragile: Will be deleted in Phase 3 — must work until then
+- Common failures: Any changes must keep both clients working
+- Safe modification: No new features; only bug fixes before Phase 3
+
+**PaginatedList iterator:**
+- Why fragile: Iterator protocol with auto-fetch; consumer must not exhaust while iterating
+- File: `sdk/canvas_sdk/paginated_list.py`
+- Common failures: Consuming list while network error mid-iteration
+- Safe modification: Don't change while iterating; wrap in try/except for network errors
+
+## Dependencies at Risk
+
+**Textual framework:**
+- Risk: TUI tightly coupled to Textual; breaking changes in Textual could break TUI
+- Impact: `canvas_tui/app.py` and all `screens/` depend on Textual
+- Mitigation: `textual>=0.40` pinned in dependencies
+
+**requests library:**
+- Risk: `requests` is mature and stable; low risk
+- Impact: Both clients depend on `requests.Session`
+
+## Missing Critical Features
+
+**SDK persistent cache:**
+- Problem: SDK has no disk-backed cache — each process starts fresh
+- Current workaround: TUI has its own cache, but SDK consumers have none
+- Blocks: SDK users can't do offline mode or reduce API calls
+- Implementation complexity: Medium (Phase 2 `canvas_sdk/cache.py` addresses this)
+
+**SDK configuration management:**
+- Problem: SDK requires manual `base_url` + `access_token` passed to every `Canvas()` constructor
+- Current workaround: Users manage their own config
+- Blocks: Hard to share SDK with consistent defaults
+- Implementation complexity: Low (Phase 2 `CanvasSDKConfig` dataclass addresses this)
+
+## Test Coverage Gaps
+
+**SDK core modules:**
+- What's not tested: `canvas_sdk/canvas.py`, `requester.py`, `paginated_list.py`, `canvas_object.py`, `config.py`
+- Risk: Refactoring could break SDK without detection
+- Priority: High (Phase 4 addresses this)
+- Difficulty to test: Need mock HTTP responses and token validation
+
+**TUI integration without Canvas:**
+- What's not tested: Full TUI screen flow with mocked data
+- Risk: Screen changes could break without detection
+- Priority: Medium
+- Difficulty to test: Requires Textual test infrastructure (not currently in CI)
+
+---
+
+*Concerns audit: 2026-05-05*
+*Update as issues are fixed or new ones discovered*

--- a/.planning/codebase/CONVENTIONS.md
+++ b/.planning/codebase/CONVENTIONS.md
@@ -1,0 +1,113 @@
+# Coding Conventions
+
+**Analysis Date:** 2026-05-05
+
+## Naming Patterns
+
+**Files:**
+- snake_case.py for all Python modules
+- test files: `test_*.py` in `tests/` directory
+- Config: `*.toml`, `*.json`, `*.yml`
+
+**Functions:**
+- snake_case for all functions and methods
+- No special prefix for async functions
+
+**Variables:**
+- snake_case for variables and instance attributes
+- `_prefix` for private/internal attributes (by convention)
+- UPPER_SNAKE_CASE for module-level constants
+
+**Types:**
+- PascalCase for classes and type names
+- `|` union syntax for type annotations (Python 3.10+)
+- Dataclasses for structured data (via `@dataclass`)
+
+## Code Style
+
+**Formatting:**
+- Tool: `ruff` (configured in `ruff.toml` / `ruff.toml`)
+- Line length: 120 characters
+- Target Python: 3.11+ (`target-version = "py311"`)
+- Import sorting: enabled via ruff (I rule)
+
+**Linting:**
+- Rules enabled: `E`, `F`, `W`, `I`, `UP`, `B`, `SIM`, `RUF`
+- Ignored: `E501` (line length handled by formatter), `E741`, `B008`, `SIM108`, `RUF012`
+- Per-file ignores: `tests/*` skips `B` and `SIM`
+
+**Type Checking:**
+- Tool: `mypy` (in dev dependencies)
+- Config: `pyproject.toml` has pytest config, mypy configured separately
+
+## Import Organization
+
+**Order:**
+1. Standard library
+2. Third-party packages
+3. Local application imports (relative)
+
+**Pattern:** `from __future__ import annotations` at top of most files
+
+**SDK imports:**
+- `from canvas_sdk.canvas import Canvas` — main entry
+- `from canvas_sdk.x import Y` — individual modules
+- TUI imports SDK as `canvas_sdk.*`
+
+**TUI imports:**
+- Relative imports within `canvas_tui` package: `from . import module`
+- Cross-package: `from canvas_sdk import ...` (after SDK is installed/available)
+
+## Error Handling
+
+**Patterns:**
+- TUI (`api.py`): Raises generic `Exception` with string messages
+- SDK: Typed exception hierarchy in `canvas_sdk/exceptions.py`
+  - `CanvasException` (base), `RequiredFieldMissing`, `BadRequest`, `Unauthorized`, `Forbidden`, `ResourceDoesNotExist`, `RateLimitExceeded`, `UnprocessableEntity`, `InvalidAccessToken`
+- Phase 2 refactor: TUI will migrate to SDK's typed exceptions
+
+**Retry:**
+- TUI `api.py`: `urllib3.util.retry.Retry` with `status_forcelist=(429,500,502,503,504)`
+- SDK `requester.py`: Custom `_retry_request()` with explicit retry loop
+
+## Comments
+
+**When to Comment:**
+- Module-level docstrings (all major files)
+- Class docstrings (Canvas API client classes)
+- Method docstrings with `:param` / `:returns` for complex methods
+
+**Pattern:** Google-style docstrings (used in `canvas_sdk/` modules)
+
+**TODO Comments:**
+- Plain `TODO:` style (no username/issue format enforced)
+
+## Function Design
+
+**Size:** Keep functions focused; multiple smaller functions preferred
+
+**Parameters:** Type hints on all parameters and return values
+
+**Return Values:** Explicit `return` statements; no implicit `None`
+
+## Module Design
+
+**SDK Structure:**
+- One file per Canvas endpoint class: `account.py`, `course.py`, `assignment.py`, etc.
+- Base classes in `canvas_object.py`, `canvas.py`, `requester.py`
+- `__init__.py` re-exports main classes
+
+**TUI Structure:**
+- `screens/` — Textual screen implementations
+- `widgets/` — Reusable UI components
+- `models/` — Data model classes
+- `agent/tools/` — Agent tool implementations
+
+**Exports:**
+- Named exports via `__init__.py`
+- Public API surface: `Canvas`, `PaginatedList`, `CanvasObject` in SDK
+
+---
+
+*Convention analysis: 2026-05-05*
+*Update when patterns change*

--- a/.planning/codebase/INTEGRATIONS.md
+++ b/.planning/codebase/INTEGRATIONS.md
@@ -1,0 +1,54 @@
+# External Integrations
+
+**Analysis Date:** 2026-05-05
+
+## APIs & External Services
+
+**Canvas LMS REST API:**
+- Purpose: Fetch courses, assignments, grades, announcements, calendar events, submissions
+- Integration method: REST API via `requests` library
+- Auth: Bearer token (`CANVAS_TOKEN` env var) — passed as `Authorization: Bearer <token>` header
+- Endpoints used: `/api/v1/` prefix (e.g., `/api/v1/courses`, `/api/v1/users/:id`)
+- Rate limits: Canvas enforces `X-Rate-Limit-Remaining` header; both clients handle 429 responses
+- Base URL: Configured via `CANVAS_BASE_URL` (e.g., `https://vt.instructure.com`)
+
+**RateMyProfessors (RMP) API:**
+- Purpose: Course/instructor ratings in TUI analytics screen
+- Integration method: HTTP client in `src/canvas_tui/rmp/client.py`
+- Auth: None (public API)
+- Note: RMP has no official API; integration uses scrape patterns
+
+## Data Storage
+
+**Disk Cache:**
+- Tool: SQLite via `src/canvas_tui/adapters/sqlite_cache.py` and `src/canvas_tui/cache.py`
+- Purpose: Cache Canvas API responses for offline mode and rate-limit reduction
+- Location: `~/.cache/canvas-tui/` or per-configured cache directory
+- TTL: Configurable per installation
+
+**SDK Cache:**
+- Tool: `canvas_sdk/requester.py` uses `requests.Session` with internal `_cache` list (memory-only)
+
+## Configuration
+
+**Environment Variables (required for TUI + SDK):**
+- `CANVAS_TOKEN` — Access token (no default, must be set)
+- `CANVAS_BASE_URL` — Canvas instance root (e.g., `https://vt.instructure.com`)
+- `TZ` — Timezone (defaults to `America/New_York`)
+- `EXPORT_DIR` — Export output directory (defaults to current directory)
+
+**Environment Variables (optional):**
+- `KEYRING_SERVICE` — Use system keyring for token storage
+- `RERANKER_MODEL_PATH` — Local GGUF model for reranking (AI extra)
+
+## CI/CD & Deployment
+
+**GitHub Actions:**
+- Workflows: `.github/workflows/ci.yml` (pytest + coverage check)
+- Python versions tested: 3.11 (ubuntu-latest)
+- Secrets: None required (tests run against mock/real Canvas, no external deps)
+
+---
+
+*Integration audit: 2026-05-05*
+*Update when adding/removing external services*

--- a/.planning/codebase/STACK.md
+++ b/.planning/codebase/STACK.md
@@ -1,0 +1,82 @@
+# Technology Stack
+
+**Analysis Date:** 2026-05-05
+
+## Languages
+
+**Primary:**
+- Python 3.11+ — All application code, SDK, TUI, and tests
+
+**Secondary:**
+- JavaScript/TypeScript — Browser extension (`extension/`)
+
+## Runtime
+
+**Environment:**
+- Python 3.11–3.13 (tested across 3.11, 3.12, 3.13)
+- Node.js — Only for extension/build tooling
+
+**Package Manager:**
+- pip (via `pip install -e .`)
+- npm for extension (`package-lock.json` present)
+- Lockfile: `pyproject.toml` (setuptools) + `package-lock.json`
+
+## Frameworks
+
+**Core:**
+- Textual 0.40+ — TUI framework (`canvas_tui.app`)
+- requests 2.28+ — HTTP client for Canvas API
+- urllib3 2.0+ — Retry and rate-limit logic
+
+**Testing:**
+- pytest — Test runner (configured in `pyproject.toml`)
+- pytest-cov — Coverage enforcement
+
+**Build/Dev:**
+- setuptools 68+ — Package building
+- ruff — Linting and formatting
+- mypy — Static type checking
+- mkdocs + mkdocs-material — Documentation site
+
+## Key Dependencies
+
+**Critical:**
+- `requests>=2.28` — Canvas API HTTP calls (TUI `api.py` and SDK `requester.py`)
+- `urllib3>=2.0` — Retry strategy (`Retry` class), connection pooling
+- `textual>=0.40` — Terminal UI framework
+
+**CLI/TUI:**
+- `keyring>=23.0` — Optional secure token storage (`[keyring]` extra)
+- `llama-cpp-python>=0.3` — Optional local GGUF inference for reranker (`[ai]` extra)
+
+**SDK-specific:**
+- `canvas_sdk/` — Self-contained SDK package (separate `sdk/pyproject.toml`)
+- SDK uses same `requests` + `urllib3` stack as TUI
+
+## Configuration
+
+**Environment:**
+- `CANVAS_TOKEN` — Canvas API access token
+- `CANVAS_BASE_URL` — Canvas instance root URL
+- `TZ` — Timezone for deadline display
+- `EXPORT_DIR` — Output directory for ICS/exports
+
+**Build:**
+- `pyproject.toml` — Package metadata, dependencies, pytest config
+- `sdk/pyproject.toml` — Separate package manifest for `canvas_sdk`
+- `ruff.toml` / `.ruff.toml` — Linter config (line-length: 120)
+
+## Platform Requirements
+
+**Development:**
+- macOS/Linux/Windows (Python 3.11+)
+- No external services required (offline-capable when cached)
+
+**Production:**
+- Distributed as pip-installable package (`canvas-tui`)
+- SDK independently pip-installable from `sdk/` subdirectory
+
+---
+
+*Stack analysis: 2026-05-05*
+*Update after major dependency changes*

--- a/.planning/codebase/STRUCTURE.md
+++ b/.planning/codebase/STRUCTURE.md
@@ -1,0 +1,151 @@
+# Codebase Structure
+
+**Analysis Date:** 2026-05-05
+
+## Directory Layout
+
+```
+CS3704-Canvas-Project/
+├── src/                        # TUI application (pip-installable as "canvas-tui")
+│   ├── canvas_tui/            # Main package
+│   │   ├── __init__.py
+│   │   ├── __main__.py         # CLI entry point ("python -m canvas_tui")
+│   │   ├── app.py             # Textual application root
+│   │   ├── api.py             # Duplicate Canvas API client (to be deleted)
+│   │   ├── cache.py           # Disk-backed response cache
+│   │   ├── config.py          # Configuration loading
+│   │   ├── cli.py             # CLI argument parsing
+│   │   ├── state.py           # Application state
+│   │   ├── normalize.py       # Data normalization utilities
+│   │   ├── filtering.py       # Course/assignment filtering
+│   │   ├── notifications.py   # Notification management
+│   │   ├── ics.py             # ICS calendar export
+│   │   ├── reranker.py        # Local reranking (AI extra)
+│   │   ├── models.py          # TUI-specific data models
+│   │   ├── models/            # Sub-package models
+│   │   ├── screens/           # Textual screen implementations
+│   │   ├── widgets/          # Reusable Textual widgets
+│   │   ├── commands/         # Command registry
+│   │   ├── agent/             # Agent tools
+│   │   │   └── tools/        # Canvas, study, calendar, reranker tools
+│   │   ├── adapters/          # Database/cache adapters
+│   │   ├── core/              # Interface definitions
+│   │   └── rmp/              # RateMyProfessors integration
+│   └── canvas_sdk/           # ⭐ SDK MOVE TARGET: sdk/canvas_sdk/ moves here (Phase 1)
+├── sdk/                       # SDK package (will be removed after Phase 1 move)
+│   └── canvas_sdk/           # 50+ API modules + __init__.py
+├── tests/                     # Test suite (pytest)
+│   ├── conftest.py           # Shared fixtures
+│   ├── test_*.py             # Unit tests (test_api.py, test_cache.py, etc.)
+│   └── rmp/                  # RMP-specific tests
+├── extension/                 # Browser extension (JavaScript)
+│   ├── manifest.json
+│   ├── background.js
+│   ├── content.js
+│   └── canvas-client.js     # Independent JS API client
+├── docs-site/                 # mkdocs documentation site
+├── docs/                      # Developer documentation (md)
+├── scripts/                   # Build/release scripts
+├── tools/                     # Utility scripts
+├── .github/workflows/         # CI/CD workflows
+├── pyproject.toml             # TUI package manifest
+├── sdk/pyproject.toml         # SDK package manifest (separate pip-installable)
+├── requirements.txt           # TUI dependencies
+└── Makefile                   # Build automation
+```
+
+## Directory Purposes
+
+**src/canvas_tui/ — TUI Application**
+- Purpose: Terminal UI application for Canvas LMS
+- Contains: Textual screens, widgets, state management, CLI entry
+- Key files: `app.py` (root), `api.py` (duplicate client), `cache.py` (response cache)
+- Subdirectories: `screens/`, `widgets/`, `agent/tools/`, `adapters/`, `models/`
+
+**sdk/canvas_sdk/ — Canvas SDK (Phase 1 move target)**
+- Purpose: Canonical Canvas API SDK (pip-installable independently)
+- Contains: 50+ API endpoint modules, base classes, requester, exceptions
+- Key files: `canvas.py` (entry), `requester.py` (HTTP), `canvas_object.py` (base model)
+- Note: Moves to `src/canvas_sdk/` in Phase 1 of refactor
+
+**tests/ — Test Suite**
+- Purpose: Pytest-based unit and integration tests
+- Contains: `conftest.py` (shared fixtures), 20+ `test_*.py` files
+- Note: SDK tests live in `sdk/canvas_sdk/agent_tools/tests/` (separate test suite)
+
+**extension/ — Browser Extension**
+- Purpose: Chrome/Firefox extension for Canvas web interface
+- Contains: JS/CSS files, `manifest.json`
+- Note: Has independent `canvas-client.js` (separate from Python clients)
+
+## Key File Locations
+
+**Entry Points:**
+- `src/canvas_tui/__main__.py` — CLI entry (`python -m canvas_tui`)
+- `src/canvas_tui/app.py` — Textual TUI application root
+- `sdk/canvas_sdk/__init__.py` — SDK package entry (`from canvas_sdk import ...`)
+
+**Configuration:**
+- `src/canvas_tui/config.py` — Config loading from env vars
+- `pyproject.toml` — TUI package config (pytest, setuptools)
+- `sdk/pyproject.toml` — SDK package config
+- `ruff.toml` — Linter configuration (line-length: 120)
+
+**SDK Core (Phase 1 move target):**
+- `sdk/canvas_sdk/canvas.py` — `Canvas` class (main SDK entry)
+- `sdk/canvas_sdk/requester.py` — HTTP client with auth
+- `sdk/canvas_sdk/canvas_object.py` — Base class for all endpoint models
+- `sdk/canvas_sdk/paginated_list.py` — Lazy pagination
+- `sdk/canvas_sdk/exceptions.py` — Exception hierarchy
+
+**TUI Core:**
+- `src/canvas_tui/api.py` — Duplicate Canvas API client (~344 lines)
+- `src/canvas_tui/cache.py` — Response cache (SQLite-backed)
+- `src/canvas_tui/state.py` — Application state
+- `src/canvas_tui/screens/` — Textual screens (grades, analytics, weekview, etc.)
+
+## Naming Conventions
+
+**Files:**
+- Python: `snake_case.py` for modules, `PascalCase.py` for classes
+- Test files: `test_*.py` (collocated with source via `tests/` directory)
+- Config files: `*.toml`, `*.json`, `*.yml`
+
+**Directories:**
+- snake_case for all package directories
+- Plural names for collections: `screens/`, `widgets/`, `models/`, `tools/`
+
+**Classes:**
+- PascalCase: `CanvasAPI`, `Canvas`, `PaginatedList`, `CanvasObject`
+- No prefix: No `I` or `T` prefixes
+
+## Where to Add New Code
+
+**New TUI Feature:**
+- Primary code: `src/canvas_tui/screens/` (screen) or `src/canvas_tui/widgets/` (widget)
+- Tests: `tests/test_*.py`
+- Config if needed: `src/canvas_tui/config.py`
+
+**New SDK Endpoint:**
+- Primary code: `src/canvas_sdk/` (after Phase 1) or `sdk/canvas_sdk/` (before Phase 1)
+- Tests: `sdk/canvas_sdk/agent_tools/tests/` (current) or new `tests/canvas_sdk/` (post-refactor)
+- Model file: One file per endpoint (e.g., `course.py`, `assignment.py`)
+
+**New API Client Feature (pre-consolidation):**
+- Primary code: `src/canvas_tui/api.py` (TUI client) or `sdk/canvas_sdk/canvas.py` (SDK client)
+- Note: Phase 2 consolidates into single `canvas_sdk/client.py`
+
+## Special Directories
+
+**sdk/canvas_sdk/agent_tools/tests/**
+- Purpose: SDK agent tools test suite (separate from TUI tests)
+- Note: Will be consolidated into `tests/canvas_sdk/` in Phase 4
+
+**src/canvas_tui/agent/**
+- Purpose: Agent backend tools (calendar adapter, canvas tools, study tools)
+- Note: Uses SDK's `canvas_sdk` package (will update after Phase 1 move)
+
+---
+
+*Structure analysis: 2026-05-05*
+*Update when directory structure changes*

--- a/.planning/codebase/TESTING.md
+++ b/.planning/codebase/TESTING.md
@@ -1,0 +1,166 @@
+# Testing Patterns
+
+**Analysis Date:** 2026-05-05
+
+## Test Framework
+
+**Runner:**
+- pytest — configured in `pyproject.toml`
+- Config file: `[tool.pytest]` section in `pyproject.toml`
+- Config file: `tests/conftest.py` (shared fixtures)
+
+**Assertion Library:**
+- pytest built-in `assert` statements
+- `unittest.mock` for mocking (`MagicMock`, `patch`)
+
+**Run Commands:**
+```bash
+pytest tests/ -q -p no:cacheprovider --tb=short   # Run all tests (CI)
+pytest tests/                                     # Run with verbose
+pytest tests/test_api.py                          # Single file
+pip install -e ".[dev]" && pytest --cov          # With coverage
+```
+
+## Test File Organization
+
+**Location:**
+- `tests/` directory (separate from source)
+- `sdk/canvas_sdk/agent_tools/tests/` — SDK agent tools tests (separate suite)
+
+**Naming:**
+- `test_*.py` for all test files
+- Class-based: `class TestClassName:` with methods `test_*()`
+
+**Structure:**
+```
+tests/
+├── conftest.py           # Shared fixtures (tmp_dir, sample_config_env, etc.)
+├── test_api.py           # CanvasAPI tests
+├── test_cache.py         # Cache tests
+├── test_config.py        # Config loading tests
+├── test_courses.py       # Course-related tests
+├── test_grades.py        # Grades tests
+└── ...                   # 20+ test files
+```
+
+## Test Structure
+
+**Suite Organization:**
+```python
+class TestClassName:
+    def setup_method(self):
+        # Per-test setup (not `setup_class`)
+
+    def test_something(self):
+        # arrange
+        # act
+        # assert
+
+    def test_something_else(self):
+        # test code
+```
+
+**Patterns:**
+- `setup_method` for per-test setup (fixtures, mocks)
+- `unittest.mock.MagicMock` + `@patch` for mocking
+- No `beforeAll` / `afterAll` (per-test isolation preferred)
+
+## Mocking
+
+**Framework:**
+- `unittest.mock` (built-in)
+- `@patch` decorator for patching imports
+- `MagicMock` for creating mock objects
+
+**Patterns:**
+```python
+from unittest.mock import MagicMock, patch
+
+@patch("canvas_tui.api.requests.Session")
+def test_something(mock_session_cls):
+    session = MagicMock()
+    session.get.return_value = _make_response()
+    mock_session_cls.return_value = session
+    # test code
+```
+
+**What to Mock:**
+- `requests.Session` (HTTP layer)
+- `canvas_tui.config.Config` (configuration)
+- External Canvas API (network calls)
+
+**What NOT to Mock:**
+- Internal pure functions (where possible)
+- Simple utility functions
+
+## Fixtures
+
+**Defined in `tests/conftest.py`:**
+```python
+@pytest.fixture
+def tmp_dir():
+    """Temporary directory for test files."""
+    with tempfile.TemporaryDirectory(prefix="canvas_tui_test_") as d:
+        yield d
+
+@pytest.fixture
+def sample_config_env(monkeypatch, tmp_dir):
+    """Set up minimal environment for Config loading."""
+    monkeypatch.setenv("CANVAS_TOKEN", "test-token-12345")
+    monkeypatch.setenv("CANVAS_BASE_URL", "https://canvas.example.edu")
+    # ...
+```
+
+## Coverage
+
+**Requirements:**
+- Target: ≥80% line coverage (enforced in CI via `fail_under = 80`)
+- Exclusions (in `pyproject.toml`):
+  - TUI app/screen files (require terminal)
+  - Adapter/command/prefetch modules
+  - RMP client (integration-dependent)
+  - `core/__init__.py`, `models.py`
+
+**Configuration:**
+- `pytest-cov` plugin
+- `.coveragerc` or `[tool.coverage.run]` in `pyproject.toml`
+
+**View Coverage:**
+```bash
+pytest --cov=canvas_tui --cov-report=term-missing
+```
+
+## Test Types
+
+**Unit Tests:**
+- Test individual classes/functions in isolation
+- Mock all external dependencies (HTTP, config)
+- `test_api.py`, `test_cache.py`, `test_config.py`, etc.
+
+**Integration Tests:**
+- Not currently explicit (tests for TUI without real Canvas)
+- SDK tests in `sdk/canvas_sdk/agent_tools/tests/` (separate)
+
+## Common Patterns
+
+**HTTP Mocking:**
+```python
+def _make_response(status=200, json_data=None, headers=None):
+    resp = MagicMock()
+    resp.status_code = status
+    resp.json.return_value = json_data or []
+    resp.headers = headers or {}
+    resp.raise_for_status.return_value = None
+    return resp
+```
+
+**Config Mocking:**
+```python
+cfg = Config(token="test-token", base_url="https://canvas.example.com")
+api = CanvasAPI(cfg=cfg)
+```
+
+---
+
+*Testing analysis: 2026-05-05*
+*Update when test patterns change*

--- a/.planning/config.json
+++ b/.planning/config.json
@@ -1,0 +1,19 @@
+{
+  "mode": "yolo",
+  "granularity": "standard",
+  "parallelization": true,
+  "commit_docs": true,
+  "model_profile": "balanced",
+  "workflow": {
+    "research": true,
+    "plan_check": true,
+    "verifier": true,
+    "nyquist_validation": true,
+    "auto_advance": true
+  },
+  "project": {
+    "code": "CS3704-REFACTOR",
+    "path": "/home/broklein/codeWS/Python/CS3704-Canvas-Project",
+    "is_brownfield": true
+  }
+}


### PR DESCRIPTION
## Summary

Initialize CS3704-REFACTOR project planning docs and map existing codebase architecture.

### Commits

1. **docs: initialize project CS3704-REFACTOR** - Add PROJECT.md and config.json for the refactor project using GSD workflow
2. **docs: map existing codebase** - Document existing codebase architecture, concerns, conventions, integrations, stack, structure, and testing approach

### Files changed

- `.planning/PROJECT.md` - Project definition and goals
- `.planning/config.json` - GSD workflow configuration  
- `.planning/codebase/ARCHITECTURE.md` - Architecture overview
- `.planning/codebase/CONCERNS.md` - Key concerns and challenges
- `.planning/codebase/CONVENTIONS.md` - Coding conventions
- `.planning/codebase/INTEGRATIONS.md` - External integrations
- `.planning/codebase/STACK.md` - Tech stack
- `.planning/codebase/STRUCTURE.md` - Directory structure
- `.planning/codebase/TESTING.md` - Testing approach

### Notes

These docs establish the planning foundation for the SDK centralization refactor (Phase 2 of GSD workflow).