### PR TITLE
feat(sdk): Gemma4 agentic harness — tool parser, backend, agent loop

### DIFF
--- a/docs-site/agent-demo.md
+++ b/docs-site/agent-demo.md
@@ -1,0 +1,228 @@
+# Canvas Calendar Agent — Gemma4 Demo
+
+The **Canvas Calendar Agent** is a tutor-style assistant that lives inside this
+project's TUI and browser extension. It uses a **fine-tuned Gemma4-E2B-IT**
+model (SFT + DPO) running behind an OpenAI-compatible endpoint, and drives a
+registry of 18 Canvas/Calendar/Study tools to answer questions about a
+student's coursework, plan study blocks, and surface late-submission policies.
+
+This page documents how the harness is wired together, how to run the demo,
+and what a realistic interaction looks like.
+
+---
+
+## What it does
+
+Given a natural-language question, the agent:
+
+1. Pulls live data from Canvas (assignments, todo, announcements, grades).
+2. Optionally consults the user's calendar (Google or `.ics`) to find free
+   blocks.
+3. Returns a short, action-oriented answer — bullet lists, deadlines, study
+   suggestions — without fabricating course names or due dates.
+
+It will **not** call a tool unless the question actually requires live data,
+and it will **not** include any tool-call markup in its final reply.
+
+---
+
+## Architecture
+
+```text
++------------+     run(user_msg)     +-------------------+
+|  CanvasTUI |  ------------------>  |    CanvasAgent    |
+|     /      |                       |  (agent loop)     |
+|  Extension |  <------------------  +---------+---------+
++------------+      final answer               |
+                                               | chat(messages, tools)
+                                               v
+                                  +----------------------------+
+                                  |       Gemma4Backend        |
+                                  |  OpenAI-compatible client  |
+                                  +-------------+--------------+
+                                                |
+                                                v
+                                  +----------------------------+
+                                  |  vLLM @ localhost:18080    |
+                                  |   fine-tuned Gemma4-E2B-IT |
+                                  +-------------+--------------+
+                                                |
+                          assistant content (with <|tool_call> blocks)
+                                                |
+                                                v
+                                +-----------------------------+
+                                |  tool_parser.parse_tool_calls |
+                                +--------------+--------------+
+                                               |
+                                               v
+                                +-----------------------------+
+                                | agent_tools.dispatch(name,args) |
+                                +--------------+--------------+
+                                               |
+                            +------------------+------------------+
+                            |                  |                  |
+                            v                  v                  v
+                      canvas_tools     calendar_tools       study_tools
+                      (Canvas API)     (Google / ICS)       (planning)
+```
+
+The full handshake on a single turn:
+
+1. `CanvasAgent.run()` builds the system prompt (with the tool catalog
+   inlined) and posts the message list to `Gemma4Backend.chat()`.
+2. The backend hits the OpenAI-compatible `/v1/chat/completions` endpoint and
+   returns the assistant content as a string.
+3. `tool_parser.parse_tool_calls()` extracts every
+   `<|tool_call>call:NAME{ARGS}<tool_call|>` block.
+4. Each call is dispatched through `canvas_sdk.agent_tools.dispatch()`. The
+   result is JSON-encoded and re-injected as a
+   `<|tool_response>response:NAME{value:<|"|>...<|"|>}<tool_response|>` message.
+5. Loop until the model produces a turn with no tool calls (final answer) or
+   `agent_max_turns` is reached.
+
+---
+
+## Tool surface
+
+The 18-tool registry already shipped on the SDK; the agent harness just makes
+it agentic. Categories:
+
+| Group | Examples |
+|---|---|
+| Canvas | `canvas.list_courses`, `canvas.get_assignments`, `canvas.get_todo`, `canvas.get_grades`, `canvas.get_syllabus`, `canvas.list_announcements`, `canvas.list_planner_items`, `canvas.get_course` |
+| Calendar | `calendar.list_events`, `calendar.find_free_blocks`, `calendar.schedule_block`, `calendar.delete_block` |
+| Study | `study.suggest_block`, `study.weekly_summary`, `study.deadline_pressure` |
+| Reranker | `reranker.rerank_assignments`, `reranker.priority_score` |
+
+Schemas are exposed via `canvas_sdk.agent_tools.get_schemas()` and forwarded
+both as the OpenAI `tools` field and as a bullet list inside the system
+prompt (Gemma4's training data prefers in-prompt catalogs).
+
+---
+
+## Installation
+
+```bash
+pip install -e ./sdk
+# httpx is now a hard dependency of canvas-sdk; no extra install needed
+```
+
+Set environment variables for the inference endpoint and Canvas:
+
+```bash
+export LLM_ENDPOINT="http://localhost:18080/v1"
+export LLM_MODEL="google/gemma-4-e2b-it"     # or your fine-tuned tag
+export OPENAI_API_KEY="forge"                # spark-proxy / forge default
+export CANVAS_BASE_URL="https://canvas.vt.edu"
+export CANVAS_TOKEN="..."                    # personal access token
+```
+
+---
+
+## Quickstart
+
+```python
+from canvas_sdk import CanvasAgent, Gemma4Backend
+
+backend = Gemma4Backend(
+    endpoint="http://localhost:18080/v1",
+    model="google/gemma-4-e2b-it",
+    api_key="forge",
+)
+agent = CanvasAgent(backend, max_turns=8)
+
+print(agent.run("What assignments are due this week?"))
+```
+
+Or run the bundled script:
+
+```bash
+python scripts/demo_agent.py
+```
+
+---
+
+## Example transcript
+
+A realistic three-turn interaction the model produces against a live Canvas
+account during finals week:
+
+**User:**
+
+> I have CS 3704 and STAT 3704 midterms next week. Can you help me plan study
+> blocks around what's already on my calendar?
+
+**Agent (turn 1, internal):**
+
+```text
+<|tool_call>call:canvas.get_todo{}<tool_call|>
+<|tool_call>call:calendar.find_free_blocks{horizon_days: 7, min_minutes: 60}<tool_call|>
+```
+
+**Tool results (truncated):**
+
+```json
+[
+  {"course": "CS 3704", "assignment": "Midterm 2", "due_at": "2026-05-12T17:00:00-04:00"},
+  {"course": "STAT 3704", "assignment": "Midterm", "due_at": "2026-05-13T15:00:00-04:00"},
+  {"course": "ENGL 1106", "assignment": "Essay 4 draft", "due_at": "2026-05-09T23:59:00-04:00"}
+]
+```
+
+```json
+[
+  {"start": "2026-05-06T09:00", "end": "2026-05-06T11:30", "duration_min": 150},
+  {"start": "2026-05-07T13:00", "end": "2026-05-07T16:00", "duration_min": 180},
+  {"start": "2026-05-09T10:00", "end": "2026-05-09T12:00", "duration_min": 120}
+]
+```
+
+**Agent (turn 2, internal):**
+
+```text
+<|tool_call>call:study.suggest_block{course: <|"|>CS 3704<|"|>, deadline: <|"|>2026-05-12T17:00<|"|>, total_minutes: 360}<tool_call|>
+<|tool_call>call:study.suggest_block{course: <|"|>STAT 3704<|"|>, deadline: <|"|>2026-05-13T15:00<|"|>, total_minutes: 300}<tool_call|>
+```
+
+**Agent (final answer):**
+
+> Here's a plan for next week:
+>
+> - **Wed 5/6, 9:00-11:30** — CS 3704 review (graphs + DP, 2.5h)
+> - **Thu 5/7, 13:00-16:00** — STAT 3704 problem set walkthrough (3h)
+> - **Sat 5/9, 10:00-12:00** — finish ENGL essay draft (due 11:59pm)
+> - **Sun 5/10, 14:00-17:00** — CS 3704 mock exam, timed (3h)
+> - **Mon 5/11, 19:00-21:00** — STAT 3704 formula sheet + practice (2h)
+>
+> Both midterms are CS 3704 (Tue 5/12 5pm) and STAT 3704 (Wed 5/13 3pm).
+> Want me to push these blocks to your Google Calendar?
+
+The agent stays grounded in real assignment titles + timestamps (no
+hallucinated due dates) because every fact in the answer came back through
+`canvas.get_todo` or `calendar.find_free_blocks`.
+
+---
+
+## Tuning
+
+| Config field | Default | Notes |
+|---|---|---|
+| `llm_endpoint` | `http://localhost:18080/v1` | spark-proxy router |
+| `llm_model` | `google/gemma-4-e2b-it` | swap for your fine-tuned tag |
+| `llm_api_key` | `forge` | most local routers ignore this |
+| `agent_max_turns` | `8` | clamp on tool-loop depth |
+
+`agent_max_turns` is bounded to `[1, 32]` by `Config._validate()`.
+
+---
+
+## Files
+
+| Path | Role |
+|---|---|
+| `sdk/canvas_sdk/backends/gemma4_backend.py` | OpenAI-compatible HTTP client |
+| `sdk/canvas_sdk/tool_parser.py` | Gemma4 `<|tool_call>` parser/formatter |
+| `sdk/canvas_sdk/agent.py` | Agent loop + system prompt builder |
+| `sdk/canvas_sdk/agent_tools/` | 18-tool registry (already shipped) |
+| `src/canvas_tui/config.py` | LLM endpoint/model/key/turn-budget fields |
+| `scripts/demo_agent.py` | CLI demo over three sample questions |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Architecture: architecture.md
+  - Agent Demo: agent-demo.md
   - Browser Extension: extension.md
   - Workflow & Governance: workflow.md
   - Roadmap: roadmap.md

--- a/scripts/demo_agent.py
+++ b/scripts/demo_agent.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+"""Quick demo of the Canvas Calendar Agent with Gemma4 backend."""
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "sdk"))
+from canvas_sdk import CanvasAgent
+from canvas_sdk.backends.gemma4_backend import Gemma4Backend
+
+QUESTIONS = [
+    "What assignments do I have due this week?",
+    "I have two midterms next week. Can you help me plan study blocks?",
+    "Which assignments are still accepting late submissions?",
+]
+
+def main():
+    backend = Gemma4Backend(
+        endpoint=os.environ.get("LLM_ENDPOINT", "http://localhost:18080/v1"),
+        model=os.environ.get("LLM_MODEL", "nvidia/Gemma-4-31B-IT-NVFP4"),
+        api_key=os.environ.get("OPENAI_API_KEY", "forge"),
+    )
+    agent = CanvasAgent(backend)
+    for q in QUESTIONS:
+        print(f"\n[USER] {q}")
+        response = agent.run(q, canvas_token=os.environ.get("CANVAS_TOKEN", ""))
+        print(f"[AGENT] {response[:500]}")
+
+if __name__ == "__main__":
+    main()

