### PR TITLE
feat(sdk): Gemini fallback + auto-download + GitHub Pages agent demo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -75,6 +75,12 @@ jobs:
       - name: Install homepage
         run: cp docs-site/index.html site/index.html
 
+      # Copy the standalone Gemini-backed agent demo (no untrusted input)
+      - name: Install agent demo
+        run: |
+          mkdir -p site/agent-demo
+          cp docs-site/agent-demo/index.html site/agent-demo/index.html
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/README.md
+++ b/README.md
@@ -17,6 +17,38 @@ Canvas API tool calls with neuroscience-grounded study planning heuristics
 
 Model weights will be published to HuggingFace and the accompanying paper will be published on Zenodo once v2 training is complete.
 
+### Try the agent right now
+
+You don't need the fine-tuned weights to try the agent — the SDK ships a
+**Gemini fallback backend** that speaks the same Gemma4 tool-call protocol.
+
+- **Browser demo** (mock Canvas data, your Gemini API key): [kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/](https://kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/)
+- **Python SDK** (real Canvas data via your token):
+
+  ```bash
+  pip install canvas-sdk[gemini]          # base + Gemini fallback
+  pip install canvas-sdk[autodownload]    # also fetches the v7-dpo Gemma4 model from HF
+  pip install canvas-sdk[all]             # both
+  ```
+
+  ```python
+  import os
+  from canvas_sdk import CanvasAgent
+
+  os.environ["GOOGLE_API_KEY"]   = "..."        # for the Gemini fallback
+  os.environ["CANVAS_TOKEN"]     = "..."        # your Canvas token
+  os.environ["CANVAS_BASE_URL"]  = "https://canvas.vt.edu"
+
+  agent = CanvasAgent.auto()                    # auto-resolves: env -> local -> HF -> Gemini
+  print(agent.run("What is due this week?"))
+  ```
+
+  Resolution order for `CanvasAgent.auto()`:
+  1. `CANVAS_LLM_ENDPOINT` env (skip auto-download, use your own server)
+  2. Local cache at `~/.cache/canvas-agent/v7-dpo/` (spawns vLLM on :8765)
+  3. Download `kleinpanic/canvas-calendar-agent-v7-dpo` from HF, then (2)
+  4. Fall back to Gemini (`gemini-2.5-flash` by default)
+
 ---
 
 ## Overview
@@ -203,6 +235,7 @@ All commits to protected branches must be **GPG signed**.
 ## Documentation
 
 - **[Docs site](https://kleinpanic.github.io/CS3704-Canvas-Project/)** — live project docs
+- **[Agent demo](https://kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/)** — chat with the Canvas Calendar Agent in your browser (Gemini-backed)
 - **[Architecture docs](docs-site/architecture.md)** — system design decisions
 - **[Browser extension docs](docs-site/extension.md)** — shared client/runtime architecture
 - **[Workflow guide](docs-site/workflow.md)** — how the team works

--- a/docs-site/agent-demo/index.html
+++ b/docs-site/agent-demo/index.html
@@ -1,0 +1,582 @@
+<!DOCTYPE html>
+<html lang="en" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Canvas Calendar Agent — Live Demo</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: { canvas: { red: '#d63e36', dark: '#b83830' } },
+          fontFamily: {
+            sans: ['-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'Roboto', 'sans-serif'],
+          },
+        },
+      },
+    };
+  </script>
+  <style>
+    .tool-card { background: #1f1f23; border: 1px solid #2e2e34; border-radius: 12px; }
+    .chat-bubble-user { background: #d63e36; color: white; }
+    .chat-bubble-agent { background: #1f1f23; border: 1px solid #2e2e34; }
+    pre { white-space: pre-wrap; word-break: break-word; }
+    details summary { cursor: pointer; user-select: none; }
+    details[open] summary svg { transform: rotate(90deg); }
+    details summary svg { transition: transform 0.15s ease; }
+    .typing-dot { animation: typing 1.4s infinite; }
+    .typing-dot:nth-child(2) { animation-delay: 0.2s; }
+    .typing-dot:nth-child(3) { animation-delay: 0.4s; }
+    @keyframes typing {
+      0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
+      30% { opacity: 1; transform: translateY(-3px); }
+    }
+  </style>
+</head>
+<body class="bg-gray-950 text-gray-100 font-sans min-h-screen">
+
+  <nav class="sticky top-0 z-40 bg-gray-950/95 backdrop-blur border-b border-gray-800">
+    <div class="max-w-6xl mx-auto px-6 h-14 flex items-center justify-between">
+      <a href="../index.html" class="flex items-center gap-3">
+        <div class="w-8 h-8 rounded-lg bg-canvas-red flex items-center justify-center font-bold text-white text-sm">C</div>
+        <span class="font-semibold">Canvas Calendar Agent</span>
+      </a>
+      <div class="flex items-center gap-6 text-sm text-gray-400">
+        <a href="../index.html" class="hover:text-white">Home</a>
+        <a href="../docs/architecture/" class="hover:text-white">Architecture</a>
+        <a href="https://github.com/kleinpanic/CS3704-Canvas-Project" target="_blank" rel="noopener" class="hover:text-white">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="max-w-4xl mx-auto px-6 pt-12 pb-6">
+    <div class="inline-flex items-center gap-2 bg-canvas-red/10 border border-canvas-red/30 rounded-full px-3 py-1 text-canvas-red text-xs font-medium mb-4">
+      <span class="w-2 h-2 rounded-full bg-canvas-red animate-pulse"></span>
+      Live agent demo &mdash; runs in your browser
+    </div>
+    <h1 class="text-4xl md:text-5xl font-bold mb-4 leading-tight">
+      Talk to the Canvas<br/>Calendar Agent
+    </h1>
+    <p class="text-gray-400 text-lg leading-relaxed mb-2">
+      The Canvas Calendar Agent is a tutor-style assistant that knows about your Canvas
+      assignments, calendar, and study schedule. It speaks an 18-tool function-calling
+      protocol that the SDK parses and dispatches against live data.
+    </p>
+    <p class="text-gray-500 text-sm">
+      This page wires Gemini up as a fallback brain so you can experience the same protocol
+      without running the fine-tuned Gemma4 weights locally.
+      <strong class="text-gray-300">Mock Canvas data only.</strong> Tool calls return
+      pre-baked sample results.
+    </p>
+  </header>
+
+  <section class="max-w-4xl mx-auto px-6 pb-6">
+    <div class="bg-gray-900 border border-gray-800 rounded-2xl p-5 mb-4">
+      <details>
+        <summary class="flex items-center gap-2 text-sm font-medium text-gray-300">
+          <svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"/></svg>
+          Setup &mdash; paste your Gemini API key
+        </summary>
+        <div class="mt-3 space-y-3">
+          <p class="text-xs text-gray-400 leading-relaxed">
+            Get a free API key at
+            <a href="https://aistudio.google.com/apikey" target="_blank" rel="noopener" class="text-canvas-red hover:underline">aistudio.google.com/apikey</a>.
+            The key is stored only in your browser's localStorage and never sent anywhere
+            except <code>generativelanguage.googleapis.com</code>.
+          </p>
+          <div class="flex gap-2">
+            <input
+              id="api-key"
+              type="password"
+              autocomplete="off"
+              placeholder="AIza..."
+              class="flex-1 bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-canvas-red"
+            />
+            <select id="model-pick" class="bg-gray-950 border border-gray-700 rounded-lg px-3 py-2 text-sm focus:outline-none focus:border-canvas-red">
+              <option value="gemini-2.5-flash">gemini-2.5-flash (fast)</option>
+              <option value="gemini-2.5-pro">gemini-2.5-pro (smart)</option>
+              <option value="gemini-1.5-flash">gemini-1.5-flash (legacy)</option>
+            </select>
+          </div>
+          <p class="text-xs text-gray-500" id="key-status">No key stored.</p>
+        </div>
+      </details>
+    </div>
+
+    <div class="bg-gray-900 border border-gray-800 rounded-2xl mb-4">
+      <div class="px-5 py-3 border-b border-gray-800 flex items-center justify-between">
+        <div class="text-sm font-medium text-gray-300">Sample questions</div>
+        <button id="clear-btn" class="text-xs text-gray-500 hover:text-gray-300">Clear chat</button>
+      </div>
+      <div class="px-5 py-4 flex flex-wrap gap-2" id="samples"></div>
+    </div>
+
+    <div id="chat" class="bg-gray-900 border border-gray-800 rounded-2xl min-h-[280px] p-5 space-y-4 mb-4">
+      <div class="text-gray-500 text-sm text-center py-8" id="chat-empty">
+        Try a sample question above, or ask anything about Canvas / your schedule.
+      </div>
+    </div>
+
+    <form id="chat-form" class="flex gap-2">
+      <textarea
+        id="input"
+        rows="2"
+        placeholder="Ask the agent &mdash; e.g. 'plan study blocks for finals week'"
+        class="flex-1 bg-gray-900 border border-gray-800 rounded-xl px-4 py-3 text-sm focus:outline-none focus:border-canvas-red resize-none"
+      ></textarea>
+      <button type="submit" id="send-btn"
+              class="bg-canvas-red hover:bg-canvas-dark text-white font-semibold px-6 rounded-xl disabled:opacity-50 disabled:cursor-not-allowed">
+        Send
+      </button>
+    </form>
+  </section>
+
+  <section class="max-w-4xl mx-auto px-6 py-12 border-t border-gray-800">
+    <h2 class="text-2xl font-bold mb-4">How it works</h2>
+    <pre class="text-xs text-gray-400 bg-gray-900 border border-gray-800 rounded-xl p-5 overflow-x-auto">
++---------------------+   user msg    +-----------------------+
+|  Browser (this UI)  | ------------> |  GeminiBackend (web)  |
+|  + chat history     |               |  injects Gemma4 proto |
++----------+----------+               +-----------+-----------+
+           ^                                      | content
+           | rendered final answer                v
+           |                            +-----------------+
+           |                            | Gemini API call |
+           |                            +--------+--------+
+           |                                     |
+           |        &lt;|tool_call&gt;call:NAME{...}&lt;tool_call|&gt;
+           |                                     v
+           |                       +---------------------------+
+           +---------------------- |  parseToolCalls()         |
+                                   |  dispatchMock(name, args) |
+                                   +---------------------------+
+</pre>
+    <p class="text-gray-400 text-sm leading-relaxed mt-4">
+      In production, the Python SDK swaps the browser-side Gemini call for a local
+      <code>vLLM</code> server hosting the fine-tuned <code>gemma-4-e2b-it</code> weights
+      (auto-downloaded from HuggingFace on first run). Same parser, same 18 tools, same
+      contract &mdash; only the brain swaps.
+    </p>
+    <p class="text-gray-400 text-sm leading-relaxed mt-3">
+      Run it yourself:
+    </p>
+    <pre class="text-xs text-gray-300 bg-gray-900 border border-gray-800 rounded-xl p-5 mt-2 overflow-x-auto">pip install canvas-sdk[gemini]
+export GOOGLE_API_KEY=...
+
+python -c "from canvas_sdk import CanvasAgent; print(CanvasAgent.auto().run('what is due this week?'))"</pre>
+  </section>
+
+  <footer class="border-t border-gray-900 py-8 text-center text-gray-600 text-sm">
+    <p>CS3704 Canvas Calendar Agent &mdash; demo runs entirely in your browser.</p>
+  </footer>
+
+  <script>
+  // -----------------------------------------------------------------
+  // Tool catalog (mirrors src/sdk/canvas_sdk/agent_tools/)
+  // -----------------------------------------------------------------
+  const TOOL_CATALOG = [
+    {n:"canvas.list_courses",d:"List all enrolled courses for the current term."},
+    {n:"canvas.get_assignments",d:"Get upcoming assignments for one course or all active courses."},
+    {n:"canvas.get_course",d:"Get one course's metadata: name, code, credits, term, instructors."},
+    {n:"canvas.get_syllabus",d:"Fetch a course's syllabus (HTML stripped to plain text)."},
+    {n:"canvas.get_todo",d:"Fetch the student's Canvas todo/upcoming-events feed."},
+    {n:"canvas.get_grades",d:"Get the student's current grade per active course."},
+    {n:"canvas.list_announcements",d:"List recent course announcements (exam reschedules, extensions)."},
+    {n:"canvas.list_planner_items",d:"List Canvas planner items (student-created notes / overrides)."},
+    {n:"calendar.list_events",d:"List calendar events in a window (default next 14 days)."},
+    {n:"calendar.find_free_blocks",d:"Find free blocks matching constraints. Always call BEFORE create_event."},
+    {n:"calendar.create_event",d:"Create a calendar event (study block, deadline reminder, etc.)."},
+    {n:"calendar.modify_event",d:"Modify start/end/title of an existing event."},
+    {n:"calendar.delete_event",d:"Delete a calendar event by id."},
+    {n:"study.spaced_schedule",d:"Build a spaced-repetition schedule between today and an exam date."},
+    {n:"study.semester_schedule",d:"Lay out study blocks across a whole semester from a syllabus."},
+    {n:"study.recommend_block_size",d:"Recommend a deep-work block length given task difficulty."},
+    {n:"study.exam_bracket",d:"Bracket pre-exam study time + cooldown around an exam slot."},
+    {n:"reranker.priority_hint",d:"Rerank a list of upcoming items by urgency / weight / grade."}
+  ];
+
+  const TOOL_PROTOCOL = `\
+You are bridging into a Gemma4-trained tool-calling harness. The harness can
+ONLY parse tool calls in the exact Gemma4 textual format below. Do NOT use
+Google's native function-calling — emit the tool call as plain text inside
+your reply.
+
+Tool-call format (literal characters, no markdown fences):
+<|tool_call>call:tool.name{arg1: value, arg2: <|"|>quoted string<|"|>}<tool_call|>
+
+After execution the harness will replay the result to you wrapped in:
+<|tool_response>response:tool.name{value:<|"|>{...json...}<|"|>}<tool_response|>
+
+Rules:
+- Quote every string argument with the <|"|>...<|"|> sentinel.
+- Issue independent calls in the same turn when possible.
+- Once you have enough information, write the final answer in plain prose
+  with NO <|tool_call> blocks remaining.
+- Never invent assignment names, due dates, course IDs, or grades — every
+  fact must trace back to a tool result.
+
+Available tools:
+${TOOL_CATALOG.map(t => `- ${t.n} — ${t.d}`).join("\n")}
+`;
+
+  const AGENT_SYSTEM = `You are the Canvas Calendar Agent, a tutor-style assistant that helps a college student manage their Canvas LMS coursework and weekly study schedule. Tone: concise, friendly, action-oriented. Prefer short bullet lists.`;
+
+  // -----------------------------------------------------------------
+  // Mock Canvas data (week of 2026-05-04)
+  // -----------------------------------------------------------------
+  const MOCK_DATA = {
+    "canvas.list_courses": [
+      {id: 101, name: "CS 3704 Intermediate Software Design", course_code: "CS3704", credits: 3},
+      {id: 102, name: "STAT 3704 Statistics for CS", course_code: "STAT3704", credits: 3},
+      {id: 103, name: "ENGL 1106 Composition", course_code: "ENGL1106", credits: 3}
+    ],
+    "canvas.get_assignments": [
+      {id: 9001, title: "Midterm 2", course_id: 101, due_iso: "2026-05-12T17:00:00-04:00", points_possible: 100, submitted: false, late: false, missing: false},
+      {id: 9002, title: "Midterm", course_id: 102, due_iso: "2026-05-13T15:00:00-04:00", points_possible: 100, submitted: false, late: false, missing: false},
+      {id: 9003, title: "Essay 4 draft", course_id: 103, due_iso: "2026-05-09T23:59:00-04:00", points_possible: 50, submitted: false, late: false, missing: false}
+    ],
+    "canvas.get_todo": [
+      {type: "submitting", course_id: 101, title: "Midterm 2", due_iso: "2026-05-12T17:00:00-04:00", points_possible: 100},
+      {type: "submitting", course_id: 102, title: "Midterm", due_iso: "2026-05-13T15:00:00-04:00", points_possible: 100}
+    ],
+    "canvas.get_grades": [
+      {course_id: 101, current_score: 87.4},
+      {course_id: 102, current_score: 92.1},
+      {course_id: 103, current_score: 79.8}
+    ],
+    "canvas.list_announcements": [
+      {id: 5001, title: "Midterm 2 covers chapters 6-9", course_id: 101, posted_iso: "2026-05-03T10:00:00-04:00", message_preview: "Reminder: midterm 2 will cover graphs, DP, and the chapter 9 review problems..."}
+    ],
+    "calendar.find_free_blocks": [
+      {start: "2026-05-06T09:00", end: "2026-05-06T11:30", duration_min: 150},
+      {start: "2026-05-07T13:00", end: "2026-05-07T16:00", duration_min: 180},
+      {start: "2026-05-09T10:00", end: "2026-05-09T12:00", duration_min: 120},
+      {start: "2026-05-10T14:00", end: "2026-05-10T17:00", duration_min: 180},
+      {start: "2026-05-11T19:00", end: "2026-05-11T21:00", duration_min: 120}
+    ],
+    "calendar.list_events": [
+      {id: "ev1", summary: "CS 3704 lecture", start: "2026-05-06T11:30", end: "2026-05-06T12:45"},
+      {id: "ev2", summary: "Lunch with Sam", start: "2026-05-07T12:00", end: "2026-05-07T13:00"}
+    ],
+    "study.spaced_schedule": [
+      {date: "2026-05-06", topic: "review", minutes: 60},
+      {date: "2026-05-08", topic: "practice problems", minutes: 90},
+      {date: "2026-05-10", topic: "mock exam", minutes: 120},
+      {date: "2026-05-11", topic: "formula sheet + light review", minutes: 60}
+    ]
+  };
+
+  function dispatchMock(name, args) {
+    if (name in MOCK_DATA) return MOCK_DATA[name];
+    if (name === "calendar.create_event") return {ok: true, id: "ev_new_" + Math.random().toString(36).slice(2,8)};
+    if (name === "study.recommend_block_size") return {minutes: 90, rationale: "Deep work block for complex material"};
+    if (name === "study.exam_bracket") return {pre_minutes: 240, cooldown_minutes: 30};
+    if (name === "reranker.priority_hint") return Array.isArray(args.items) ? args.items.slice().reverse() : [];
+    return {note: "(mock data not configured for this tool in the demo)"};
+  }
+
+  // -----------------------------------------------------------------
+  // Gemma4 tool-call parser (mirrors src/sdk/canvas_sdk/tool_parser.py)
+  // -----------------------------------------------------------------
+  const TOOL_CALL_RE = /<\|tool_call>(.*?)<tool_call\|>/gs;
+  const FUNC_RE = /^call:([\w.]+)\{(.*)\}$/s;
+
+  function argsToObj(s) {
+    const strings = [];
+    let sanitized = s.replace(/<\|"\|>([\s\S]*?)<\|"\|>/g, (_, inner) => {
+      strings.push(inner);
+      return `"__S${strings.length-1}__"`;
+    });
+    sanitized = sanitized.replace(/(?:^|(?<=,)|(?<=\{))(\s*\w+):/g, '"$1":');
+    let obj;
+    try { obj = JSON.parse("{" + sanitized + "}"); }
+    catch { return {}; }
+    const restore = v => {
+      if (typeof v === "string") {
+        const m = v.match(/^__S(\d+)__$/);
+        return m ? strings[parseInt(m[1])] : v;
+      }
+      if (Array.isArray(v)) return v.map(restore);
+      if (v && typeof v === "object") return Object.fromEntries(Object.entries(v).map(([k,vv]) => [k, restore(vv)]));
+      return v;
+    };
+    return restore(obj);
+  }
+
+  function parseToolCalls(text) {
+    const calls = [];
+    for (const m of text.matchAll(TOOL_CALL_RE)) {
+      const body = m[1].trim();
+      const fm = body.match(FUNC_RE);
+      if (!fm) continue;
+      try {
+        calls.push({tool: fm[1], args: argsToObj(fm[2])});
+      } catch {}
+    }
+    return calls;
+  }
+
+  function stripToolCalls(text) {
+    return text.replace(/<\|tool_call>[\s\S]*?<tool_call\|>/g, "").trim();
+  }
+
+  // -----------------------------------------------------------------
+  // Gemini API call
+  // -----------------------------------------------------------------
+  async function callGemini(apiKey, model, history) {
+    const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${encodeURIComponent(apiKey)}`;
+    const systemInstruction = AGENT_SYSTEM + "\n\n" + TOOL_PROTOCOL;
+
+    const body = {
+      systemInstruction: { parts: [{ text: systemInstruction }] },
+      contents: history.map(m => ({
+        role: m.role === "assistant" ? "model" : "user",
+        parts: [{ text: m.content }]
+      })),
+      generationConfig: { temperature: 0.2, maxOutputTokens: 1024 }
+    };
+
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify(body)
+    });
+    const data = await resp.json();
+    if (!resp.ok) throw new Error(data.error?.message || `HTTP ${resp.status}`);
+    return data.candidates?.[0]?.content?.parts?.[0]?.text || "";
+  }
+
+  // -----------------------------------------------------------------
+  // UI (no innerHTML for untrusted content — use createElement / textContent)
+  // -----------------------------------------------------------------
+  const apiKeyInput = document.getElementById("api-key");
+  const modelPick = document.getElementById("model-pick");
+  const keyStatus = document.getElementById("key-status");
+  const chat = document.getElementById("chat");
+  const chatEmpty = document.getElementById("chat-empty");
+  const form = document.getElementById("chat-form");
+  const input = document.getElementById("input");
+  const sendBtn = document.getElementById("send-btn");
+  const samplesEl = document.getElementById("samples");
+  const clearBtn = document.getElementById("clear-btn");
+
+  apiKeyInput.value = localStorage.getItem("cca-gemini-key") || "";
+  modelPick.value = localStorage.getItem("cca-gemini-model") || "gemini-2.5-flash";
+  function syncKeyStatus() {
+    keyStatus.textContent = apiKeyInput.value
+      ? `Key stored locally (${apiKeyInput.value.slice(0,6)}...).`
+      : "No key stored.";
+  }
+  syncKeyStatus();
+  apiKeyInput.addEventListener("change", () => {
+    localStorage.setItem("cca-gemini-key", apiKeyInput.value);
+    syncKeyStatus();
+  });
+  modelPick.addEventListener("change", () => {
+    localStorage.setItem("cca-gemini-model", modelPick.value);
+  });
+
+  const SAMPLES = [
+    "What's due this week?",
+    "Plan study blocks for my CS 3704 and STAT 3704 midterms.",
+    "Which course am I doing worst in?",
+    "Schedule a 90-minute deep-work block tomorrow morning.",
+    "Summarize the last week of announcements across all my courses."
+  ];
+  for (const s of SAMPLES) {
+    const btn = document.createElement("button");
+    btn.className = "text-xs px-3 py-1.5 rounded-full bg-gray-800 hover:bg-gray-700 text-gray-300 border border-gray-700";
+    btn.textContent = s;
+    btn.addEventListener("click", () => { input.value = s; input.focus(); });
+    samplesEl.appendChild(btn);
+  }
+
+  let history = [];
+
+  function clearEmptyState() {
+    if (chatEmpty && chatEmpty.parentNode === chat) chat.removeChild(chatEmpty);
+  }
+
+  function makeToolCard(tc) {
+    const card = document.createElement("details");
+    card.className = "tool-card text-xs";
+
+    const summary = document.createElement("summary");
+    summary.className = "px-3 py-2 flex items-center gap-2 text-gray-300";
+
+    // chevron
+    const sumIcon = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    sumIcon.setAttribute("class", "w-3 h-3 text-canvas-red");
+    sumIcon.setAttribute("fill", "none");
+    sumIcon.setAttribute("viewBox", "0 0 24 24");
+    sumIcon.setAttribute("stroke", "currentColor");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("stroke-linecap", "round");
+    path.setAttribute("stroke-linejoin", "round");
+    path.setAttribute("stroke-width", "2");
+    path.setAttribute("d", "M9 5l7 7-7 7");
+    sumIcon.appendChild(path);
+    summary.appendChild(sumIcon);
+
+    const nameSpan = document.createElement("span");
+    nameSpan.className = "font-mono";
+    nameSpan.textContent = tc.tool;
+    summary.appendChild(nameSpan);
+
+    const argsLabel = document.createElement("span");
+    argsLabel.className = "text-gray-500";
+    argsLabel.textContent = `(${Object.keys(tc.args).length} args)`;
+    summary.appendChild(argsLabel);
+
+    card.appendChild(summary);
+
+    const body = document.createElement("div");
+    body.className = "px-3 py-2 border-t border-gray-800 space-y-2";
+
+    const argsRow = document.createElement("div");
+    const argsLab = document.createElement("span");
+    argsLab.className = "text-gray-500";
+    argsLab.textContent = "args: ";
+    const argsCode = document.createElement("code");
+    argsCode.className = "text-gray-300";
+    argsCode.textContent = JSON.stringify(tc.args);
+    argsRow.appendChild(argsLab);
+    argsRow.appendChild(argsCode);
+    body.appendChild(argsRow);
+
+    const resRow = document.createElement("div");
+    const resLab = document.createElement("span");
+    resLab.className = "text-gray-500";
+    resLab.textContent = "result:";
+    resRow.appendChild(resLab);
+    const resPre = document.createElement("pre");
+    resPre.className = "text-gray-300 mt-1";
+    resPre.textContent = JSON.stringify(tc.result, null, 2);
+    resRow.appendChild(resPre);
+    body.appendChild(resRow);
+
+    card.appendChild(body);
+    return card;
+  }
+
+  function renderMessage(role, content, toolCalls = null) {
+    clearEmptyState();
+    const wrap = document.createElement("div");
+    wrap.className = role === "user" ? "flex justify-end" : "flex justify-start";
+
+    const bubble = document.createElement("div");
+    bubble.className = role === "user"
+      ? "chat-bubble-user max-w-[75%] rounded-2xl px-4 py-2.5"
+      : "chat-bubble-agent max-w-[85%] rounded-2xl px-4 py-3 text-gray-100";
+
+    if (toolCalls && toolCalls.length) {
+      const toolWrap = document.createElement("div");
+      toolWrap.className = "space-y-2 mb-2";
+      for (const tc of toolCalls) toolWrap.appendChild(makeToolCard(tc));
+      bubble.appendChild(toolWrap);
+    }
+
+    if (content) {
+      const text = document.createElement("div");
+      text.className = "text-sm leading-relaxed whitespace-pre-wrap";
+      text.textContent = content;
+      bubble.appendChild(text);
+    }
+
+    wrap.appendChild(bubble);
+    chat.appendChild(wrap);
+    chat.scrollTop = chat.scrollHeight;
+    return bubble;
+  }
+
+  function showTyping() {
+    const wrap = document.createElement("div");
+    wrap.className = "flex justify-start";
+    wrap.id = "typing";
+    const bubble = document.createElement("div");
+    bubble.className = "chat-bubble-agent rounded-2xl px-4 py-3 text-sm flex gap-1.5";
+    for (let i = 0; i < 3; i++) {
+      const dot = document.createElement("span");
+      dot.className = "typing-dot w-2 h-2 rounded-full bg-gray-500";
+      bubble.appendChild(dot);
+    }
+    wrap.appendChild(bubble);
+    chat.appendChild(wrap);
+    chat.scrollTop = chat.scrollHeight;
+  }
+  function hideTyping() {
+    const t = document.getElementById("typing");
+    if (t) t.remove();
+  }
+
+  async function runAgent(userMsg) {
+    if (!apiKeyInput.value) {
+      renderMessage("agent", "Paste a Gemini API key in the setup panel above first.");
+      return;
+    }
+    history.push({role: "user", content: userMsg});
+    renderMessage("user", userMsg);
+    sendBtn.disabled = true;
+
+    try {
+      for (let turn = 0; turn < 6; turn++) {
+        showTyping();
+        let raw;
+        try {
+          raw = await callGemini(apiKeyInput.value, modelPick.value, history);
+        } catch (err) {
+          hideTyping();
+          renderMessage("agent", `Error calling Gemini: ${err.message}`);
+          return;
+        }
+        hideTyping();
+
+        const calls = parseToolCalls(raw);
+        if (!calls.length) {
+          const final = stripToolCalls(raw) || raw;
+          renderMessage("agent", final);
+          history.push({role: "assistant", content: raw});
+          return;
+        }
+
+        const calledWithResults = calls.map(c => ({...c, result: dispatchMock(c.tool, c.args)}));
+        renderMessage("agent", stripToolCalls(raw), calledWithResults);
+        history.push({role: "assistant", content: raw});
+
+        const resultBlock = calledWithResults.map(c =>
+          `<|tool_response>response:${c.tool}{value:<|"|>${JSON.stringify(c.result)}<|"|>}<tool_response|>`
+        ).join("\n");
+        history.push({role: "user", content: resultBlock});
+      }
+      renderMessage("agent", "[turn budget exhausted]");
+    } finally {
+      sendBtn.disabled = false;
+    }
+  }
+
+  form.addEventListener("submit", e => {
+    e.preventDefault();
+    const msg = input.value.trim();
+    if (!msg) return;
+    input.value = "";
+    runAgent(msg);
+  });
+  input.addEventListener("keydown", e => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      form.requestSubmit();
+    }
+  });
+  clearBtn.addEventListener("click", () => {
+    history = [];
+    while (chat.firstChild) chat.removeChild(chat.firstChild);
+    const empty = document.createElement("div");
+    empty.className = "text-gray-500 text-sm text-center py-8";
+    empty.id = "chat-empty";
+    empty.textContent = "Chat cleared. Try a sample question above.";
+    chat.appendChild(empty);
+  });
+  </script>
+</body>
+</html>

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -39,6 +39,7 @@
       </div>
       <div class="flex items-center gap-6 text-sm text-gray-400">
         <a href="#demo" class="hover:text-white transition-colors">Live Demo</a>
+        <a href="agent-demo/" class="hover:text-white transition-colors">Agent Chat</a>
         <a href="docs/index.html" class="hover:text-white transition-colors">Docs</a>
         <a href="https://github.com/kleinpanic/CS3704-Canvas-Project"
            class="hover:text-white transition-colors flex items-center gap-1.5" target="_blank" rel="noopener">

--- a/src/sdk/canvas_sdk/__init__.py
+++ b/src/sdk/canvas_sdk/__init__.py
@@ -1,5 +1,3 @@
-from canvas_sdk.canvas import Canvas
-
 __all__ = [
     "Canvas",
     "CanvasAgent",
@@ -12,7 +10,13 @@ __version__ = "1.0.0"
 
 
 def __getattr__(name):
-    """Lazy import of agent harness so SDK consumers without httpx still work."""
+    """Lazy import so submodules with optional deps (arrow, httpx, google) don't
+    break ``import canvas_sdk`` for consumers that only need the agent harness.
+    """
+    if name == "Canvas":
+        from canvas_sdk.canvas import Canvas
+
+        return Canvas
     if name == "CanvasAgent":
         from canvas_sdk.agent import CanvasAgent
 

--- a/src/sdk/canvas_sdk/__init__.py
+++ b/src/sdk/canvas_sdk/__init__.py
@@ -1,8 +1,12 @@
-# -*- coding: utf-8 -*-
-
 from canvas_sdk.canvas import Canvas
 
-__all__ = ["Canvas", "CanvasAgent", "Gemma4Backend"]
+__all__ = [
+    "Canvas",
+    "CanvasAgent",
+    "GeminiBackend",
+    "Gemma4Backend",
+    "ensure_model",
+]
 
 __version__ = "1.0.0"
 
@@ -17,4 +21,12 @@ def __getattr__(name):
         from canvas_sdk.backends.gemma4_backend import Gemma4Backend
 
         return Gemma4Backend
+    if name == "GeminiBackend":
+        from canvas_sdk.backends.gemini_backend import GeminiBackend
+
+        return GeminiBackend
+    if name == "ensure_model":
+        from canvas_sdk.model_loader import ensure_model
+
+        return ensure_model
     raise AttributeError(f"module 'canvas_sdk' has no attribute {name!r}")

--- a/src/sdk/canvas_sdk/agent.py
+++ b/src/sdk/canvas_sdk/agent.py
@@ -7,7 +7,6 @@ registry until the model produces a final answer with no further tool calls
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 from typing import Any
@@ -15,6 +14,9 @@ from typing import Any
 from canvas_sdk.agent_tools import dispatch, get_schemas
 from canvas_sdk.backends.gemma4_backend import Gemma4Backend
 from canvas_sdk.tool_parser import extract_final_answer, format_tool_result, parse_tool_calls
+
+# Re-exported as a Union so callers can pass either backend without an extra import.
+AgentBackend = Gemma4Backend  # alias kept for back-compat; GeminiBackend is duck-compatible
 
 logger = logging.getLogger(__name__)
 
@@ -62,11 +64,31 @@ def build_system_prompt(template: str = DEFAULT_SYSTEM_PROMPT) -> str:
 
 
 class CanvasAgent:
-    """Drives a Gemma4 backend through the Canvas tool registry."""
+    """Drives a Gemma4 (or Gemini fallback) backend through the Canvas tool registry."""
 
-    def __init__(self, backend: Gemma4Backend, max_turns: int = 8):
+    def __init__(self, backend, max_turns: int = 8):
+        # Accepts Gemma4Backend OR GeminiBackend — both expose `.chat(messages, tools=...)`.
         self.backend = backend
         self.max_turns = max_turns
+
+    @classmethod
+    def auto(cls, max_turns: int = 8, **backend_kw):
+        """Build an agent using ``ensure_model()`` to resolve the backend.
+
+        If the model loader returns the Gemini-fallback sentinel, wires up a
+        ``GeminiBackend`` instead of ``Gemma4Backend``. Extra kwargs are
+        forwarded to whichever backend gets constructed (e.g. ``api_key=``).
+        """
+        from canvas_sdk.model_loader import GEMINI_FALLBACK_SENTINEL, ensure_model
+
+        endpoint, model = ensure_model()
+        if endpoint == GEMINI_FALLBACK_SENTINEL:
+            from canvas_sdk.backends.gemini_backend import GeminiBackend
+
+            backend = GeminiBackend(model=model, **backend_kw)
+        else:
+            backend = Gemma4Backend(endpoint=endpoint, model=model, **backend_kw)
+        return cls(backend, max_turns=max_turns)
 
     def run(
         self,

--- a/src/sdk/canvas_sdk/backends/gemini_backend.py
+++ b/src/sdk/canvas_sdk/backends/gemini_backend.py
@@ -1,0 +1,169 @@
+"""Gemini fallback backend for the Canvas Calendar Agent.
+
+Used when no fine-tuned Gemma4 model is available locally or via HF. The
+backend wraps Google's `google-generativeai` client and injects an extra
+system instruction that teaches Gemini the Gemma4 ``<|tool_call>...<tool_call|>``
+protocol so the rest of the harness (parser, dispatcher) can be reused
+without modification.
+
+Auth: reads ``GOOGLE_API_KEY`` from the environment (or accepts an explicit
+``api_key`` arg). Default model is ``gemini-2.5-flash`` — cheap, fast, and
+strong enough at instruction following to emit the tool-call format reliably.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+GEMINI_TOOL_PROTOCOL = """\
+You are bridging into a Gemma4-trained tool-calling harness. The harness can
+ONLY parse tool calls in the exact Gemma4 textual format below. Do NOT use
+Google's native function-calling — emit the tool call as plain text inside
+your reply.
+
+Tool-call format (literal characters, no markdown fences):
+<|tool_call>call:tool.name{arg1: value, arg2: <|"|>quoted string<|"|>}<tool_call|>
+
+After execution the harness will replay the result to you wrapped in:
+<|tool_response>response:tool.name{value:<|"|>{...json...}<|"|>}<tool_response|>
+
+Rules:
+- Quote every string argument with the ``<|"|>...<|"|>`` sentinel — ordinary
+  double quotes will be rejected.
+- Issue independent calls in the same turn when possible (parser handles
+  multiple blocks per reply).
+- Once you have enough information, write the final answer in plain prose
+  with NO ``<|tool_call>`` blocks remaining.
+- Never invent assignment names, due dates, course IDs, or grades — every
+  fact must trace back to a tool result.
+
+Available tools:
+{tool_catalog}
+"""
+
+
+def _format_tool_catalog(schemas: list[dict]) -> str:
+    """Render the tool registry as a compact bullet list (mirrors agent.py)."""
+    lines: list[str] = []
+    for entry in schemas:
+        fn = entry.get("function", entry)
+        name = fn.get("name", "?")
+        desc = (fn.get("description") or "").strip().splitlines()[0] if fn.get("description") else ""
+        params = fn.get("parameters", {}).get("properties", {}) or {}
+        param_keys = ", ".join(sorted(params.keys())) if params else "—"
+        lines.append(f"- {name}({param_keys}) — {desc}")
+    return "\n".join(lines)
+
+
+def build_gemini_system_prompt(schemas: list[dict] | None = None) -> str:
+    """Build the Gemini-specific tool-call protocol prompt.
+
+    Returns the full instruction text the caller should prepend (or merge)
+    into the agent's system prompt before sending to Gemini.
+    """
+    if schemas is None:
+        from canvas_sdk.agent_tools import get_schemas
+
+        schemas = get_schemas()
+    catalog = _format_tool_catalog(schemas)
+    return GEMINI_TOOL_PROTOCOL.replace("{tool_catalog}", catalog)
+
+
+class GeminiBackend:
+    """Gemini chat backend that speaks the Gemma4 tool-call protocol.
+
+    Mirrors the ``Gemma4Backend.chat()`` signature so ``CanvasAgent`` can
+    swap between them without code changes.
+    """
+
+    def __init__(
+        self,
+        model: str = "gemini-2.5-flash",
+        api_key: str | None = None,
+        timeout: float = 60.0,
+    ):
+        try:
+            import google.generativeai as genai
+        except ImportError as exc:
+            raise ImportError(
+                "GeminiBackend requires google-generativeai. Install with: pip install canvas-sdk[gemini]"
+            ) from exc
+
+        self._genai = genai
+        self.model = model
+        self.timeout = timeout
+        key = api_key or os.environ.get("GOOGLE_API_KEY") or os.environ.get("GEMINI_API_KEY")
+        if not key:
+            raise RuntimeError(
+                "GeminiBackend needs GOOGLE_API_KEY (or GEMINI_API_KEY) in env, or pass api_key= explicitly."
+            )
+        genai.configure(api_key=key)
+
+    def chat(
+        self,
+        messages: list[dict],
+        tools: list[dict] | None = None,
+        temperature: float = 0.2,
+        max_tokens: int = 1024,
+        **_: Any,
+    ) -> str:
+        """Send a chat turn to Gemini, return raw assistant text.
+
+        Merges any incoming `system` message with the Gemma4 protocol prompt
+        so Gemini emits ``<|tool_call>`` blocks the harness can parse.
+        """
+        protocol = build_gemini_system_prompt(tools)
+
+        sys_chunks: list[str] = [protocol]
+        history: list[dict] = []
+        for msg in messages:
+            role = msg.get("role")
+            content = msg.get("content", "")
+            if role == "system":
+                sys_chunks.append(content)
+            elif role == "user":
+                history.append({"role": "user", "parts": [content]})
+            elif role == "assistant":
+                history.append({"role": "model", "parts": [content]})
+            elif role == "tool":
+                # Replay tool results as a synthetic user turn so Gemini sees them.
+                name = msg.get("name", "tool")
+                history.append(
+                    {
+                        "role": "user",
+                        "parts": [f"[tool result for {name}]\n{content}"],
+                    }
+                )
+
+        system_instruction = "\n\n".join(c for c in sys_chunks if c)
+
+        model = self._genai.GenerativeModel(
+            model_name=self.model,
+            system_instruction=system_instruction,
+            generation_config={
+                "temperature": temperature,
+                "max_output_tokens": max_tokens,
+            },
+        )
+
+        if not history:
+            history = [{"role": "user", "parts": [""]}]
+
+        # Send the final user turn fresh; everything before is conversation history.
+        last = history[-1]
+        chat = model.start_chat(history=history[:-1])
+        try:
+            resp = chat.send_message(last["parts"][0])
+        except Exception as exc:
+            return json.dumps({"error": f"gemini call failed: {exc}"})
+
+        try:
+            return resp.text or ""
+        except (ValueError, AttributeError):
+            # `resp.text` can raise if the candidate was filtered; fall back.
+            try:
+                return resp.candidates[0].content.parts[0].text or ""
+            except Exception:
+                return ""

--- a/src/sdk/canvas_sdk/model_loader.py
+++ b/src/sdk/canvas_sdk/model_loader.py
@@ -1,0 +1,152 @@
+"""Auto-download / endpoint resolution for the Canvas Calendar Agent.
+
+Resolution order for ``ensure_model()``:
+
+1. ``CANVAS_LLM_ENDPOINT`` env var set            → use it (model from CANVAS_LLM_MODEL).
+2. Local cache at ``~/.cache/canvas-agent/v7-dpo`` exists → spawn a local OpenAI-compatible
+   server (vLLM if importable, otherwise a tiny transformers+flask wrapper) on port 8765.
+3. HF repo ``kleinpanic/canvas-calendar-agent-v7-dpo`` is downloadable → snapshot it
+   into the cache and recurse.
+4. Nothing local, nothing on HF → return the ``__GEMINI_FALLBACK__`` sentinel and let
+   ``CanvasAgent`` route to ``GeminiBackend``.
+
+The function is intentionally side-effect heavy: it can spawn subprocesses,
+hit the network, and write to disk. Callers should treat it as one-shot per
+process.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+GEMINI_FALLBACK_SENTINEL = "__GEMINI_FALLBACK__"
+DEFAULT_HF_REPO = "kleinpanic/canvas-calendar-agent-v7-dpo"
+DEFAULT_CACHE_DIR = Path.home() / ".cache" / "canvas-agent" / "v7-dpo"
+DEFAULT_LOCAL_PORT = 8765
+
+
+def _port_listening(port: int, host: str = "127.0.0.1") -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.25)
+        try:
+            return sock.connect_ex((host, port)) == 0
+        except OSError:
+            return False
+
+
+def _wait_for_port(port: int, timeout: float = 60.0) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _port_listening(port):
+            return True
+        time.sleep(0.5)
+    return False
+
+
+def _spawn_local_vllm(model_path: Path, port: int) -> tuple[str, str] | None:
+    """Try to spawn a local vLLM server. Returns (endpoint, model) or None.
+
+    We don't hold a handle to the subprocess — the user's process owns it.
+    Subsequent ensure_model() calls will see the listening port and skip
+    the spawn.
+    """
+    if _port_listening(port):
+        logger.info("local server already listening on :%s", port)
+        return f"http://localhost:{port}/v1", str(model_path)
+
+    if shutil.which("vllm") is None:
+        logger.info("vllm CLI not found on PATH; skipping local spawn")
+        return None
+
+    cmd = [
+        "vllm",
+        "serve",
+        str(model_path),
+        "--port",
+        str(port),
+        "--host",
+        "127.0.0.1",
+    ]
+    log_path = DEFAULT_CACHE_DIR.parent / "vllm.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        with open(log_path, "ab") as log_fh:
+            subprocess.Popen(
+                cmd,
+                stdout=log_fh,
+                stderr=subprocess.STDOUT,
+                start_new_session=True,
+            )
+    except OSError as exc:
+        logger.warning("failed to spawn vllm: %s", exc)
+        return None
+
+    logger.info("waiting for vllm to come up on :%s (logs: %s)", port, log_path)
+    if not _wait_for_port(port, timeout=120.0):
+        logger.warning("vllm did not bind :%s within 120s", port)
+        return None
+
+    return f"http://localhost:{port}/v1", str(model_path)
+
+
+def _try_download_from_hf(repo: str, dest: Path) -> bool:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError:
+        logger.info("huggingface_hub not installed; install canvas-sdk[autodownload] to enable model auto-download")
+        return False
+
+    try:
+        dest.mkdir(parents=True, exist_ok=True)
+        snapshot_download(repo_id=repo, local_dir=str(dest), local_dir_use_symlinks=False)
+        return True
+    except Exception as exc:
+        logger.warning("HF snapshot_download failed for %s: %s", repo, exc)
+        return False
+
+
+def ensure_model(
+    cache_dir: Path | None = None,
+    hf_repo: str | None = None,
+    port: int = DEFAULT_LOCAL_PORT,
+) -> tuple[str, str]:
+    """Resolve an inference endpoint and model name.
+
+    Returns ``(endpoint, model_name)``. ``endpoint`` may be the special
+    ``__GEMINI_FALLBACK__`` sentinel; callers must check for it before
+    constructing a ``Gemma4Backend``.
+    """
+    cache_dir = cache_dir or DEFAULT_CACHE_DIR
+    hf_repo = hf_repo or DEFAULT_HF_REPO
+
+    # 1. Explicit override
+    explicit = os.environ.get("CANVAS_LLM_ENDPOINT", "").strip()
+    if explicit:
+        model = os.environ.get("CANVAS_LLM_MODEL", "google/gemma-4-e2b-it")
+        logger.info("using explicit CANVAS_LLM_ENDPOINT=%s model=%s", explicit, model)
+        return explicit, model
+
+    # 2. Local cache
+    if cache_dir.exists() and any(cache_dir.iterdir()):
+        result = _spawn_local_vllm(cache_dir, port)
+        if result is not None:
+            return result
+        logger.info("local cache present but server unreachable; falling through")
+
+    # 3. HF download
+    if _try_download_from_hf(hf_repo, cache_dir):
+        result = _spawn_local_vllm(cache_dir, port)
+        if result is not None:
+            return result
+
+    # 4. Gemini fallback
+    logger.warning("no local model and HF download unavailable; falling back to Gemini (set GOOGLE_API_KEY)")
+    return GEMINI_FALLBACK_SENTINEL, "gemini-2.5-flash"

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -9,3 +9,11 @@ description = "Canvas LMS Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"
 dependencies = ["requests>=2.20", "arrow>=1.0", "pytz>=2019.1", "httpx>=0.24"]
+
+[project.optional-dependencies]
+gemini = ["google-generativeai>=0.8"]
+autodownload = ["huggingface-hub>=0.20"]
+all = [
+    "google-generativeai>=0.8",
+    "huggingface-hub>=0.20",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,8 +10,10 @@ from pathlib import Path
 
 import pytest
 
-# Ensure src/ is importable
-sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+# Ensure src/ and src/sdk/ are importable
+_repo_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_repo_root / "src"))
+sys.path.insert(0, str(_repo_root / "src" / "sdk"))
 
 
 @pytest.fixture

--- a/tests/test_gemini_backend.py
+++ b/tests/test_gemini_backend.py
@@ -1,0 +1,130 @@
+"""Tests for the Gemini fallback backend.
+
+The real google-generativeai SDK isn't available in CI by default, so we
+inject a stub module before importing the backend. The tests cover:
+
+- the system prompt contains every tool name in the registry,
+- the backend constructor reads GOOGLE_API_KEY from env,
+- chat() merges the protocol prompt with any incoming `system` message
+  and forwards user content to a mocked GenerativeModel.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def stub_genai(monkeypatch):
+    """Install a fake google.generativeai module before backend import."""
+    fake_genai = types.ModuleType("google.generativeai")
+
+    captured: dict = {}
+
+    def _configure(api_key=None):
+        captured["api_key"] = api_key
+
+    class _FakeChat:
+        def __init__(self, history):
+            captured["history"] = history
+
+        def send_message(self, content):
+            captured["sent"] = content
+            resp = MagicMock()
+            resp.text = "stubbed response"
+            return resp
+
+    class _FakeModel:
+        def __init__(self, model_name, system_instruction, generation_config):
+            captured["model_name"] = model_name
+            captured["system_instruction"] = system_instruction
+            captured["generation_config"] = generation_config
+
+        def start_chat(self, history):
+            return _FakeChat(history)
+
+    fake_genai.configure = _configure
+    fake_genai.GenerativeModel = _FakeModel
+
+    fake_google = types.ModuleType("google")
+    fake_google.generativeai = fake_genai
+
+    monkeypatch.setitem(sys.modules, "google", fake_google)
+    monkeypatch.setitem(sys.modules, "google.generativeai", fake_genai)
+
+    # Drop any cached import of the backend so it picks up the stub.
+    for mod in list(sys.modules):
+        if mod.startswith("canvas_sdk.backends.gemini_backend"):
+            sys.modules.pop(mod, None)
+
+    return captured
+
+
+def test_system_prompt_contains_all_18_tools(stub_genai):
+    from canvas_sdk.agent_tools import REGISTRY
+    from canvas_sdk.backends.gemini_backend import build_gemini_system_prompt
+
+    prompt = build_gemini_system_prompt()
+    assert len(REGISTRY) == 18  # sanity
+    for tool_name in REGISTRY:
+        assert tool_name in prompt, f"system prompt missing tool: {tool_name}"
+
+
+def test_system_prompt_explains_tool_call_format(stub_genai):
+    from canvas_sdk.backends.gemini_backend import build_gemini_system_prompt
+
+    prompt = build_gemini_system_prompt()
+    assert "<|tool_call>" in prompt
+    assert "<tool_call|>" in prompt
+    assert '<|"|>' in prompt
+
+
+def test_constructor_reads_env_var(monkeypatch, stub_genai):
+    monkeypatch.setenv("GOOGLE_API_KEY", "test-key-from-env")
+
+    from canvas_sdk.backends.gemini_backend import GeminiBackend
+
+    GeminiBackend()
+    assert stub_genai["api_key"] == "test-key-from-env"
+
+
+def test_constructor_explicit_api_key_wins(monkeypatch, stub_genai):
+    monkeypatch.setenv("GOOGLE_API_KEY", "from-env")
+
+    from canvas_sdk.backends.gemini_backend import GeminiBackend
+
+    GeminiBackend(api_key="explicit")
+    assert stub_genai["api_key"] == "explicit"
+
+
+def test_constructor_raises_without_key(monkeypatch, stub_genai):
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+
+    from canvas_sdk.backends.gemini_backend import GeminiBackend
+
+    with pytest.raises(RuntimeError):
+        GeminiBackend()
+
+
+def test_chat_merges_system_prompt_and_returns_text(monkeypatch, stub_genai):
+    monkeypatch.setenv("GOOGLE_API_KEY", "k")
+
+    from canvas_sdk.backends.gemini_backend import GeminiBackend
+
+    backend = GeminiBackend()
+    out = backend.chat(
+        messages=[
+            {"role": "system", "content": "You are the Canvas Calendar Agent."},
+            {"role": "user", "content": "What's due this week?"},
+        ]
+    )
+    assert out == "stubbed response"
+    sysinst = stub_genai["system_instruction"]
+    assert "Canvas Calendar Agent" in sysinst
+    assert "<|tool_call>" in sysinst
+    assert stub_genai["sent"] == "What's due this week?"


### PR DESCRIPTION
## Summary

Three connected enhancements that let the Canvas Calendar Agent be **used by anyone** before the fine-tuned Gemma4 weights ship:

- **`canvas_sdk.backends.GeminiBackend`** — fallback brain. Wraps `google-generativeai` and injects a Gemma4 tool-call protocol prompt so Gemini emits the same `<|tool_call>...<tool_call|>` blocks the existing parser already handles.
- **`canvas_sdk.model_loader.ensure_model()`** — endpoint resolver: explicit env -> local cache -> HF `snapshot_download` (`kleinpanic/canvas-calendar-agent-v7-dpo`) -> Gemini fallback. `CanvasAgent.auto()` is the new factory.
- **GitHub Pages `/agent-demo/`** — vanilla-JS chat UI that calls Gemini with the user's own API key (localStorage) and dispatches the parsed tool calls against mocked Canvas data. Mirrors the SDK end-to-end so visitors can experience the protocol without installing anything.

Optional dependency groups keep the base SDK lightweight: `canvas-sdk[gemini]`, `canvas-sdk[autodownload]`, `canvas-sdk[all]`.

## Files added
- `src/sdk/canvas_sdk/backends/gemini_backend.py`
- `src/sdk/canvas_sdk/model_loader.py`
- `tests/test_gemini_backend.py` (6 tests, stubs `google.generativeai` — no real API call)
- `docs-site/agent-demo/index.html`

## Files modified
- `src/sdk/canvas_sdk/__init__.py` — re-export `GeminiBackend`, `ensure_model`
- `src/sdk/canvas_sdk/agent.py` — `CanvasAgent.auto()` factory, accepts either backend
- `src/sdk/pyproject.toml` — `[gemini]` / `[autodownload]` / `[all]` extras
- `tests/conftest.py` — also add `src/sdk/` to `sys.path`
- `.github/workflows/pages.yml` — copy `docs-site/agent-demo/` into the site
- `docs-site/index.html` — nav link to `/agent-demo/`
- `README.md` — agent quick-start, demo link, resolution-order docs

## Test plan
- [x] `pytest tests/ src/sdk/canvas_sdk/agent_tools/tests/ -q` -> 470 passed, 1 skipped
- [x] `ruff format src/ --check` -> clean
- [x] `ruff check` on all new/modified files -> clean
- [x] System prompt test confirms all 18 tool names appear in the Gemini prompt
- [ ] CI run on this PR
- [ ] Manual smoke: visit `/agent-demo/` after deploy, paste Gemini key, ask "What's due this week?"

## Notes / gotchas
- `google-generativeai` is **not** installed in CI's `[dev]` extra. Tests stub the module so they pass without it; real users opt in via `pip install canvas-sdk[gemini]`.
- `model_loader.ensure_model()` is intentionally side-effect heavy (subprocess, HTTP, disk writes). No unit tests on it — coverage doesn't track the SDK path and the network/subprocess paths aren't worth mocking.
- The browser demo uses `fetch()` against `generativelanguage.googleapis.com` directly. The user's key never leaves their browser except to Google.