### PR TITLE
feat(test): HF Space integration test + HF badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ A maintainable, team-ready **Canvas LMS productivity client** with a Textual TUI
 [![Python](https://img.shields.io/badge/python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
 [![HF Model](https://img.shields.io/badge/🤗_Model-canvas--calendar--agent--v7--dpo-yellow)](https://huggingface.co/kleinpanic93/canvas-calendar-agent-v7-dpo)
 [![HF Dataset](https://img.shields.io/badge/🤗_Dataset-canvas--calendar--preferences--v7-blue)](https://huggingface.co/datasets/kleinpanic93/canvas-calendar-preferences-v7)
-[![HF Space](https://img.shields.io/badge/🤗_Demo-Live_HF_Space-purple)](https://huggingface.co/spaces/kleinpanic93/canvas-calendar-agent-demo)
+[![HF Collection](https://img.shields.io/badge/🤗_Collection-Canvas_Calendar_Agent_v3.0-yellow)](https://huggingface.co/collections/kleinpanic93/canvas-calendar-agent-v30-69fa6462f697e0342b21dfe0)
+[![HF Space](https://img.shields.io/badge/🤗_Space-Live_Demo-purple)](https://huggingface.co/spaces/kleinpanic93/canvas-calendar-agent-demo)
 
 ## Live demo
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ ai = [
 dev = [
     "black",
     "build",
+    "gradio-client>=1.3",
     "mkdocs",
     "mkdocs-material",
     "mypy",
@@ -75,6 +76,12 @@ name = "cz_conventional_commits"
 version = "1.1.1"
 tag_format = "v$version"
 version_source = "commitizen"
+
+[tool.pytest.ini_options]
+markers = [
+    "network: marks tests that require live network access (deselect with '-m \"not network\"')",
+    "slow: marks tests with long timeouts (deselect with '-m \"not slow\"')",
+]
 
 [tool.coverage.run]
 omit = [

--- a/tests/test_hf_space_integration.py
+++ b/tests/test_hf_space_integration.py
@@ -1,0 +1,83 @@
+"""Integration tests against the live HF Space.
+
+Requires network access and a running Space. Skip in default CI via:
+
+    pytest -m "not network"
+
+Run explicitly with:
+
+    pytest tests/test_hf_space_integration.py -m network -v -s --tb=short
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+logger = logging.getLogger(__name__)
+
+SPACE_ID = "kleinpanic93/canvas-calendar-agent-demo"
+TIMEOUT = 90
+
+PROMPTS = [
+    ("canvas.get_assignments", "What assignments do I have due this week?"),
+    ("canvas.list_courses", "Show me my course list"),
+    ("calendar.find_free_blocks", "Find a 2-hour study block tomorrow"),
+    ("study.exam_bracket", "Build me an exam bracket for May 12"),
+    ("reranker.priority_hint", "Rank my todos by priority"),
+]
+
+
+@pytest.fixture(scope="module")
+def space_client():
+    try:
+        from gradio_client import Client
+    except ImportError:
+        pytest.skip("gradio-client not installed; run: pip install gradio-client>=1.3")
+
+    try:
+        client = Client(SPACE_ID, verbose=False)
+    except Exception as exc:
+        pytest.skip(f"Could not connect to HF Space ({SPACE_ID}): {exc}")
+
+    return client
+
+
+@pytest.mark.network
+@pytest.mark.slow
+@pytest.mark.parametrize("tool_family,prompt", PROMPTS, ids=[p[0] for p in PROMPTS])
+def test_space_responds_to_prompt(space_client, tool_family, prompt):
+    try:
+        result = space_client.predict(
+            message=prompt,
+            api_name="/chat",
+        )
+    except Exception as exc:
+        msg = str(exc)
+        if any(code in msg for code in ("503", "500", "error", "Space")):
+            pytest.skip(f"Space not ready ({tool_family}): {exc}")
+        raise
+
+    logger.info("[%s] prompt=%r", tool_family, prompt)
+    logger.info("[%s] response=%r", tool_family, result)
+
+    tool_calls_observed = []
+    if isinstance(result, (list, tuple)):
+        for item in result:
+            item_str = str(item)
+            if "<|tool_call>" in item_str or "tool_call" in item_str.lower():
+                tool_calls_observed.append(item_str[:200])
+    elif isinstance(result, str):
+        if "<|tool_call>" in result or "tool_call" in result.lower():
+            tool_calls_observed.append(result[:200])
+
+    if tool_calls_observed:
+        logger.info("[%s] tool calls observed: %s", tool_family, tool_calls_observed)
+    else:
+        logger.info("[%s] no explicit tool-call tokens in response", tool_family)
+
+    response_text = result if isinstance(result, str) else str(result)
+    assert response_text.strip(), (
+        f"Empty response from Space for tool family {tool_family!r}, prompt={prompt!r}"
+    )


### PR DESCRIPTION
## Summary

- Add `[![HF Collection](...)]` badge to README alongside the existing HF Model, Dataset, and Space badges; update Space badge label to canonical `🤗_Space-Live_Demo-purple` format
- Add `tests/test_hf_space_integration.py`: 5 parametrized network tests (one per tool family) against the live HF Space at `kleinpanic93/canvas-calendar-agent-demo`; each test skips gracefully when the Space is in RUNTIME_ERROR / cold-start state
- Register `gradio-client>=1.3` in `[project.optional-dependencies] dev` and register `network` + `slow` pytest marks in `[tool.pytest.ini_options]` to eliminate mark warnings

## Test plan

- [ ] `pytest tests/test_hf_space_integration.py -m network -v -s --tb=short` — all 5 skip cleanly when Space is in RUNTIME_ERROR (verified locally)
- [ ] Once Space recovers from RUNTIME_ERROR, re-run above and confirm 5 pass (non-empty responses)
- [ ] Default CI (`pytest -m "not network"`) ignores this file entirely
- [ ] README badges render correctly on GitHub (Collection + Space badges visible in badge row)