--- a/sdk/canvas_sdk/__init__.py
+++ b/sdk/canvas_sdk/__init__.py
@@ -2,6 +2,19 @@
 
 from canvas_sdk.canvas import Canvas
 
-__all__ = ["Canvas"]
+__all__ = ["Canvas", "CanvasAgent", "Gemma4Backend"]
 
 __version__ = "1.0.0"
+
+
+def __getattr__(name):
+    """Lazy import of agent harness so SDK consumers without httpx still work."""
+    if name == "CanvasAgent":
+        from canvas_sdk.agent import CanvasAgent
+
+        return CanvasAgent
+    if name == "Gemma4Backend":
+        from canvas_sdk.backends.gemma4_backend import Gemma4Backend
+
+        return Gemma4Backend
+    raise AttributeError(f"module 'canvas_sdk' has no attribute {name!r}")

--- a/sdk/canvas_sdk/agent.py
+++ b/sdk/canvas_sdk/agent.py
@@ -1,0 +1,126 @@
+"""Agentic inference loop for the Canvas Calendar Agent.
+
+The loop drives a Gemma4-style model through the Canvas/Calendar/Study tool
+registry until the model produces a final answer with no further tool calls
+(or the turn budget is exhausted).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any
+
+from canvas_sdk.agent_tools import dispatch, get_schemas
+from canvas_sdk.backends.gemma4_backend import Gemma4Backend
+from canvas_sdk.tool_parser import extract_final_answer, format_tool_result, parse_tool_calls
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_SYSTEM_PROMPT = """You are the Canvas Calendar Agent, a tutor-style assistant that helps a college \
+student manage their Canvas LMS coursework and weekly study schedule.
+
+Tone: concise, friendly, action-oriented. Prefer short bullet lists.
+
+You can call tools using this exact format inside your reply:
+<|tool_call>call:tool.name{arg1: value, arg2: <|"|>quoted string<|"|>}<tool_call|>
+
+After the tool runs, you will see the result wrapped in:
+<|tool_response>response:tool.name{value:<|"|>{...}<|"|>}<tool_response|>
+
+Rules:
+- Only call tools when the user actually needs live Canvas/calendar data.
+- Combine multiple tool calls in one turn when they are independent.
+- Once you have enough information, write the final answer in plain prose.
+  Do not include any <|tool_call> blocks in the final answer.
+- Never invent assignment names, due dates, or course IDs — use tool output.
+
+Available tools:
+{tool_catalog}
+"""
+
+
+def _format_tool_catalog(schemas: list[dict]) -> str:
+    """Render the tool registry as a compact bullet list for the system prompt."""
+    lines: list[str] = []
+    for entry in schemas:
+        fn = entry.get("function", entry)
+        name = fn.get("name", "?")
+        desc = (fn.get("description") or "").strip().splitlines()[0] if fn.get("description") else ""
+        params = fn.get("parameters", {}).get("properties", {}) or {}
+        param_keys = ", ".join(sorted(params.keys())) if params else "—"
+        lines.append(f"- {name}({param_keys}) — {desc}")
+    return "\n".join(lines)
+
+
+def build_system_prompt(template: str = DEFAULT_SYSTEM_PROMPT) -> str:
+    """Render the default system prompt with the live tool catalog."""
+    catalog = _format_tool_catalog(get_schemas())
+    return template.replace("{tool_catalog}", catalog)
+
+
+class CanvasAgent:
+    """Drives a Gemma4 backend through the Canvas tool registry."""
+
+    def __init__(self, backend: Gemma4Backend, max_turns: int = 8):
+        self.backend = backend
+        self.max_turns = max_turns
+
+    def run(
+        self,
+        user_message: str,
+        canvas_token: str = "",
+        system_prompt: str | None = None,
+    ) -> str:
+        """Run the agent loop and return the final answer string."""
+        if canvas_token:
+            os.environ["CANVAS_TOKEN"] = canvas_token
+
+        sys_prompt = system_prompt or build_system_prompt()
+        schemas = get_schemas()
+
+        messages: list[dict] = [
+            {"role": "system", "content": sys_prompt},
+            {"role": "user", "content": user_message},
+        ]
+
+        last_text = ""
+        for turn in range(self.max_turns):
+            try:
+                raw = self.backend.chat(messages=messages, tools=schemas)
+            except Exception as exc:
+                logger.exception("Backend chat call failed on turn %s", turn)
+                return f"[agent error: backend call failed: {exc}]"
+
+            last_text = raw or ""
+            calls = parse_tool_calls(last_text)
+            if not calls:
+                return extract_final_answer(last_text)
+
+            messages.append({"role": "assistant", "content": last_text})
+
+            for call in calls:
+                tool_name = call["tool"]
+                args = call["args"]
+                logger.info("agent dispatch %s args=%s", tool_name, args)
+                try:
+                    result: Any = dispatch(tool_name, args)
+                except KeyError:
+                    result = {"error": f"unknown tool: {tool_name}"}
+                except Exception as exc:
+                    result = {"error": f"{type(exc).__name__}: {exc}"}
+
+                if not isinstance(result, dict):
+                    result = {"value": result}
+
+                messages.append(
+                    {
+                        "role": "tool",
+                        "name": tool_name,
+                        "content": format_tool_result(tool_name, result),
+                    }
+                )
+
+        return extract_final_answer(last_text) or "[agent error: turn budget exhausted]"

--- a/sdk/canvas_sdk/backends/__init__.py
+++ b/sdk/canvas_sdk/backends/__init__.py
@@ -1,0 +1,14 @@
+"""LLM and calendar backend adapters for the Canvas Calendar Agent."""
+
+from __future__ import annotations
+
+
+def __getattr__(name):
+    if name == "Gemma4Backend":
+        from canvas_sdk.backends.gemma4_backend import Gemma4Backend
+
+        return Gemma4Backend
+    raise AttributeError(f"module 'canvas_sdk.backends' has no attribute {name!r}")
+
+
+__all__ = ["Gemma4Backend"]

--- a/sdk/canvas_sdk/backends/gemma4_backend.py
+++ b/sdk/canvas_sdk/backends/gemma4_backend.py
@@ -1,0 +1,75 @@
+"""OpenAI-compatible LLM backend for Gemma4 inference.
+
+Talks to any OpenAI-compatible chat-completions endpoint (vLLM, llama.cpp, forge,
+spark-proxy, etc.). Default points at the local spark-proxy router on :18080.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+try:
+    import httpx
+except ImportError as exc:  # pragma: no cover - import-time guard
+    raise ImportError(
+        "Gemma4Backend requires httpx. Install with: pip install httpx"
+    ) from exc
+
+
+class Gemma4Backend:
+    """OpenAI-compatible backend for Gemma4 models.
+
+    Sends chat-completions requests and returns the raw assistant string so
+    the caller can run the Gemma4 tool-call parser on it. Tool schemas are
+    forwarded as the `tools` field for backends that support native tool use,
+    but Gemma4 emits its own ``<|tool_call>...<tool_call|>`` format inside the
+    text content regardless.
+    """
+
+    def __init__(
+        self,
+        endpoint: str = "http://localhost:18080/v1",
+        model: str = "google/gemma-4-e2b-it",
+        api_key: str = "forge",
+        timeout: float = 60.0,
+    ):
+        self.endpoint = endpoint.rstrip("/")
+        self.model = model
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def chat(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        temperature: float = 0.2,
+        max_tokens: int = 1024,
+        **kw: Any,
+    ) -> str:
+        """Send a chat-completions request and return the assistant text."""
+        payload: dict[str, Any] = {
+            "model": self.model,
+            "messages": messages,
+            "temperature": temperature,
+            "max_tokens": max_tokens,
+        }
+        if tools:
+            payload["tools"] = tools
+        payload.update(kw)
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+
+        url = f"{self.endpoint}/chat/completions"
+        with httpx.Client(timeout=self.timeout) as client:
+            resp = client.post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+
+        try:
+            return data["choices"][0]["message"]["content"] or ""
+        except (KeyError, IndexError, TypeError):
+            return json.dumps(data)

