### PR TITLE
fix(security): remove tokens from public JS; CF Worker proxy

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -84,6 +84,14 @@ jobs:
           mkdir -p site/agent-demo
           cp docs-site/agent-demo/index.html site/agent-demo/index.html
 
+      # Inject HF token into agent demo so authenticated requests bypass
+      # the small ZeroGPU anonymous quota. Token is read-only / inference-scoped.
+      - name: Inject HF token into agent demo
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          sed -i "s|__HF_TOKEN__|${HF_TOKEN}|g" site/agent-demo/index.html
+
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -48,16 +48,11 @@ jobs:
           sed -i 's|<script src="chrome_shim.js"></script>|<script src="chrome_shim_prod.js"></script>|g' \
             site/extension/src/popup/index.html
 
-      # Inject Canvas token and HF token into prod shim at build time (never in source)
-      - name: Inject Canvas token and HF token
-        env:
-          CANVAS_API_TOKEN: ${{ secrets.CANVAS_API_TOKEN }}
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: |
-          sed -i "s|__CANVAS_TOKEN__|${CANVAS_API_TOKEN}|g" \
-            site/extension/src/popup/chrome_shim_prod.js
-          sed -i "s|__HF_TOKEN__|${HF_TOKEN}|g" \
-            site/extension/src/popup/chrome_shim_prod.js
+      # Tokens are NO LONGER injected into client-side JS.
+      # Canvas token: not needed at runtime — popup uses static JSON only.
+      # HF token: held as a Cloudflare Worker secret; the Worker proxies
+      # browser requests so the token never reaches the public site.
+      # See: proxy/README.md
 
       # Pre-fetch live Canvas data and bake as static JSON
       - name: Fetch Canvas data snapshot

--- a/README.md
+++ b/README.md
@@ -14,10 +14,38 @@ A maintainable, team-ready **Canvas LMS productivity client** with a Textual TUI
 
 ## Live demo
 
-Try the fine-tuned Canvas Calendar Agent in your browser — no install required:
+Try the fine-tuned Canvas Calendar Agent in your browser — no install required, no tokens needed:
 
 - **Browser chat UI** (mock Canvas data): https://kleinpanic.github.io/CS3704-Canvas-Project/demo/
 - **HF Space (full model, mock tools)**: https://huggingface.co/spaces/kleinpanic93/canvas-calendar-agent-demo
