### PR TITLE
revert: remove .planning/ docs added in PR #95

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,8 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - uses: github/codeql-action/init@v4
         with:
           languages: python


### PR DESCRIPTION
Reverts PR #95 which added .planning/ docs that should not be on main.

These docs belong in the GSD-OC project repo, not in the Canvas-Project repo.

Also fixes CodeQL workflow to use checkout@v6 (was v4, out of sync with other workflows).