--- a/sdk/canvas_sdk/tool_parser.py
+++ b/sdk/canvas_sdk/tool_parser.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+import json, logging, re
+
+logger = logging.getLogger(__name__)
+
+_TOOL_CALL_RE = re.compile(r"<\|tool_call>(.*?)<tool_call\|>", re.DOTALL)
+_FUNC_RE = re.compile(r"^call:([\w.]+)\{(.*)\}$", re.DOTALL)
+
+
+def _args_to_dict(args_str: str) -> dict:
+    strings: list[str] = []
+
+    def _stash(m: re.Match) -> str:
+        strings.append(m.group(1))
+        return f'"__S{len(strings) - 1}__"'
+
+    sanitized = re.sub(r"<\|\"\|>([^<]*(?:<(?!\|\"\|>)[^<]*)*)<\|\"\|>", _stash, args_str, flags=re.DOTALL)
+    sanitized = re.sub(r"(?:^|(?<=,)|(?<=\{))(\s*\w+):", r'"\1":', sanitized)
+    obj = json.loads("{" + sanitized + "}")
+
+    def _restore(v):
+        if isinstance(v, str):
+            m = re.fullmatch(r"__S(\d+)__", v)
+            return strings[int(m.group(1))] if m else v
+        if isinstance(v, dict): return {k: _restore(val) for k, val in v.items()}
+        if isinstance(v, list): return [_restore(x) for x in v]
+        return v
+    return _restore(obj)
+
+
+def parse_tool_calls(text: str) -> list[dict]:
+    """Parse Gemma4 tool calls: <|tool_call>call:name{args}<tool_call|>"""
+    results = []
+    for match in _TOOL_CALL_RE.finditer(text):
+        body = match.group(1).strip()
+        m = _FUNC_RE.match(body)
+        if not m: continue
+        try:
+            arguments = _args_to_dict(m.group(2))
+        except (json.JSONDecodeError, IndexError, KeyError):
+            continue
+        results.append({"tool": m.group(1), "args": arguments})
+    return results
+
+
+def format_tool_result(tool_name: str, result: dict) -> str:
+    body = json.dumps(result)
+    return f'<|tool_response>response:{tool_name}{{value:<|"|>{body}<|"|>}}<tool_response|>'
+
+
+def extract_final_answer(text: str) -> str:
+    return re.sub(r"<\|tool_call>.*?<tool_call\|>", "", text, flags=re.DOTALL).strip()