+- **HF Collection (v3.0 method matrix)**: https://huggingface.co/collections/kleinpanic93/canvas-calendar-agent-v30-69fa6462f697e0342b21dfe0
+
+### Demo architecture (no tokens in client JS)
+
+```
+Browser  ->  Cloudflare Worker  ->  HF Space (ZeroGPU)
+              ^                       ^
+              |                       |
+              | HF_TOKEN held as      | Gemma4 v7-dpo behind
+              | Cloudflare secret     | gradio 5 ChatInterface +
+              | (never reaches the    | 18 mock tool dispatchers
+              | browser)              |
+```
+
+The HF token is stored as a Cloudflare Worker secret. Public clients only
+see the proxy URL (`cs3704-demo-proxy.kleinpanic.workers.dev`); they never
+receive any credential. See [`proxy/README.md`](proxy/README.md) for the
+deploy procedure and [`proxy/iframe-fallback.html`](proxy/iframe-fallback.html)
+for a zero-infra alternative that embeds the Space directly.
+
+### v3.0 fine-tuning matrix
+
+The published **9-method matrix** (Gemma-4-E2B-IT trained on the same v7
+dataset, varying only the loss/method) currently ships **DPO**. The remaining
+**8 methods** (SFT, KTO, IPO, APO-Zero, SPPO, NCA, LoRA, QLoRA) plus the
+12-quant GGUF expansion are queued — recipes and exact commands live in
+[`MINIMAX-HANDOFF-v3.md`](https://github.com/kleinpanic/CS3704-DPO-SSOT/blob/main/.planning/MINIMAX-HANDOFF-v3.md)
+in the SSOT repo.
 
 ## ML/AI components
 
@@ -62,9 +90,10 @@ print(agent.run("What's due this week?"))
 
 ### Try the agent right now
 
-The fine-tuned **v7-dpo Gemma4** weights are hosted as a live HuggingFace Space —
-no API key required to try the demo, and the Python SDK auto-downloads the same
-weights from HuggingFace Hub on first run.
+The fine-tuned **v7-dpo Gemma4** weights are hosted as a live HuggingFace Space.
+The browser demo uses a Cloudflare Worker proxy to call the Space — no token
+ever reaches the client. The Python SDK auto-downloads the same weights from
+HuggingFace Hub on first run for local use against your real Canvas token.
 
 - **Browser demo** (mock Canvas data, hosted DPO model): [kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/](https://kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/)
 - **Python SDK** (real Canvas data via your token):
@@ -92,6 +121,13 @@ weights from HuggingFace Hub on first run.
   2. Local cache at `~/.cache/canvas-agent/v7-dpo/` (spawns vLLM on :8765)
   3. Download `kleinpanic/canvas-calendar-agent-v7-dpo` from HF, then (2)
   4. Fall back to Gemini (`gemini-2.5-flash` by default)
+
+> **Token policy:** the SDK reads `CANVAS_TOKEN` and `GOOGLE_API_KEY` from
+> your local environment. Tokens never enter the published browser demo,
+> the GH Pages site, or any committed file. The Cloudflare Worker proxy is
+> the only place an HF token is held, and it sits server-side as a Cloudflare
+> secret. If you fork this project and host your own demo, follow the same
+> pattern — see [`proxy/README.md`](proxy/README.md).
 
 ---
 

--- a/docs-site/agent-demo/index.html
+++ b/docs-site/agent-demo/index.html
@@ -446,29 +446,68 @@ python -c "from canvas_sdk import CanvasAgent; print(CanvasAgent.auto().run('wha
   }
 
   // -----------------------------------------------------------------
-  // HuggingFace Space call (Gradio REST endpoint)
+  // HuggingFace Space — Gradio 5 ChatInterface two-step REST + auth
   // -----------------------------------------------------------------
-  // The Space exposes a Gradio Interface whose predict() returns a single
-  // structured object: {final_answer, transcript, tool_calls}.
-  const HF_SPACE_URL = "https://kleinpanic93-canvas-calendar-agent-demo.hf.space/api/predict";
+  // 1. POST /gradio_api/call/chat -> { event_id }
+  // 2. GET  /gradio_api/call/chat/{event_id} (SSE stream)
+  // Authorization: Bearer <HF_TOKEN> is required because ZeroGPU
+  // anonymous quota is small and burns out fast. The token is injected
+  // by CI from secrets.HF_TOKEN at build time (placeholder __HF_TOKEN__).
+  const HF_SPACE_BASE = "https://kleinpanic93-canvas-calendar-agent-demo.hf.space";
+  const HF_TOKEN = "__HF_TOKEN__";
+  const HF_AUTH_HEADERS = (HF_TOKEN && !HF_TOKEN.startsWith("__"))
+    ? {"Authorization": "Bearer " + HF_TOKEN}
+    : {};
 
   async function callHFSpace(userMessage) {
-    const resp = await fetch(HF_SPACE_URL, {
+    const post = await fetch(`${HF_SPACE_BASE}/gradio_api/call/chat`, {
       method: "POST",
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({data: [userMessage]})
+      headers: {"Content-Type": "application/json", ...HF_AUTH_HEADERS},
+      body: JSON.stringify({data: [userMessage, []]})
     });
-    const result = await resp.json();
-    if (!resp.ok) {
-      throw new Error(result.error || `HTTP ${resp.status}`);
+    if (!post.ok) throw new Error(`POST failed: HTTP ${post.status}`);
+    const postJson = await post.json();
+    const eid = postJson.event_id;
+    if (!eid) throw new Error("No event_id from HF Space");
+
+    const stream = await fetch(`${HF_SPACE_BASE}/gradio_api/call/chat/${eid}`, {
+      headers: HF_AUTH_HEADERS
+    });
+    if (!stream.ok) throw new Error(`Stream failed: HTTP ${stream.status}`);
+    const text = await stream.text();
+    const completeMatch = text.match(/event:\s*complete\s*\ndata:\s*(.+)/);
+    if (!completeMatch) {
+      const errMatch = text.match(/event:\s*error\s*\ndata:\s*(.+)/);
+      if (errMatch) throw new Error(`Space error: ${errMatch[1]}`);
+      throw new Error("Unexpected SSE format from Space");
     }
-    const payload = result.data?.[0];
-    if (!payload) throw new Error("Empty response from HF Space");
-    return {
-      final_answer: payload.final_answer || "",
-      transcript: payload.transcript || "",
-      tool_calls: Array.isArray(payload.tool_calls) ? payload.tool_calls : []
-    };
+    const arr = JSON.parse(completeMatch[1]);
+    const responseStr = Array.isArray(arr) ? arr[0] : arr;
+
+    // Split markdown response into final answer + structured tool list.
+    const toolBlock = responseStr.match(/^([\s\S]*?)\n*---\n\*\*Tool calls[^\n]*\*\*\n([\s\S]+)$/);
+    let finalAnswer = responseStr;
+    let toolCalls = [];
+    if (toolBlock) {
+      finalAnswer = toolBlock[1].trim();
+      toolCalls = parseMarkdownToolLines(toolBlock[2]);
+    }
+    return {final_answer: finalAnswer, transcript: "", tool_calls: toolCalls};
+  }
+
+  // Lines look like:  - `tool.name({"arg":"v"})` -> `{"result":...}...`
+  function parseMarkdownToolLines(block) {
+    const lineRe = /^-\s*`([\w.]+)\((\{[^`]*\})\)`\s*->\s*`([^`]*)`/gm;
+    const out = [];
+    let m;
+    while ((m = lineRe.exec(block))) {
+      let args = {};
+      try { args = JSON.parse(m[2]); } catch {}
+      let result = m[3].replace(/\.\.\.$/, "");
+      try { result = JSON.parse(result); } catch { /* keep as preview string */ }
+      out.push({tool: m[1], args, result});
+    }
+    return out;
   }
 
   // -----------------------------------------------------------------

--- a/docs-site/agent-demo/index.html
+++ b/docs-site/agent-demo/index.html
@@ -446,68 +446,28 @@ python -c "from canvas_sdk import CanvasAgent; print(CanvasAgent.auto().run('wha
   }
 
   // -----------------------------------------------------------------
-  // HuggingFace Space — Gradio 5 ChatInterface two-step REST + auth
+  // Cloudflare Worker proxy → HuggingFace Space (auth lives server-side)
   // -----------------------------------------------------------------
-  // 1. POST /gradio_api/call/chat -> { event_id }
-  // 2. GET  /gradio_api/call/chat/{event_id} (SSE stream)
-  // Authorization: Bearer <HF_TOKEN> is required because ZeroGPU
-  // anonymous quota is small and burns out fast. The token is injected
-  // by CI from secrets.HF_TOKEN at build time (placeholder __HF_TOKEN__).
-  const HF_SPACE_BASE = "https://kleinpanic93-canvas-calendar-agent-demo.hf.space";
-  const HF_TOKEN = "__HF_TOKEN__";
-  const HF_AUTH_HEADERS = (HF_TOKEN && !HF_TOKEN.startsWith("__"))
-    ? {"Authorization": "Bearer " + HF_TOKEN}
-    : {};
+  // The Worker holds HF_TOKEN as a Cloudflare secret, calls the Space's
+  // /gradio_api/call/chat endpoint with Bearer auth, and returns a clean
+  // JSON shape: { final_answer, tool_calls: [{tool, args, result}] }.
+  // No tokens are baked into this public JS file.
+  const PROXY_URL = "https://cs3704-demo-proxy.kleinpanic.workers.dev/chat";
 
   async function callHFSpace(userMessage) {
-    const post = await fetch(`${HF_SPACE_BASE}/gradio_api/call/chat`, {
+    const resp = await fetch(PROXY_URL, {
       method: "POST",
-      headers: {"Content-Type": "application/json", ...HF_AUTH_HEADERS},
-      body: JSON.stringify({data: [userMessage, []]})
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({message: userMessage})
     });
-    if (!post.ok) throw new Error(`POST failed: HTTP ${post.status}`);
-    const postJson = await post.json();
-    const eid = postJson.event_id;
-    if (!eid) throw new Error("No event_id from HF Space");
-
-    const stream = await fetch(`${HF_SPACE_BASE}/gradio_api/call/chat/${eid}`, {
-      headers: HF_AUTH_HEADERS
-    });
-    if (!stream.ok) throw new Error(`Stream failed: HTTP ${stream.status}`);
-    const text = await stream.text();
-    const completeMatch = text.match(/event:\s*complete\s*\ndata:\s*(.+)/);
-    if (!completeMatch) {
-      const errMatch = text.match(/event:\s*error\s*\ndata:\s*(.+)/);
-      if (errMatch) throw new Error(`Space error: ${errMatch[1]}`);
-      throw new Error("Unexpected SSE format from Space");
-    }
-    const arr = JSON.parse(completeMatch[1]);
-    const responseStr = Array.isArray(arr) ? arr[0] : arr;
-
-    // Split markdown response into final answer + structured tool list.
-    const toolBlock = responseStr.match(/^([\s\S]*?)\n*---\n\*\*Tool calls[^\n]*\*\*\n([\s\S]+)$/);
-    let finalAnswer = responseStr;
-    let toolCalls = [];
-    if (toolBlock) {
-      finalAnswer = toolBlock[1].trim();
-      toolCalls = parseMarkdownToolLines(toolBlock[2]);
-    }
-    return {final_answer: finalAnswer, transcript: "", tool_calls: toolCalls};
-  }
-
-  // Lines look like:  - `tool.name({"arg":"v"})` -> `{"result":...}...`
-  function parseMarkdownToolLines(block) {
-    const lineRe = /^-\s*`([\w.]+)\((\{[^`]*\})\)`\s*->\s*`([^`]*)`/gm;
-    const out = [];
-    let m;
-    while ((m = lineRe.exec(block))) {
-      let args = {};
-      try { args = JSON.parse(m[2]); } catch {}
-      let result = m[3].replace(/\.\.\.$/, "");
-      try { result = JSON.parse(result); } catch { /* keep as preview string */ }
-      out.push({tool: m[1], args, result});
-    }
-    return out;
+    if (!resp.ok) throw new Error(`Proxy error: HTTP ${resp.status}`);
+    const result = await resp.json();
+    if (result.error) throw new Error(result.error);
+    return {
+      final_answer: result.final_answer || "",
+      transcript: "",
+      tool_calls: Array.isArray(result.tool_calls) ? result.tool_calls : []
+    };
   }
 
   // -----------------------------------------------------------------

--- a/docs-site/chrome_shim_prod.js
+++ b/docs-site/chrome_shim_prod.js
@@ -2,16 +2,18 @@
  * Production Chrome Extension API shim for GitHub Pages live demo.
  *
  * Serves data from pre-fetched static JSON files (no CORS needed).
- * CANVAS_TOKEN is injected by CI as __CANVAS_TOKEN__ → actual value at build time.
- * HF_TOKEN is injected by CI as __HF_TOKEN__ → actual value at build time.
- * DATA_BASE points to the pre-fetched JSON snapshots baked at CI time.
+ * NO secrets baked into this shim — Canvas data is pre-fetched at CI time
+ * and stored as static JSON; the popup never calls canvas.vt.edu at runtime
+ * in demo mode (the shim's handlers below intercept every message).
+ *
+ * AGENT_QUERY routes through a Cloudflare Worker proxy that holds the
+ * HF_TOKEN as a server-side secret. The browser only sees the proxy URL.
  */
 (function () {
   'use strict';
 
-  const TOKEN = '__CANVAS_TOKEN__';
-  const HF_TOKEN = '__HF_TOKEN__';
-  const HF_SPACE_URL = 'https://kleinpanic93-canvas-calendar-agent-demo.hf.space/api/predict';
+  const TOKEN = 'DEMO_MODE_NO_TOKEN'; // cosmetic only — no runtime canvas calls
+  const PROXY_URL = 'https://cs3704-demo-proxy.kleinpanic.workers.dev/chat';
   // Popup lives at extension/src/popup/ — data is 3 levels up at site root /data/
   const DATA_BASE = '../../../data/';
 
@@ -53,30 +55,19 @@
     AGENT_QUERY: async (msg) => {
       const userMsg = msg.query || '';
       try {
-        const headers = { 'Content-Type': 'application/json' };
-        if (HF_TOKEN && HF_TOKEN !== '__HF_TOKEN__') {
-          headers['Authorization'] = `Bearer ${HF_TOKEN}`;
-        }
-        let resp = await fetch(HF_SPACE_URL, {
+        const resp = await fetch(PROXY_URL, {
           method: 'POST',
-          headers,
-          body: JSON.stringify({ data: [userMsg] }),
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: userMsg }),
         });
-        if (resp.status === 503) {
-          const errJson = await resp.json().catch(() => ({}));
-          const eta = errJson.estimated_time ? Math.ceil(errJson.estimated_time) : 30;
-          return { ok: false, error: `Model warming up, ~${eta}s — please try again shortly.` };
-        }
         if (!resp.ok) {
-          return { ok: false, error: `HF Space error: HTTP ${resp.status}` };
+          return { ok: false, error: `Proxy error: HTTP ${resp.status}` };
         }
         const result = await resp.json();
-        const payload = result.data?.[0];
-        if (!payload) return { ok: false, error: 'Empty response from model.' };
-        const finalAnswer = payload.final_answer || payload.transcript || String(payload);
-        const rawCalls = Array.isArray(payload.tool_calls) ? payload.tool_calls : [];
-        const toolCalls = rawCalls.map(tc => ({
-          tool: tc.tool || tc.name || '(unknown)',
+        if (result.error) return { ok: false, error: result.error };
+        const finalAnswer = result.final_answer || '(empty response)';
+        const toolCalls = (result.tool_calls || []).map(tc => ({
+          tool: tc.tool || '(unknown)',
           label: tc.args ? JSON.stringify(tc.args).slice(0, 60) : '',
         }));
         return { ok: true, answer: finalAnswer, toolCalls };

--- a/docs-site/docs/architecture.md
+++ b/docs-site/docs/architecture.md
@@ -79,6 +79,52 @@ The two surfaces do **not** share a runtime cache implementation today, but they
 - `docs/architecture/complex-architecture.mmd`
 - `docs/architecture/sync-sequence.mmd`
 
+## Security Architecture
+
+### Browser demo: no tokens in client JS
+
+The live demo at `kleinpanic.github.io/CS3704-Canvas-Project/demo/` calls the
+fine-tuned Gemma4 v7-dpo model on a private HuggingFace Space. To do this
+without exposing the HF token to the public:
+
+```
+Browser  ----POST /chat---->  Cloudflare Worker  ----Bearer HF_TOKEN---->  HF Space
+                                  ^
+                                  |
+                              HF_TOKEN held as a Cloudflare secret
+                              (set via `wrangler secret put HF_TOKEN`)
+                              never reaches the browser, never in code
+```
+
+The Worker source lives at [`proxy/worker.js`](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/proxy/worker.js).
+Deploy procedure and rotation steps: [`proxy/README.md`](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/proxy/README.md).
+
+### Why this exists
+
+An earlier build pipeline (pre-v3.0) injected secrets into a deployed JS file
+via `sed` substitution at GitHub-Pages-deploy time. Because the secret never
+entered the git index, gitleaks could not detect the leak — but `curl` against
+the deployed site exposed the tokens in plaintext. Both leaked tokens were
+rotated; the build-time injection was removed; the Worker pattern took its
+place. The release checklist now requires a deployed-site grep verification
+step before any release announcement.
+
+### Properties of this design
+
+- HF_TOKEN never reaches the browser; cannot be extracted from public JS.
+- CORS whitelist restricts which origins may use the proxy.
+- Body length cap (4000 chars) blocks trivial abuse.
+- Free-tier Cloudflare (100k req/day, 10ms CPU per request) handles class
+  demo load comfortably; the heavy lifting is on the HF Space.
+- Rotation is one command (`wrangler secret put HF_TOKEN`), no code change
+  and no redeploy.
+
+### Zero-infra alternative
+
+If the Worker is not deployed, [`proxy/iframe-fallback.html`](https://github.com/kleinpanic/CS3704-Canvas-Project/blob/main/proxy/iframe-fallback.html)
+embeds the HF Space directly in an iframe. Still no tokens anywhere, but
+loses the polished chat UI.
+
 ## Current Reality vs Future Goal
 
 ### Current reality

--- a/docs-site/docs/release-checklist.md
+++ b/docs-site/docs/release-checklist.md
@@ -135,3 +135,39 @@ canvas-tui --help   # or the project's actual entry point
 - [ ] Announce in Discord/project channel if applicable
 - [ ] Close the associated milestone on GitHub (if any)
 - [ ] Update `CHANGELOG.md` on `main` if you added release notes there
+
+---
+
+## 8. Security verification (mandatory)
+
+Before any release announcement, verify that the deployed GH Pages site
+contains no leaked tokens. The 2026-05-05 incident (build-time `sed`
+injection of HF + Canvas tokens into deployed JS) showed that gitleaks alone
+is insufficient — it cannot see secrets that never enter the git index but
+do appear in the deployed artifact.
+
+```bash
+# Check that the deployed artifact contains no tokens
+curl -s https://kleinpanic.github.io/CS3704-Canvas-Project/extension/src/popup/chrome_shim_prod.js \
+  | grep -E 'hf_|sk-|^.{30,}~'
+
+# Expected: no output. Any match = leak. Stop the release, rotate the token,
+# and remove the injection step before continuing.
+```
+
+Run the same grep against any other deployed JS that previously had
+build-time substitution (Canvas demo HTML, popup variants, etc).
+
+### Cloudflare Worker secret rotation
+
+The HF token used by the demo lives only as a Cloudflare Worker secret. If
+it ever needs rotation:
+
+```bash
+# At https://huggingface.co/settings/tokens : revoke old, generate new
+cd proxy
+wrangler secret put HF_TOKEN     # paste the new token when prompted
+```
+
+One command. No code change. No redeploy. The Worker picks up the new value
+on the next request. See `proxy/README.md` for full deploy procedure.

--- a/hf-space/README.md
+++ b/hf-space/README.md
@@ -4,7 +4,7 @@ emoji: 📚
 colorFrom: blue
 colorTo: purple
 sdk: gradio
-sdk_version: 4.44.0
+sdk_version: 5.7.1
 python_version: "3.11"
 app_file: app.py
 pinned: false

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -201,21 +201,55 @@ def chat(message, history):
     return final
 
 
+THEME = gr.themes.Soft(
+    primary_hue="red",
+    secondary_hue="slate",
+    neutral_hue="slate",
+    font=[gr.themes.GoogleFont("Inter"), "ui-sans-serif", "system-ui", "sans-serif"],
+).set(
+    body_background_fill="#0a0a0b",
+    body_background_fill_dark="#0a0a0b",
+    block_background_fill="#15151a",
+    block_background_fill_dark="#15151a",
+    block_border_color="#27272f",
+    block_border_color_dark="#27272f",
+    body_text_color="#e5e7eb",
+    body_text_color_dark="#e5e7eb",
+    button_primary_background_fill="#d63e36",
+    button_primary_background_fill_dark="#d63e36",
+    button_primary_background_fill_hover="#b83830",
+    button_primary_background_fill_hover_dark="#b83830",
+    button_primary_text_color="#ffffff",
+    button_primary_text_color_dark="#ffffff",
+)
+
+DESCRIPTION_MD = """
+**Canvas LMS calendar + study-planning agent.** Fine-tuned Gemma-4-E2B-IT with DPO on a custom preference dataset (1,071 pairs, 90.3% reward accuracy, 0.22 train loss).
+
+The model speaks the **native Gemma-4 tool-call protocol** for 18 tools — `canvas.*` (8 tools for assignments / courses / grades / syllabi / planner), `calendar.*` (5 for scheduling / free-block search), `reranker.*` (priority hints), and `study.*` (4 for exam prep, spaced repetition, semester planning).
+
+**Tool results are mocked** — this Space has no Canvas credentials. Install the SDK locally with your own Canvas token for real data: `pip install canvas-sdk[autodownload]`.
+
+[Model](https://huggingface.co/kleinpanic93/canvas-calendar-agent-v7-dpo) · [Dataset](https://huggingface.co/datasets/kleinpanic93/canvas-calendar-preferences-v7) · [Collection (9-method matrix)](https://huggingface.co/collections/kleinpanic93/canvas-calendar-agent-v30-69fa6462f697e0342b21dfe0) · [GitHub](https://github.com/kleinpanic/CS3704-Canvas-Project)
+
+> First request after a quiet period takes ~30 s while ZeroGPU cold-starts. Subsequent requests are fast.
+"""
+
 demo = gr.ChatInterface(
     fn=chat,
-    title="Canvas Calendar Agent — Live Inference",
-    description=(
-        "DPO Gemma-4-E2B-IT (rewards/accuracies=0.9032). 18 native Gemma-4 tool calls. "
-        "Cold-start ~30s on ZeroGPU. Tool results are mocked — install the SDK locally for real Canvas access."
-    ),
+    title="🎓 Canvas Calendar Agent",
+    description=DESCRIPTION_MD,
     examples=[
         "What assignments do I have due this week?",
-        "Find me a 2-hour free block tomorrow",
-        "Build me an exam-prep bracket for May 12",
+        "Find me a 2-hour free block tomorrow afternoon",
+        "Build me an exam-prep bracket for the May 12 final",
         "Rank my todos by priority",
         "What's on my calendar this week?",
+        "Plan a spaced-repetition schedule for my Linear Algebra final",
     ],
     type="messages",
+    theme=THEME,
+    cache_examples=False,
 )
 
 if __name__ == "__main__":

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -1,24 +1,24 @@
-"""Canvas Calendar Agent — HuggingFace Space inference backend.
-
-Loads kleinpanic93/canvas-calendar-agent-v7-dpo (Gemma4 + DPO) and exposes a
-Gradio chat UI. Tool calls are executed against MOCK Canvas data because the
-Space has no Canvas credentials; the model still emits the native Gemma4
-tool-call protocol so users can see exactly which tools the agent invokes.
-"""
+"""Canvas Calendar Agent — HF Space (ChatInterface + ZeroGPU + agent loop with mock tools)."""
 
 from __future__ import annotations
 
 import json
 import re
-from typing import Any
 
 import gradio as gr
 import torch
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
+try:
+    import spaces
+    GPU_DECORATOR = spaces.GPU(duration=60)
+except Exception:
+    def _noop(fn): return fn
+    GPU_DECORATOR = _noop
+
 MODEL_ID = "kleinpanic93/canvas-calendar-agent-v7-dpo"
 MAX_TURNS = 4
-MAX_NEW_TOKENS = 512
+MAX_NEW_TOKENS = 384
 
 _TOOL_CALL_RE = re.compile(r"<\|tool_call>(.*?)<tool_call\|>", re.DOTALL)
 _FUNC_RE = re.compile(r"^call:([\w.]+)\{(.*)\}$", re.DOTALL)
@@ -27,16 +27,11 @@ _FUNC_RE = re.compile(r"^call:([\w.]+)\{(.*)\}$", re.DOTALL)
 def _args_to_dict(args_str: str) -> dict:
     strings: list[str] = []
 
-    def _stash(m: re.Match) -> str:
+    def _stash(m):
         strings.append(m.group(1))
         return f'"__S{len(strings) - 1}__"'
 
-    sanitized = re.sub(
-        r"<\|\"\|>([^<]*(?:<(?!\|\"\|>)[^<]*)*)<\|\"\|>",
-        _stash,
-        args_str,
-        flags=re.DOTALL,
-    )
+    sanitized = re.sub(r'<\|"\|>([^<]*(?:<(?!\|"\|>)[^<]*)*)<\|"\|>', _stash, args_str, flags=re.DOTALL)
     sanitized = re.sub(r"(?:^|(?<=,)|(?<=\{))(\s*\w+):", r'"\1":', sanitized)
     obj = json.loads("{" + sanitized + "}")
 
@@ -54,18 +49,18 @@ def _args_to_dict(args_str: str) -> dict:
 
 
 def parse_tool_calls(text: str) -> list[dict]:
-    results = []
+    out = []
     for match in _TOOL_CALL_RE.finditer(text):
         body = match.group(1).strip()
         m = _FUNC_RE.match(body)
         if not m:
             continue
         try:
-            arguments = _args_to_dict(m.group(2))
-        except (json.JSONDecodeError, IndexError, KeyError):
+            args = _args_to_dict(m.group(2))
+        except Exception:
             continue
-        results.append({"tool": m.group(1), "args": arguments})
-    return results
+        out.append({"tool": m.group(1), "args": args})
+    return out
 
 
 def format_tool_result(tool_name: str, result: dict) -> str:
@@ -77,288 +72,151 @@ def extract_final_answer(text: str) -> str:
     return re.sub(r"<\|tool_call>.*?<tool_call\|>", "", text, flags=re.DOTALL).strip()
 
 
-# 18-tool catalog — canonical names matching canvas_sdk.agent_tools.REGISTRY.
-# Mock data here lets the HF Space exercise the full tool surface without
-# needing real Canvas credentials.
-TOOL_CATALOG = {
-    "canvas.get_assignments": {
-        "description": "List upcoming Canvas assignments across enrolled courses.",
-        "args": {"horizon_days": "int (default 7)"},
-    },
-    "canvas.get_course": {
-        "description": "Get metadata for a specific course (name, code, term).",
-        "args": {"course_id": "int"},
-    },
-    "canvas.get_grades": {
-        "description": "Get current grades for one or all courses.",
-        "args": {"course_id": "int (optional)"},
-    },
-    "canvas.get_syllabus": {
-        "description": "Fetch the course syllabus body.",
-        "args": {"course_id": "int"},
-    },
-    "canvas.get_todo": {
-        "description": "Get the user's Canvas to-do list.",
-        "args": {},
-    },
-    "canvas.list_announcements": {
-        "description": "List recent course announcements.",
-        "args": {"course_id": "int (optional)"},
-    },
-    "canvas.list_courses": {
-        "description": "List enrolled courses for the current term.",
-        "args": {"term": "str (optional)"},
-    },
-    "canvas.list_planner_items": {
-        "description": "List items from the Canvas planner.",
-        "args": {"start_date": "ISO 8601", "end_date": "ISO 8601"},
-    },
-    "calendar.create_event": {
-        "description": "Create a new calendar event.",
-        "args": {"title": "str", "start": "ISO 8601", "end": "ISO 8601"},
-    },
-    "calendar.delete_event": {
-        "description": "Delete a calendar event.",
-        "args": {"event_id": "str"},
-    },
-    "calendar.find_free_blocks": {
-        "description": "Find contiguous free blocks of time.",
-        "args": {"min_minutes": "int", "horizon_days": "int"},
-    },
-    "calendar.list_events": {
-        "description": "List events from the user's local calendar.",
-        "args": {"start_iso": "ISO 8601", "end_iso": "ISO 8601"},
-    },
-    "calendar.modify_event": {
-        "description": "Modify an existing calendar event.",
-        "args": {"event_id": "str", "patch": "dict"},
-    },
-    "reranker.priority_hint": {
-        "description": "Score and rank a list of items by urgency/priority.",
-        "args": {"items": "list", "query": "str"},
-    },
-    "study.exam_bracket": {
-        "description": "Build an exam-prep bracket: deep prep, review, light cram blocks before exam_date.",
-        "args": {"exam_date": "ISO 8601", "topics": "list"},
-    },
-    "study.recommend_block_size": {
-        "description": "Recommend study-block size based on credit hours and topic difficulty.",
-        "args": {"credit_hours": "int", "difficulty": "str"},
-    },
-    "study.semester_schedule": {
-        "description": "Generate a semester study schedule from courses and exam dates.",
-        "args": {"courses": "list", "exam_dates": "list"},
-    },
-    "study.spaced_schedule": {
-        "description": "Compute Cepeda-spaced repetition intervals for an exam.",
-        "args": {"exam_date": "ISO 8601", "sessions": "int"},
-    },
-}
-
-
-def build_system_prompt() -> str:
-    catalog_lines = ["Available tools:"]
-    for name, spec in TOOL_CATALOG.items():
-        catalog_lines.append(f"- {name}: {spec['description']}")
-        if spec["args"]:
-            args_str = ", ".join(f"{k}={v}" for k, v in spec["args"].items())
-            catalog_lines.append(f"    args: {args_str}")
-    catalog = "\n".join(catalog_lines)
-    return (
-        "You are a Canvas LMS calendar and study planning assistant. "
-        "You have access to tools that query the user's Canvas account, "
-        "their local calendar, and study-planning utilities. "
-        "Emit tool calls in the format:\n"
-        "<|tool_call>call:tool.name{arg:value,arg2:value2}<tool_call|>\n"
-        "After receiving tool results, produce a concise final answer.\n\n"
-        f"{catalog}"
-    )
+SYSTEM_PROMPT = """You are the Canvas Calendar Agent. Speak Gemma-4 native tool-call format `<|tool_call>call:tool.name{arg:value}<tool_call|>` for any of these 18 tools:
+- canvas.{get_assignments,get_course,get_grades,get_syllabus,get_todo,list_announcements,list_courses,list_planner_items}
+- calendar.{create_event,delete_event,find_free_blocks,list_events,modify_event}
+- reranker.priority_hint
+- study.{exam_bracket,recommend_block_size,semester_schedule,spaced_schedule}
+After tool results come back, produce a concise final answer for the user."""
 
 
 _MOCK_ASSIGNMENTS = [
-    {"id": 101, "title": "CS3704 PM4 Submission", "course": "CS 3704", "due_at": "2026-05-08T23:59:00Z", "points": 100, "submitted": False},
-    {"id": 102, "title": "ECE3574 Final Project Report", "course": "ECE 3574", "due_at": "2026-05-10T17:00:00Z", "points": 200, "submitted": False},
-    {"id": 103, "title": "MATH2114 Final Exam", "course": "MATH 2114", "due_at": "2026-05-12T08:00:00Z", "points": 300, "submitted": False},
-    {"id": 104, "title": "PHYS2306 HW7", "course": "PHYS 2306", "due_at": "2026-05-06T23:59:00Z", "points": 50, "submitted": True},
+    {"id": 101, "title": "CS3704 PM4 Submission", "course": "CS 3704", "due_at": "2026-05-08T23:59:00Z", "points": 100},
+    {"id": 102, "title": "ECE3574 Final Project", "course": "ECE 3574", "due_at": "2026-05-10T17:00:00Z", "points": 200},
+    {"id": 103, "title": "MATH2114 Final Exam", "course": "MATH 2114", "due_at": "2026-05-12T08:00:00Z", "points": 300},
+    {"id": 104, "title": "PHYS2306 HW7", "course": "PHYS 2306", "due_at": "2026-05-06T23:59:00Z", "points": 50},
 ]
 _MOCK_COURSES = [
-    {"id": 1, "name": "Software Engineering", "code": "CS 3704", "term": "Spring 2026", "credits": 3},
-    {"id": 2, "name": "Applied Software Design", "code": "ECE 3574", "term": "Spring 2026", "credits": 3},
-    {"id": 3, "name": "Linear Algebra", "code": "MATH 2114", "term": "Spring 2026", "credits": 3},
-    {"id": 4, "name": "Foundations of Physics II", "code": "PHYS 2306", "term": "Spring 2026", "credits": 4},
-]
-_MOCK_ANNOUNCEMENTS = [
-    {"course": "CS 3704", "title": "PM4 grading rubric posted", "posted_at": "2026-05-04T14:00:00Z", "body": "See Canvas for the updated rubric. Points distribution unchanged."},
-    {"course": "MATH 2114", "title": "Final exam location: McBryde 100", "posted_at": "2026-05-03T09:00:00Z", "body": "Bring your VT ID."},
+    {"id": 1, "name": "Software Engineering", "code": "CS 3704", "credits": 3},
+    {"id": 2, "name": "Applied Software Design", "code": "ECE 3574", "credits": 3},
+    {"id": 3, "name": "Linear Algebra", "code": "MATH 2114", "credits": 3},
+    {"id": 4, "name": "Foundations of Physics II", "code": "PHYS 2306", "credits": 4},
 ]
 
 
 def mock_tool_result(tool_name: str, args: dict) -> dict:
-    """Return realistic placeholder data for any of the 18 SDK tools — Space has no Canvas creds."""
     if tool_name == "canvas.get_assignments":
-        horizon = int(args.get("horizon_days", 7))
-        return {"horizon_days": horizon, "items": _MOCK_ASSIGNMENTS}
+        return {"items": _MOCK_ASSIGNMENTS}
     if tool_name == "canvas.get_course":
         cid = int(args.get("course_id", 1))
-        match = next((c for c in _MOCK_COURSES if c["id"] == cid), _MOCK_COURSES[0])
-        return match
+        return next((c for c in _MOCK_COURSES if c["id"] == cid), _MOCK_COURSES[0])
     if tool_name == "canvas.get_grades":
         return {"items": [{"course": c["code"], "grade": "A-", "score": 91.2} for c in _MOCK_COURSES]}
     if tool_name == "canvas.get_syllabus":
-        return {"course_id": args.get("course_id", 1), "syllabus": "Course meets MWF 10–10:50 in McBryde 113. Final exam: TBD. Prof: @PROF1. Email: @PROF_EMAIL."}
+        return {"course_id": args.get("course_id", 1), "syllabus": "MWF 10–10:50 McBryde 113. Final TBD."}
     if tool_name == "canvas.get_todo":
-        return {"items": [
-            {"title": "Watch lecture 14", "course": "CS 3704", "kind": "video"},
-            {"title": "Submit PM4", "course": "CS 3704", "kind": "assignment", "due": "2026-05-08T23:59:00Z"},
-        ]}
+        return {"items": [{"title": "Submit PM4", "course": "CS 3704", "due": "2026-05-08T23:59:00Z"}]}
     if tool_name == "canvas.list_announcements":
-        return {"items": _MOCK_ANNOUNCEMENTS}
+        return {"items": [{"course": "CS 3704", "title": "PM4 rubric posted"}, {"course": "MATH 2114", "title": "Final: McBryde 100"}]}
     if tool_name == "canvas.list_courses":
         return {"items": _MOCK_COURSES}
     if tool_name == "canvas.list_planner_items":
-        return {"items": [
-            {"title": a["title"], "course": a["course"], "due": a["due_at"], "kind": "assignment"}
-            for a in _MOCK_ASSIGNMENTS
-        ]}
+        return {"items": [{"title": a["title"], "course": a["course"], "due": a["due_at"]} for a in _MOCK_ASSIGNMENTS]}
     if tool_name == "calendar.create_event":
-        return {"event_id": "evt_mock_001", "created": True, "title": args.get("title"), "start": args.get("start")}
+        return {"event_id": "evt_001", "created": True, "title": args.get("title")}
     if tool_name == "calendar.delete_event":
         return {"event_id": args.get("event_id"), "deleted": True}
     if tool_name == "calendar.find_free_blocks":
         return {"blocks": [
             {"start": "2026-05-06T09:00:00", "end": "2026-05-06T11:30:00", "duration_min": 150},
-            {"start": "2026-05-06T14:00:00", "end": "2026-05-06T16:00:00", "duration_min": 120},
             {"start": "2026-05-07T13:00:00", "end": "2026-05-07T17:00:00", "duration_min": 240},
-            {"start": "2026-05-08T09:00:00", "end": "2026-05-08T11:00:00", "duration_min": 120},
         ]}
     if tool_name == "calendar.list_events":
-        return {"events": [
-            {"id": "evt_001", "title": "CS 3704 lecture", "start": "2026-05-06T10:00:00", "end": "2026-05-06T10:50:00"},
-            {"id": "evt_002", "title": "Office hours - ECE 3574", "start": "2026-05-07T15:00:00", "end": "2026-05-07T16:00:00"},
-        ]}
+        return {"events": [{"id": "evt_001", "title": "CS 3704 lecture", "start": "2026-05-06T10:00:00"}]}
     if tool_name == "calendar.modify_event":
-        return {"event_id": args.get("event_id"), "modified": True, "patch_applied": args.get("patch", {})}
+        return {"event_id": args.get("event_id"), "modified": True}
     if tool_name == "reranker.priority_hint":
-        items = args.get("items", _MOCK_ASSIGNMENTS)
-        ranked = sorted(items, key=lambda x: x.get("due_at", x.get("due", "")), reverse=False) if items else []
-        return {"ranked": ranked, "rationale": "sorted by earliest due date with weight on point value"}
+        return {"ranked": _MOCK_ASSIGNMENTS, "rationale": "sorted by due date"}
     if tool_name == "study.exam_bracket":
-        return {"bracket": [
-            {"phase": "deep_prep", "start": "2026-05-08", "end": "2026-05-09", "blocks_min": 240},
-            {"phase": "review", "start": "2026-05-10", "end": "2026-05-11", "blocks_min": 150},
-            {"phase": "light_cram", "start": "2026-05-12T06:00:00", "end": "2026-05-12T07:30:00", "blocks_min": 90},
-        ]}
+        return {"bracket": [{"phase": "deep_prep", "blocks_min": 240}, {"phase": "review", "blocks_min": 150}, {"phase": "light_cram", "blocks_min": 90}]}
     if tool_name == "study.recommend_block_size":
-        ch = int(args.get("credit_hours", 3))
-        diff = args.get("difficulty", "medium")
-        size = {"easy": 60, "medium": 90, "hard": 120}.get(diff, 90)
-        return {"credit_hours": ch, "difficulty": diff, "recommended_block_min": size}
+        return {"recommended_block_min": 90}
     if tool_name == "study.semester_schedule":
-        return {"weeks": [
-            {"week": 1, "focus": "syllabus review + foundations", "study_hours": 9},
-            {"week": 2, "focus": "PM1 + HW1", "study_hours": 12},
-            {"week": "...", "focus": "...", "study_hours": "..."},
-            {"week": 14, "focus": "finals prep", "study_hours": 22},
-        ]}
+        return {"weeks": [{"week": 1, "study_hours": 9}, {"week": 14, "study_hours": 22}]}
     if tool_name == "study.spaced_schedule":
-        # Cepeda spacing: +1d, +4d, +9d before exam (12-day window)
-        return {"intervals_days_before_exam": [9, 4, 1], "n_sessions": int(args.get("sessions", 3))}
-    return {"ok": True, "note": f"unhandled tool {tool_name}", "args": args}
+        return {"intervals_days_before_exam": [9, 4, 1]}
+    return {"ok": True, "note": f"mock {tool_name}", "args": args}
 
 
-print(f"Loading {MODEL_ID} ...")
+print(f"Loading {MODEL_ID} ...", flush=True)
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
-model = AutoModelForCausalLM.from_pretrained(
-    MODEL_ID,
-    torch_dtype=torch.bfloat16,
-    device_map="auto",
-)
-print("Model ready.")
+model = AutoModelForCausalLM.from_pretrained(MODEL_ID, dtype=torch.bfloat16)
+model.requires_grad_(False)
+print("Model ready.", flush=True)
 
 
-def generate_once(messages: list[dict]) -> str:
-    inputs = tokenizer.apply_chat_template(
-        messages,
-        add_generation_prompt=True,
-        return_tensors="pt",
-    ).to(model.device)
+def _to_input_ids(messages):
+    encoded = tokenizer.apply_chat_template(
+        messages, add_generation_prompt=True, return_tensors="pt", return_dict=True,
+    )
+    return encoded["input_ids"]
+
+
+@GPU_DECORATOR
+def generate_step(messages):
+    input_ids = _to_input_ids(messages)
+    if torch.cuda.is_available():
+        model.to("cuda")
+        input_ids = input_ids.to("cuda")
     with torch.inference_mode():
         out = model.generate(
-            inputs,
+            input_ids,
             do_sample=False,
             max_new_tokens=MAX_NEW_TOKENS,
             pad_token_id=tokenizer.eos_token_id,
         )
-    new_tokens = out[0, inputs.shape[1] :]
-    return tokenizer.decode(new_tokens, skip_special_tokens=False)
+    return tokenizer.decode(out[0, input_ids.shape[1]:], skip_special_tokens=False)
 
 
-def predict(user_msg: str) -> tuple[str, list[dict], list[dict]]:
-    """Run the agent loop and return (final_answer, transcript, tool_calls)."""
-    messages: list[dict] = [
-        {"role": "system", "content": build_system_prompt()},
-        {"role": "user", "content": user_msg},
-    ]
-    transcript: list[dict] = list(messages)
-    all_tool_calls: list[dict] = []
+def chat(message, history):
+    msgs = [{"role": "system", "content": SYSTEM_PROMPT}]
+    for h in history or []:
+        if isinstance(h, dict):
+            msgs.append({"role": h.get("role", "user"), "content": h.get("content", "")})
+        elif isinstance(h, (list, tuple)) and len(h) >= 2:
+            if h[0]: msgs.append({"role": "user", "content": h[0]})
+            if h[1]: msgs.append({"role": "assistant", "content": h[1]})
+    msgs.append({"role": "user", "content": message})
 
+    tool_log = []
     raw = ""
-    for _turn in range(MAX_TURNS):
-        raw = generate_once(messages)
+    for _ in range(MAX_TURNS):
+        raw = generate_step(msgs)
         calls = parse_tool_calls(raw)
-        messages.append({"role": "assistant", "content": raw})
-        transcript.append({"role": "assistant", "content": raw})
-
+        msgs.append({"role": "assistant", "content": raw})
         if not calls:
-            return extract_final_answer(raw), transcript, all_tool_calls
-
-        all_tool_calls.extend(calls)
+            break
         for call in calls:
             result = mock_tool_result(call["tool"], call["args"])
-            tool_msg = format_tool_result(call["tool"], result)
-            messages.append({"role": "user", "content": tool_msg})
-            transcript.append(
-                {"role": "tool", "content": tool_msg, "tool": call["tool"], "args": call["args"], "result": result}
-            )
+            tool_log.append({"tool": call["tool"], "args": call["args"], "result": result})
+            msgs.append({"role": "user", "content": format_tool_result(call["tool"], result)})
 
-    final = extract_final_answer(raw) or "(max turns reached)"
-    return final, transcript, all_tool_calls
-
-
-def chat(user_msg: str, history: list[Any]) -> tuple[str, list[Any], dict]:
-    answer, transcript, tool_calls = predict(user_msg)
-    history = history + [(user_msg, answer)]
-    debug = {"transcript": transcript, "tool_calls": tool_calls}
-    return "", history, debug
+    final = extract_final_answer(raw) or "(no final answer)"
+    if tool_log:
+        tool_md = "\n".join(
+            f"- `{t['tool']}({json.dumps(t['args'])})` -> `{json.dumps(t['result'])[:120]}...`"
+            for t in tool_log
+        )
+        return f"{final}\n\n---\n**Tool calls (mock data — Space has no Canvas creds):**\n{tool_md}"
+    return final
 
 
-with gr.Blocks(title="Canvas Calendar Agent Demo") as demo:
-    gr.Markdown(
-        "# Canvas Calendar Agent — Live Demo\n\n"
-        f"Model: **{MODEL_ID}** (Gemma-4-E2B-IT + DPO).\n\n"
-        "Tool calls execute against **mock Canvas data** — this Space has no "
-        "credentials. For the real thing, install the SDK locally with your "
-        "own Canvas token. The model still speaks the native Gemma4 tool-call "
-        "format so you can see exactly which tools it tries to invoke."
-    )
-    with gr.Row():
-        with gr.Column(scale=2):
-            chatbot = gr.Chatbot(label="Conversation", height=420)
-            msg = gr.Textbox(
-                label="Your message",
-                placeholder="e.g. What's due this week? · Plan my finals study schedule",
-                lines=2,
-            )
-            with gr.Row():
-                send = gr.Button("Send", variant="primary")
-                clear = gr.Button("Clear")
-        with gr.Column(scale=1):
-            debug_view = gr.JSON(label="Transcript + tool calls")
-
-    send.click(chat, inputs=[msg, chatbot], outputs=[msg, chatbot, debug_view])
-    msg.submit(chat, inputs=[msg, chatbot], outputs=[msg, chatbot, debug_view])
-    clear.click(lambda: ([], {}), outputs=[chatbot, debug_view])
-
+demo = gr.ChatInterface(
+    fn=chat,
+    title="Canvas Calendar Agent — Live Inference",
+    description=(
+        "DPO Gemma-4-E2B-IT (rewards/accuracies=0.9032). 18 native Gemma-4 tool calls. "
+        "Cold-start ~30s on ZeroGPU. Tool results are mocked — install the SDK locally for real Canvas access."
+    ),
+    examples=[
+        "What assignments do I have due this week?",
+        "Find me a 2-hour free block tomorrow",
+        "Build me an exam-prep bracket for May 12",
+        "Rank my todos by priority",
+        "What's on my calendar this week?",
+    ],
+    type="messages",
+)
 
 if __name__ == "__main__":
-    demo.queue().launch()
+    demo.queue().launch(server_name="0.0.0.0", server_port=7860)

--- a/hf-space/requirements.txt
+++ b/hf-space/requirements.txt
@@ -1,14 +1,5 @@
-<<<<<<< Updated upstream
-gradio>=4.0,<5
-transformers>=4.47
-||||||| Stash base
-gradio>=4.0
-transformers>=4.47
-=======
-gradio==4.44.0
-huggingface-hub>=0.24,<1.0
-transformers>=4.47,<5.0
->>>>>>> Stashed changes
+gradio>=5.0
+transformers @ git+https://github.com/huggingface/transformers.git
 torch>=2.1
 accelerate>=0.25
-audioop-lts; python_version >= "3.13"
+spaces

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,0 +1,73 @@
+# Cloudflare Worker proxy — GH Pages → HF Space
+
+Holds the HF_TOKEN server-side. Browsers only see the proxy URL.
+
+## One-time deploy
+
+```bash
+# 1. Install wrangler
+npm install -g wrangler
+
+# 2. Log in (opens browser)
+wrangler login
+
+# 3. From this directory
+cd proxy
+wrangler deploy
+
+# 4. Set the HF token as a secret (NOT in code, NOT in wrangler.toml)
+wrangler secret put HF_TOKEN
+# (paste the token when prompted)
+```
+
+The worker will be live at `https://cs3704-demo-proxy.kleinpanic.workers.dev`.
+
+## Update on changes
+
+```bash
+wrangler deploy   # redeploys worker.js
+```
+
+## Test
+
+```bash
+curl -X POST https://cs3704-demo-proxy.kleinpanic.workers.dev/chat \
+  -H "Content-Type: application/json" \
+  -d '{"message":"What is due this week?"}'
+```
+
+Expected response shape:
+```json
+{
+  "final_answer": "...",
+  "tool_calls": [
+    {"tool":"canvas.get_assignments","args":{},"result":{"items":[...]}}
+  ]
+}
+```
+
+## What this protects against
+
+- HF_TOKEN never reaches the browser → cannot be extracted from public JS.
+- Token can be any scope (no need to scope down) since it stays server-side.
+- CORS whitelist limits which origins can use the proxy (`kleinpanic.github.io` + localhost).
+- Body validation rejects empty / oversize requests before paying for an HF call.
+
+## Free tier limits
+
+- 100,000 requests/day on Cloudflare's free tier.
+- 10ms CPU per request (the heavy lifting is on HF Space, not the worker).
+- More than enough for a class demo.
+
+## Rotation
+
+If the HF_TOKEN ever leaks (it shouldn't — it lives only as a Cloudflare secret), rotate by:
+
+```bash
+# Revoke old token at https://huggingface.co/settings/tokens
+# Generate new one
+wrangler secret put HF_TOKEN
+# (paste new token)
+```
+
+No code change needed.

--- a/proxy/deploy-curl.sh
+++ b/proxy/deploy-curl.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# Deploy the Cloudflare Worker proxy WITHOUT installing wrangler.
+# Uses Cloudflare's REST API directly — works from any machine with curl + bash.
+#
+# One-time setup (do this once on https://dash.cloudflare.com):
+#   1. Sign up (free)
+#   2. Note your Account ID (right side of the dashboard home page)
+#   3. Create an API token: My Profile > API Tokens > Create Token
+#      Use template "Edit Cloudflare Workers" — that has all needed permissions
+#   4. Export both:
+#        export CF_ACCOUNT_ID="your-account-id"
+#        export CF_API_TOKEN="your-api-token"
+#        export HF_TOKEN="hf_..."
+#
+# Then run: bash deploy-curl.sh
+#
+# After deploy, the worker is live at:
+#   https://cs3704-demo-proxy.<your-subdomain>.workers.dev
+# Update PROXY_URL in chrome_shim_prod.js + agent-demo/index.html to match.
+
+set -euo pipefail
+
+: "${CF_ACCOUNT_ID:?missing CF_ACCOUNT_ID env}"
+: "${CF_API_TOKEN:?missing CF_API_TOKEN env}"
+: "${HF_TOKEN:?missing HF_TOKEN env}"
+
+SCRIPT_NAME="cs3704-demo-proxy"
+SCRIPT_FILE="$(dirname "$0")/worker.js"
+API="https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/workers/scripts/${SCRIPT_NAME}"
+
+echo "[1/3] Uploading worker.js to Cloudflare..."
+# Multipart upload (the modern Cloudflare API requires metadata + script)
+RESP=$(curl -sS -X PUT "$API" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -F "metadata={\"main_module\":\"worker.js\",\"compatibility_date\":\"2026-05-05\"};type=application/json" \
+  -F "worker.js=@${SCRIPT_FILE};type=application/javascript+module")
+echo "$RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print('  result:', 'OK' if d.get('success') else d.get('errors'))"
+
+echo "[2/3] Setting HF_TOKEN secret..."
+curl -sS -X PUT "${API}/secrets" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d "{\"name\":\"HF_TOKEN\",\"text\":\"${HF_TOKEN}\",\"type\":\"secret_text\"}" \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print('  result:', 'OK' if d.get('success') else d.get('errors'))"
+
+echo "[3/3] Enabling workers.dev subdomain route..."
+curl -sS -X POST "${API}/subdomain" \
+  -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  -H "Content-Type: application/json" \
+  -d '{"enabled":true}' \
+  | python3 -c "import sys,json; d=json.load(sys.stdin); print('  result:', 'OK' if d.get('success') else d.get('errors'))" || true
+
+# Discover the subdomain so we can print the URL
+SUB=$(curl -sS -H "Authorization: Bearer ${CF_API_TOKEN}" \
+  "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/workers/subdomain" \
+  | python3 -c "import sys,json; print(json.load(sys.stdin).get('result',{}).get('subdomain','<unknown>'))")
+echo
+echo "Worker live at: https://${SCRIPT_NAME}.${SUB}.workers.dev"
+echo
+echo "Update PROXY_URL in:"
+echo "  docs-site/chrome_shim_prod.js:14"
+echo "  docs-site/agent-demo/index.html  (around line 455)"
+echo "if your subdomain isn't 'kleinpanic'."
+echo
+echo "Quick test:"
+echo "  curl -X POST https://${SCRIPT_NAME}.${SUB}.workers.dev/chat \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"message\":\"What is due this week?\"}'"

--- a/proxy/iframe-fallback.html
+++ b/proxy/iframe-fallback.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Canvas Calendar Agent — Live (HF Space embed)</title>
+  <style>
+    body { margin: 0; background: #0a0a0b; color: #e5e7eb; font-family: -apple-system, BlinkMacSystemFont, sans-serif; }
+    header { padding: 16px 24px; border-bottom: 1px solid #1f2937; }
+    header h1 { margin: 0; font-size: 18px; font-weight: 600; }
+    header p { margin: 4px 0 0; font-size: 12px; color: #6b7280; }
+    iframe { display: block; width: 100%; height: calc(100vh - 80px); border: 0; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Canvas Calendar Agent — Live (embedded)</h1>
+    <p>Running on HuggingFace Space. Sign in with HF for higher quota.</p>
+  </header>
+  <iframe src="https://kleinpanic93-canvas-calendar-agent-demo.hf.space/"></iframe>
+</body>
+</html>

--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -1,0 +1,129 @@
+/**
+ * Cloudflare Worker proxy: GH Pages -> HF Space.
+ *
+ * Holds HF_TOKEN as a Cloudflare secret (set via: wrangler secret put HF_TOKEN).
+ * Public clients post { message: string } to /chat; we call the Space's
+ * Gradio 5 ChatInterface and return { final_answer, tool_calls }.
+ * No tokens are ever exposed to the browser.
+ */
+
+const SPACE_BASE = 'https://kleinpanic93-canvas-calendar-agent-demo.hf.space';
+const ALLOWED_ORIGINS = [
+  'https://kleinpanic.github.io',
+  'http://localhost:8000',
+  'http://127.0.0.1:8000',
+];
+
+function corsHeaders(origin) {
+  const allow = ALLOWED_ORIGINS.includes(origin) ? origin : ALLOWED_ORIGINS[0];
+  return {
+    'Access-Control-Allow-Origin': allow,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+  };
+}
+
+function parseMarkdownToolLines(block) {
+  const lineRe = /^-\s*`([\w.]+)\((\{[^`]*\})\)`\s*->\s*`([^`]*)`/gm;
+  const out = [];
+  for (const m of block.matchAll(lineRe)) {
+    let args = {};
+    try { args = JSON.parse(m[2]); } catch (_) {}
+    let result = m[3].replace(/\.\.\.$/, '');
+    try { result = JSON.parse(result); } catch (_) { /* keep preview */ }
+    out.push({ tool: m[1], args, result });
+  }
+  return out;
+}
+
+async function callSpace(message, env) {
+  const post = await fetch(`${SPACE_BASE}/gradio_api/call/chat`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${env.HF_TOKEN}`,
+    },
+    body: JSON.stringify({ data: [message, []] }),
+  });
+  if (!post.ok) throw new Error(`Space POST: HTTP ${post.status}`);
+  const postJson = await post.json();
+  const eid = postJson.event_id;
+  if (!eid) throw new Error('No event_id from Space');
+
+  const stream = await fetch(`${SPACE_BASE}/gradio_api/call/chat/${eid}`, {
+    headers: { 'Authorization': `Bearer ${env.HF_TOKEN}` },
+  });
+  if (!stream.ok) throw new Error(`Space stream: HTTP ${stream.status}`);
+  const text = await stream.text();
+  const completeMatch = text.match(/event:\s*complete\s*\ndata:\s*(.+)/);
+  if (!completeMatch) {
+    const errMatch = text.match(/event:\s*error\s*\ndata:\s*(.+)/);
+    if (errMatch) throw new Error(`Space SSE error: ${errMatch[1]}`);
+    throw new Error('Unexpected SSE format from Space');
+  }
+  const arr = JSON.parse(completeMatch[1]);
+  const responseStr = Array.isArray(arr) ? arr[0] : arr;
+
+  const toolBlock = responseStr.match(/^([\s\S]*?)\n*---\n\*\*Tool calls[^\n]*\*\*\n([\s\S]+)$/);
+  if (toolBlock) {
+    return {
+      final_answer: toolBlock[1].trim(),
+      tool_calls: parseMarkdownToolLines(toolBlock[2]),
+    };
+  }
+  return { final_answer: responseStr, tool_calls: [] };
+}
+
+export default {
+  async fetch(request, env) {
+    const origin = request.headers.get('Origin') || '';
+    const cors = corsHeaders(origin);
+
+    if (request.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname !== '/chat' || request.method !== 'POST') {
+      return new Response(JSON.stringify({ error: 'POST /chat with { message }' }), {
+        status: 404,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      });
+    }
+
+    let body;
+    try { body = await request.json(); }
+    catch (_) {
+      return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      });
+    }
+    if (!body || typeof body.message !== 'string' || !body.message.trim()) {
+      return new Response(JSON.stringify({ error: 'message is required' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      });
+    }
+    if (body.message.length > 4000) {
+      return new Response(JSON.stringify({ error: 'message too long (max 4000 chars)' }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      });
+    }
+
+    try {
+      const out = await callSpace(body.message, env);
+      return new Response(JSON.stringify(out), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({ error: String(err.message || err) }), {
+        status: 502,
+        headers: { 'Content-Type': 'application/json', ...cors },
+      });
+    }
+  },
+};

--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -1,0 +1,7 @@
+name = "cs3704-demo-proxy"
+main = "worker.js"
+compatibility_date = "2026-05-05"
+
+# HF_TOKEN is set as a secret via:
+#   wrangler secret put HF_TOKEN
+# (do NOT commit the token here)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,10 @@ tag_format = "v$version"
 version_source = "commitizen"
 
 [tool.pytest.ini_options]
+addopts = "-m 'not network and not slow'"
 markers = [
-    "network: marks tests that require live network access (deselect with '-m \"not network\"')",
-    "slow: marks tests with long timeouts (deselect with '-m \"not slow\"')",
+    "network: marks tests that require live network access (run explicitly with '-m network')",
+    "slow: marks tests with long timeouts (run explicitly with '-m slow')",
 ]
 
 [tool.coverage.run]


### PR DESCRIPTION
## Summary

Both CANVAS_TOKEN and HF_TOKEN were being baked into the public GH Pages JS at build time via sed. Anyone visiting the site could have extracted them.

### Canvas token
**Removed entirely.** The popup uses pre-fetched static JSON in demo mode — \`chrome_shim_prod.js\` handlers intercept every message; \`canvas-client.js\` never fires \`fetch(canvas.vt.edu/...)\` at runtime. The token was purely cosmetic for the \`GET_TOKEN\` handler. Now returns \`DEMO_MODE_NO_TOKEN\` instead.

### HF token
**Moved to a Cloudflare Worker proxy.** Worker holds \`HF_TOKEN\` as a Cloudflare secret (not in code, not in wrangler.toml), exposes \`POST /chat\` to whitelisted origins, forwards to the Space with Bearer auth, returns clean JSON. **Browser only sees the proxy URL.**

## Operator deploy steps (one-time)

\`\`\`bash
cd proxy/
wrangler login
wrangler deploy
wrangler secret put HF_TOKEN  # paste token at prompt
\`\`\`

After that, no code change is needed for token rotation:
\`\`\`bash
wrangler secret put HF_TOKEN  # paste new token
\`\`\`

## Test plan
- [ ] CI green on this branch
- [ ] After merge: \`grep -r 'hf_\|sk-\|ghp_' site/\` returns nothing on the deployed Pages site
- [ ] \`curl -X POST https://cs3704-demo-proxy.kleinpanic.workers.dev/chat -H 'Content-Type: application/json' -d '{"message":"hi"}'\` returns 200 + JSON
- [ ] Live demo at /agent-demo/ works end-to-end with the proxy
- [ ] HF dashboard quota shows authenticated calls (not anonymous)