### PR TITLE
feat(live-demo): wire Ask AI to HF Space + 18 tool buttons

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,12 +48,15 @@ jobs:
           sed -i 's|<script src="chrome_shim.js"></script>|<script src="chrome_shim_prod.js"></script>|g' \
             site/extension/src/popup/index.html
 
-      # Inject Canvas token into prod shim at build time (never in source)
-      - name: Inject Canvas token
+      # Inject Canvas token and HF token into prod shim at build time (never in source)
+      - name: Inject Canvas token and HF token
         env:
           CANVAS_API_TOKEN: ${{ secrets.CANVAS_API_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           sed -i "s|__CANVAS_TOKEN__|${CANVAS_API_TOKEN}|g" \
+            site/extension/src/popup/chrome_shim_prod.js
+          sed -i "s|__HF_TOKEN__|${HF_TOKEN}|g" \
             site/extension/src/popup/chrome_shim_prod.js
 
       # Pre-fetch live Canvas data and bake as static JSON

--- a/docs-site/chrome_shim_prod.js
+++ b/docs-site/chrome_shim_prod.js
@@ -2,13 +2,16 @@
  * Production Chrome Extension API shim for GitHub Pages live demo.
  *
  * Serves data from pre-fetched static JSON files (no CORS needed).
- * TOKEN is injected by CI as __CANVAS_TOKEN__ → actual value at build time.
+ * CANVAS_TOKEN is injected by CI as __CANVAS_TOKEN__ → actual value at build time.
+ * HF_TOKEN is injected by CI as __HF_TOKEN__ → actual value at build time.
  * DATA_BASE points to the pre-fetched JSON snapshots baked at CI time.
  */
 (function () {
   'use strict';
 
   const TOKEN = '__CANVAS_TOKEN__';
+  const HF_TOKEN = '__HF_TOKEN__';
+  const HF_SPACE_URL = 'https://kleinpanic93-canvas-calendar-agent-demo.hf.space/api/predict';
   // Popup lives at extension/src/popup/ — data is 3 levels up at site root /data/
   const DATA_BASE = '../../../data/';
 
@@ -48,27 +51,38 @@
     GET_ASSIGNMENT_GROUPS: async (msg) => fetchJson(`course_${msg.courseId}_assignment_groups.json`),
     GET_SUBMISSION: async () => ({ ok: false, error: 'Not available in demo' }),
     AGENT_QUERY: async (msg) => {
-      const q = (msg.query || '').toLowerCase();
-      const toolCalls = [];
-      let answer = '';
-      if (/due|upcoming|assign/.test(q)) {
-        toolCalls.push({ tool: 'canvas.get_assignments', label: 'Fetching upcoming' });
-        const r = await fetchJson('upcoming.json');
-        const items = ((r.data || r) || []).filter(e => e.type === 'assignment');
-        const lines = items.slice(0, 8).map(e => `• **${e.title}** — ${new Date(e.due_at).toLocaleDateString()}`);
-        answer = lines.length ? `Upcoming assignments:\n\n${lines.join('\n')}` : 'No upcoming assignments!';
-      } else if (/grade|score/.test(q)) {
-        answer = 'Check the Grades tab for your current scores.';
-      } else if (/course|class/.test(q)) {
-        toolCalls.push({ tool: 'canvas.list_courses', label: 'Fetching courses' });
-        const r = await fetchJson('courses.json');
-        const courses = r.data || r || [];
-        const lines = courses.map(c => `• **${c.course_code}** — ${c.name}`);
-        answer = lines.length ? `Your courses:\n\n${lines.join('\n')}` : 'No courses found.';
-      } else {
-        answer = 'I can help with:\n\n• "What\'s due?" — upcoming deadlines\n• "My courses" — enrolled courses\n• "My grades" — current scores';
+      const userMsg = msg.query || '';
+      try {
+        const headers = { 'Content-Type': 'application/json' };
+        if (HF_TOKEN && HF_TOKEN !== '__HF_TOKEN__') {
+          headers['Authorization'] = `Bearer ${HF_TOKEN}`;
+        }
+        let resp = await fetch(HF_SPACE_URL, {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ data: [userMsg] }),
+        });
+        if (resp.status === 503) {
+          const errJson = await resp.json().catch(() => ({}));
+          const eta = errJson.estimated_time ? Math.ceil(errJson.estimated_time) : 30;
+          return { ok: false, error: `Model warming up, ~${eta}s — please try again shortly.` };
+        }
+        if (!resp.ok) {
+          return { ok: false, error: `HF Space error: HTTP ${resp.status}` };
+        }
+        const result = await resp.json();
+        const payload = result.data?.[0];
+        if (!payload) return { ok: false, error: 'Empty response from model.' };
+        const finalAnswer = payload.final_answer || payload.transcript || String(payload);
+        const rawCalls = Array.isArray(payload.tool_calls) ? payload.tool_calls : [];
+        const toolCalls = rawCalls.map(tc => ({
+          tool: tc.tool || tc.name || '(unknown)',
+          label: tc.args ? JSON.stringify(tc.args).slice(0, 60) : '',
+        }));
+        return { ok: true, answer: finalAnswer, toolCalls };
+      } catch (e) {
+        return { ok: false, error: `Network error: ${e.message}` };
       }
-      return { ok: true, answer, toolCalls };
     },
     DISMISS: async (msg) => { dismissed.add(msg.assignmentId); return { ok: true }; },
     GET_DISMISSED: async () => ({ ok: true, data: [...dismissed] }),

--- a/extension/src/popup/app.js
+++ b/extension/src/popup/app.js
@@ -847,10 +847,12 @@ document.getElementById("agent-input")?.addEventListener("keydown", (e) => {
   }
 });
 
-document.querySelectorAll(".agent-chip").forEach(chip => {
-  chip.addEventListener("click", () => {
+document.querySelectorAll(".agent-tool-btn").forEach(btn => {
+  btn.addEventListener("click", () => {
     switchTab("agent");
-    sendAgentQuery(chip.dataset.query);
+    const $input = document.getElementById("agent-input");
+    if ($input) $input.value = btn.dataset.query || "";
+    sendAgentQuery(btn.dataset.query || "");
   });
 });
 

--- a/extension/src/popup/index.html
+++ b/extension/src/popup/index.html
@@ -133,15 +133,129 @@
           <span class="agent-badge">BETA</span>
         </div>
 
-        <!-- Quick-action chips -->
-        <div class="agent-chips" id="agent-chips">
-          <button class="agent-chip" data-query="What assignments are due this week?">Due this week</button>
-          <button class="agent-chip" data-query="Prioritize my upcoming assignments by urgency">Prioritize tasks</button>
-          <button class="agent-chip" data-query="Create a spaced study plan for my next exam">Study plan</button>
-          <button class="agent-chip" data-query="What are my current grades?">My grades</button>
-          <button class="agent-chip" data-query="Any recent announcements from my courses?">Announcements</button>
-          <button class="agent-chip" data-query="What courses am I enrolled in?">My courses</button>
-        </div>
+        <!-- 18 tool buttons grouped by family (collapsible) -->
+        <details class="agent-tools-panel" id="agent-tools-panel" open>
+          <summary class="agent-tools-summary">
+            <span>18 tools</span>
+            <span class="agent-tools-toggle-hint">click to collapse</span>
+          </summary>
+          <div class="agent-tools-body">
+            <!-- canvas (8) -->
+            <div class="agent-tool-family">
+              <div class="agent-tool-family-label">canvas</div>
+              <div class="agent-tool-grid">
+                <button class="agent-tool-btn" data-query="What assignments are due this week?" aria-label="canvas.get_assignments">
+                  <span class="agent-tool-btn-icon">&#x1F4CB;</span>
+                  <span class="agent-tool-btn-name">Get Assignments</span>
+                  <span class="agent-tool-btn-id">canvas.get_assignments</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Tell me about my CS 3704 course" aria-label="canvas.get_course">
+                  <span class="agent-tool-btn-icon">&#x1F393;</span>
+                  <span class="agent-tool-btn-name">Get Course</span>
+                  <span class="agent-tool-btn-id">canvas.get_course</span>
+                </button>
+                <button class="agent-tool-btn" data-query="What are my current grades?" aria-label="canvas.get_grades">
+                  <span class="agent-tool-btn-icon">&#x1F4CA;</span>
+                  <span class="agent-tool-btn-name">Get Grades</span>
+                  <span class="agent-tool-btn-id">canvas.get_grades</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Show me the syllabus for ECE 3574" aria-label="canvas.get_syllabus">
+                  <span class="agent-tool-btn-icon">&#x1F4C4;</span>
+                  <span class="agent-tool-btn-name">Get Syllabus</span>
+                  <span class="agent-tool-btn-id">canvas.get_syllabus</span>
+                </button>
+                <button class="agent-tool-btn" data-query="What's on my Canvas todo list?" aria-label="canvas.get_todo">
+                  <span class="agent-tool-btn-icon">&#x2705;</span>
+                  <span class="agent-tool-btn-name">Get Todo</span>
+                  <span class="agent-tool-btn-id">canvas.get_todo</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Any new announcements in my courses?" aria-label="canvas.list_announcements">
+                  <span class="agent-tool-btn-icon">&#x1F4E3;</span>
+                  <span class="agent-tool-btn-name">List Announcements</span>
+                  <span class="agent-tool-btn-id">canvas.list_announcements</span>
+                </button>
+                <button class="agent-tool-btn" data-query="List all my enrolled courses this term" aria-label="canvas.list_courses">
+                  <span class="agent-tool-btn-icon">&#x1F4DA;</span>
+                  <span class="agent-tool-btn-name">List Courses</span>
+                  <span class="agent-tool-btn-id">canvas.list_courses</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Show me my planner for the next 7 days" aria-label="canvas.list_planner_items">
+                  <span class="agent-tool-btn-icon">&#x1F5D3;&#xFE0F;</span>
+                  <span class="agent-tool-btn-name">List Planner Items</span>
+                  <span class="agent-tool-btn-id">canvas.list_planner_items</span>
+                </button>
+              </div>
+            </div>
+            <!-- calendar (5) -->
+            <div class="agent-tool-family">
+              <div class="agent-tool-family-label">calendar</div>
+              <div class="agent-tool-grid">
+                <button class="agent-tool-btn" data-query="Create a study block tomorrow at 3pm for 90 minutes" aria-label="calendar.create_event">
+                  <span class="agent-tool-btn-icon">&#x2795;</span>
+                  <span class="agent-tool-btn-name">Create Event</span>
+                  <span class="agent-tool-btn-id">calendar.create_event</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Cancel my Friday office hours visit" aria-label="calendar.delete_event">
+                  <span class="agent-tool-btn-icon">&#x1F5D1;&#xFE0F;</span>
+                  <span class="agent-tool-btn-name">Delete Event</span>
+                  <span class="agent-tool-btn-id">calendar.delete_event</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Find me a 2-hour block to study tomorrow" aria-label="calendar.find_free_blocks">
+                  <span class="agent-tool-btn-icon">&#x1F50D;</span>
+                  <span class="agent-tool-btn-name">Find Free Blocks</span>
+                  <span class="agent-tool-btn-id">calendar.find_free_blocks</span>
+                </button>
+                <button class="agent-tool-btn" data-query="What's on my calendar this week?" aria-label="calendar.list_events">
+                  <span class="agent-tool-btn-icon">&#x1F4C5;</span>
+                  <span class="agent-tool-btn-name">List Events</span>
+                  <span class="agent-tool-btn-id">calendar.list_events</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Move my CS office hours to Wednesday at 4pm" aria-label="calendar.modify_event">
+                  <span class="agent-tool-btn-icon">&#x270F;&#xFE0F;</span>
+                  <span class="agent-tool-btn-name">Modify Event</span>
+                  <span class="agent-tool-btn-id">calendar.modify_event</span>
+                </button>
+              </div>
+            </div>
+            <!-- reranker (1) -->
+            <div class="agent-tool-family">
+              <div class="agent-tool-family-label">reranker</div>
+              <div class="agent-tool-grid">
+                <button class="agent-tool-btn" data-query="Rank my todos by what I should do first" aria-label="reranker.priority_hint">
+                  <span class="agent-tool-btn-icon">&#x1F3C6;</span>
+                  <span class="agent-tool-btn-name">Priority Hint</span>
+                  <span class="agent-tool-btn-id">reranker.priority_hint</span>
+                </button>
+              </div>
+            </div>
+            <!-- study (4) -->
+            <div class="agent-tool-family">
+              <div class="agent-tool-family-label">study</div>
+              <div class="agent-tool-grid">
+                <button class="agent-tool-btn" data-query="Build me an exam-prep bracket for the May 12 final" aria-label="study.exam_bracket">
+                  <span class="agent-tool-btn-icon">&#x1F3D7;&#xFE0F;</span>
+                  <span class="agent-tool-btn-name">Exam Bracket</span>
+                  <span class="agent-tool-btn-id">study.exam_bracket</span>
+                </button>
+                <button class="agent-tool-btn" data-query="What study block size should I use for a 4-credit physics class?" aria-label="study.recommend_block_size">
+                  <span class="agent-tool-btn-icon">&#x23F1;&#xFE0F;</span>
+                  <span class="agent-tool-btn-name">Recommend Block Size</span>
+                  <span class="agent-tool-btn-id">study.recommend_block_size</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Plan a study schedule for my whole semester" aria-label="study.semester_schedule">
+                  <span class="agent-tool-btn-icon">&#x1F5FA;&#xFE0F;</span>
+                  <span class="agent-tool-btn-name">Semester Schedule</span>
+                  <span class="agent-tool-btn-id">study.semester_schedule</span>
+                </button>
+                <button class="agent-tool-btn" data-query="Compute Cepeda spacing intervals for my exam in 12 days" aria-label="study.spaced_schedule">
+                  <span class="agent-tool-btn-icon">&#x1F9E0;</span>
+                  <span class="agent-tool-btn-name">Spaced Schedule</span>
+                  <span class="agent-tool-btn-id">study.spaced_schedule</span>
+                </button>
+              </div>
+            </div>
+          </div>
+        </details>
 
         <!-- Chat history -->
         <div id="agent-messages" class="agent-messages"></div>
@@ -149,15 +263,15 @@
         <!-- Tool trace (shown while thinking) -->
         <div id="agent-trace" class="agent-trace hidden"></div>
 
-        <!-- Input row -->
+        <!-- Input row (fixed at bottom) -->
         <div class="agent-input-row">
-          <input
-            type="text"
+          <textarea
             id="agent-input"
             class="agent-input"
+            rows="2"
             placeholder="Ask about assignments, grades, study plans…"
             aria-label="Ask the Canvas AI agent"
-          />
+          ></textarea>
           <button id="agent-send" class="agent-send-btn" aria-label="Send query">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5">
               <line x1="22" y1="2" x2="11" y2="13"></line>

--- a/extension/src/popup/styles.css
+++ b/extension/src/popup/styles.css
@@ -811,11 +811,20 @@ body.dark-theme header {
 
 /* ── Agent View ──────────────────────────────────────────── */
 
+/* Agent view uses flex column so input row sticks to bottom */
+#view-agent.active {
+  display: flex;
+  flex-direction: column;
+  height: 480px;
+  overflow: hidden;
+}
+
 .agent-header {
   display: flex;
   align-items: center;
   gap: var(--space-sm);
   padding-right: var(--space-md);
+  flex: 0 0 auto;
 }
 
 .agent-badge {
@@ -829,28 +838,88 @@ body.dark-theme header {
   margin-top: 14px;
 }
 
-.agent-chips {
-  display: flex;
-  flex-wrap: wrap;
-  gap: var(--space-xs);
-  padding: var(--space-xs) var(--space-md) var(--space-sm);
+/* ── 18-tool collapsible panel ───────────────────────────── */
+
+.agent-tools-panel {
+  flex: 0 0 auto;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
 }
 
-.agent-chip {
+.agent-tools-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-xs) var(--space-md);
   font-size: var(--size-xs);
-  font-weight: var(--weight-medium);
-  color: var(--canvas-red);
-  background: rgba(214, 62, 54, 0.08);
-  border: 1px solid rgba(214, 62, 54, 0.25);
-  border-radius: 99px;
-  padding: 3px 10px;
+  font-weight: var(--weight-semibold);
+  color: var(--text-muted);
   cursor: pointer;
-  transition: background 0.15s, border-color 0.15s;
-  white-space: nowrap;
+  list-style: none;
+  user-select: none;
 }
-.agent-chip:hover {
-  background: rgba(214, 62, 54, 0.15);
+.agent-tools-summary::-webkit-details-marker { display: none; }
+
+.agent-tools-toggle-hint {
+  font-size: 0.6rem;
+  font-weight: var(--weight-normal);
+  color: var(--border-strong);
+}
+
+.agent-tools-body {
+  padding: var(--space-xs) var(--space-md) var(--space-sm);
+  max-height: 200px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.agent-tool-family-label {
+  font-size: 0.6rem;
+  font-weight: var(--weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--canvas-red);
+  margin-bottom: 3px;
+}
+
+.agent-tool-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(100px, 1fr));
+  gap: 4px;
+}
+
+.agent-tool-btn {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 1px;
+  padding: 5px 7px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  background: var(--bg);
+  cursor: pointer;
+  text-align: left;
+  transition: border-color 0.12s, background 0.12s;
+}
+.agent-tool-btn:hover {
   border-color: var(--canvas-red);
+  background: rgba(214, 62, 54, 0.06);
+}
+
+.agent-tool-btn-icon { font-size: 0.9rem; line-height: 1; }
+.agent-tool-btn-name {
+  font-size: 0.68rem;
+  font-weight: var(--weight-semibold);
+  color: var(--text);
+  line-height: 1.2;
+}
+.agent-tool-btn-id {
+  font-size: 0.58rem;
+  font-family: monospace;
+  color: var(--text-muted);
+  line-height: 1.2;
 }
 
 .agent-messages {
@@ -860,8 +929,7 @@ body.dark-theme header {
   display: flex;
   flex-direction: column;
   gap: var(--space-md);
-  min-height: 120px;
-  max-height: 260px;
+  min-height: 60px;
 }
 
 .agent-msg {
@@ -976,13 +1044,15 @@ body.dark-theme header {
   flex: 1;
   padding: var(--space-sm) var(--space-md);
   border: 1px solid var(--border);
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-md);
   font-size: var(--size-sm);
   font-family: var(--font-main);
   background: var(--bg);
   color: var(--text);
   outline: none;
   transition: border-color 0.15s;
+  resize: none;
+  line-height: 1.4;
 }
 .agent-input:focus { border-color: var(--canvas-red); }
 


### PR DESCRIPTION
## Summary

- **chrome_shim_prod.js**: replaces static pattern-match AGENT_QUERY with a real fetch to kleinpanic93-canvas-calendar-agent-demo.hf.space/api/predict (Gradio endpoint matching agent-demo). Handles 503 warm-up with estimated_time field. __HF_TOKEN__ placeholder sed-replaced at build time.
- **pages.yml**: extends token injection step to also replace __HF_TOKEN__ from secrets.HF_TOKEN. Secret HF_TOKEN set on repo (2026-05-05).
- **popup/index.html**: replaces 6 chip buttons with collapsible 18-tool panel grouped canvas×8 / calendar×5 / reranker×1 / study×4 — labels and prompts mirror agent-demo exactly. Input changed to textarea rows=2.
- **popup/styles.css**: #view-agent.active uses flex column height:480px so message log (flex:1) scrolls above and input row (flex:0 0 auto) is pinned at bottom. New tool-panel, tool-grid, tool-btn styles.
- **popup/app.js**: wires .agent-tool-btn click listeners.

## Smoke test

- Serverless API (api-inference.huggingface.co) → 404 — model not supported there.
- HF Space endpoint → 503 — Space currently in error state on HF infrastructure (transient). Wiring matches the working agent-demo pattern exactly.

## Test plan

- [ ] Merge + wait for Pages CI
- [ ] Open https://kleinpanic.github.io/CS3704-Canvas-Project/#demo
- [ ] Click Ask AI tab — 18 tool buttons in collapsible panel
- [ ] Textarea pinned at bottom, message log scrolls above
- [ ] Tool button click pre-fills and submits query
- [ ] When Space is healthy: assistant bubble renders
- [ ] When Space cold: "Model warming up, ~Xs" message shown