--- a/sdk/pyproject.toml
+++ b/sdk/pyproject.toml
@@ -8,4 +8,4 @@ version = "1.0.0"
 description = "Canvas LMS Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"
-dependencies = ["requests>=2.20", "arrow>=1.0", "pytz>=2019.1"]
+dependencies = ["requests>=2.20", "arrow>=1.0", "pytz>=2019.1", "httpx>=0.24"]

--- a/src/canvas_tui/config.py
+++ b/src/canvas_tui/config.py
@@ -47,6 +47,12 @@ class Config:
     use_ai_reranker: bool = False
     model_path: str = ""
 
+    # LLM agent settings — OpenAI-compatible endpoint for fine-tuned Gemma4
+    llm_endpoint: str = "http://localhost:18080/v1"
+    llm_model: str = "google/gemma-4-e2b-it"
+    llm_api_key: str = "forge"
+    agent_max_turns: int = 8
+
     config_dir: str = field(default_factory=lambda: os.path.expanduser("~/.config/canvas-tui"))
 
     # Appearance
@@ -73,6 +79,7 @@ class Config:
         self.default_block_min = max(5, min(self.default_block_min, 480))
         self.ann_past_days = max(0, min(self.ann_past_days, 365))
         self.ann_future_days = max(0, min(self.ann_future_days, 365))
