### PR TITLE
feat(demo): add HF Model/Dataset/Space links to nav

### DIFF
--- a/docs-site/agent-demo/index.html
+++ b/docs-site/agent-demo/index.html
@@ -46,6 +46,9 @@
         <a href="../index.html" class="hover:text-white">Home</a>
         <a href="../docs/architecture/" class="hover:text-white">Architecture</a>
         <a href="https://github.com/kleinpanic/CS3704-Canvas-Project" target="_blank" rel="noopener" class="hover:text-white">GitHub</a>
+        <a href="https://huggingface.co/kleinpanic93/canvas-calendar-agent-v7-dpo" target="_blank" rel="noopener" class="hover:text-white">🤗 Model</a>
+        <a href="https://huggingface.co/datasets/kleinpanic93/canvas-calendar-preferences-v7" target="_blank" rel="noopener" class="hover:text-white">🤗 Dataset</a>
+        <a href="https://huggingface.co/spaces/kleinpanic93/canvas-calendar-agent-demo" target="_blank" rel="noopener" class="hover:text-white">🤗 Space</a>
       </div>
     </div>
   </nav>


### PR DESCRIPTION
## Summary

- Adds three HF nav links (🤗 Model, 🤗 Dataset, 🤗 Space) next to the existing GitHub link in the sticky nav header of `docs-site/agent-demo/index.html`
- Mirrors the existing nav link pattern: same `text-sm text-gray-400` parent, `hover:text-white`, `target="_blank" rel="noopener"`

## Test plan

- [ ] CI green
- [ ] Live demo nav shows GitHub + 🤗 Model + 🤗 Dataset + 🤗 Space links
- [ ] All three HF links resolve to correct HuggingFace pages