### PR TITLE
fix(hf-space): pin Python 3.11 + audioop-lts (HF Space crash)

### DIFF
--- a/hf-space/README.md
+++ b/hf-space/README.md
@@ -5,6 +5,7 @@ colorFrom: blue
 colorTo: purple
 sdk: gradio
 sdk_version: 4.44.0
+python_version: "3.11"
 app_file: app.py
 pinned: false
 license: apache-2.0

--- a/hf-space/requirements.txt
+++ b/hf-space/requirements.txt
@@ -1,5 +1,6 @@
-gradio>=4.0
+gradio>=4.0,<5
 transformers>=4.47
 torch>=2.1
 huggingface-hub>=0.20
 accelerate>=0.25
+audioop-lts; python_version >= "3.13"


### PR DESCRIPTION
Fix HF Space deploy crash from Python 3.13 audioop stdlib removal. See commit message for full root cause.

Verifies: PR #109 demo flow which depends on the Space being reachable.