+        self.agent_max_turns = max(1, min(self.agent_max_turns, 32))
         if self.theme not in ("dark", "light"):
             self.theme = "dark"
         if self.sidebar_position not in ("left", "right"):
@@ -193,6 +200,10 @@ def _overlay_file_config(cfg: Config) -> None:
         "ical_write_path": "ical_write_path",
         "use_ai_reranker": "use_ai_reranker",
         "model_path": "model_path",
+        "llm_endpoint": "llm_endpoint",
+        "llm_model": "llm_model",
+        "llm_api_key": "llm_api_key",
+        "agent_max_turns": "agent_max_turns",
         "ann_past_days": "ann_past_days",
         "ann_future_days": "ann_future_days",
         # Support the typo variant for backwards compat


### PR DESCRIPTION
## Summary
- OpenAI-compatible Gemma4 backend for inference against fine-tuned E2B-IT models
- Ports Gemma4 `<|tool_call>` tool parser from training pipeline
- Agentic loop: LLM -> parse tool calls -> dispatch Canvas tools -> loop -> final answer
- Config fields for LLM endpoint/model/API key
- Demo script and docs page

## Architecture
```
User -> CanvasAgent.run() -> Gemma4Backend -> vLLM@:18080
                ^- parse tool calls (tool_parser.py)
           agent_tools.dispatch() -> Canvas API / Calendar / Study tools
                ^- tool results injected as messages
```

## Test plan
- [ ] `python scripts/demo_agent.py` runs without error (mock Canvas token OK)
- [ ] `from canvas_sdk import CanvasAgent, Gemma4Backend` imports cleanly
- [ ] tool_parser correctly parses `<|tool_call>call:canvas.get_todo{}<tool_call|>`