### PR TITLE
fix(hf-space): tighten tool usage (MAX_TURNS + system prompt)

### DIFF
--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -17,7 +17,7 @@ except Exception:
     GPU_DECORATOR = _noop
 
 MODEL_ID = "kleinpanic93/canvas-calendar-agent-v7-dpo"
-MAX_TURNS = 4
+MAX_TURNS = 2  # was 4 — model over-chained tool calls across rounds
 MAX_NEW_TOKENS = 384
 
 _TOOL_CALL_RE = re.compile(r"<\|tool_call>(.*?)<tool_call\|>", re.DOTALL)
@@ -72,12 +72,19 @@ def extract_final_answer(text: str) -> str:
     return re.sub(r"<\|tool_call>.*?<tool_call\|>", "", text, flags=re.DOTALL).strip()
 
 
-SYSTEM_PROMPT = """You are the Canvas Calendar Agent. Speak Gemma-4 native tool-call format `<|tool_call>call:tool.name{arg:value}<tool_call|>` for any of these 18 tools:
+SYSTEM_PROMPT = """You are the Canvas Calendar Agent. You have these 18 tools available:
 - canvas.{get_assignments,get_course,get_grades,get_syllabus,get_todo,list_announcements,list_courses,list_planner_items}
 - calendar.{create_event,delete_event,find_free_blocks,list_events,modify_event}
 - reranker.priority_hint
 - study.{exam_bracket,recommend_block_size,semester_schedule,spaced_schedule}
-After tool results come back, produce a concise final answer for the user."""
+
+RULES (follow strictly):
+1. Call the MINIMUM number of tools needed — usually ONE — to directly answer the user's question.
+2. Don't call tools speculatively. Don't fetch data the user didn't ask for.
+3. Don't iterate over courses/items unless the user explicitly asked for per-item detail.
+4. After tool results come back, IMMEDIATELY produce a concise final answer. Do NOT call more tools.
+
+Tool-call format: `<|tool_call>call:tool.name{arg:value}<tool_call|>`"""
 
 
 _MOCK_ASSIGNMENTS = [

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -69,7 +69,29 @@ def format_tool_result(tool_name: str, result: dict) -> str:
 
 
 def extract_final_answer(text: str) -> str:
-    return re.sub(r"<\|tool_call>.*?<tool_call\|>", "", text, flags=re.DOTALL).strip()
+    # Strip both tool-call and stray tool-response markers the model sometimes hallucinates.
+    cleaned = re.sub(r"<\|tool_call>.*?<tool_call\|>", "", text, flags=re.DOTALL)
+    cleaned = re.sub(r"<\|tool_response>.*?<tool_response\|>", "", cleaned, flags=re.DOTALL)
+    cleaned = re.sub(r"<\|tool_response>", "", cleaned)
+    cleaned = re.sub(r"<turn\|>|<\|turn>", "", cleaned)
+    return cleaned.strip()
+
+
+def summarize_tool_results(tool_log: list[dict]) -> str:
+    """Fallback final answer when the model only emitted tool calls without composing prose."""
+    if not tool_log:
+        return "(no final answer)"
+    parts = []
+    for t in tool_log:
+        result = t.get("result", {})
+        items = result.get("items") if isinstance(result, dict) else None
+        if isinstance(items, list) and items:
+            parts.append(f"{t['tool']} returned {len(items)} item(s)")
+        elif isinstance(result, dict) and "blocks" in result:
+            parts.append(f"{t['tool']} found {len(result.get('blocks', []))} free block(s)")
+        else:
+            parts.append(f"{t['tool']} ran successfully")
+    return "Done. " + "; ".join(parts) + "."
 
 
 SYSTEM_PROMPT = """You are the Canvas Calendar Agent. You have these 18 tools available:
@@ -187,18 +209,28 @@ def chat(message, history):
 
     tool_log = []
     raw = ""
+    MAX_CALLS_PER_TURN = 2  # cap concurrent tool calls in a single generation
     for _ in range(MAX_TURNS):
         raw = generate_step(msgs)
-        calls = parse_tool_calls(raw)
+        calls = parse_tool_calls(raw)[:MAX_CALLS_PER_TURN]
         msgs.append({"role": "assistant", "content": raw})
         if not calls:
             break
         for call in calls:
+            # Skip duplicate (same tool+args already called this conversation)
+            already = any(
+                t["tool"] == call["tool"] and t["args"] == call["args"]
+                for t in tool_log
+            )
+            if already:
+                continue
             result = mock_tool_result(call["tool"], call["args"])
             tool_log.append({"tool": call["tool"], "args": call["args"], "result": result})
             msgs.append({"role": "user", "content": format_tool_result(call["tool"], result)})
 
-    final = extract_final_answer(raw) or "(no final answer)"
+    final = extract_final_answer(raw)
+    if not final or final == "(no final answer)":
+        final = summarize_tool_results(tool_log)
     if tool_log:
         tool_md = "\n".join(
             f"- `{t['tool']}({json.dumps(t['args'])})` -> `{json.dumps(t['result'])[:120]}...`"


### PR DESCRIPTION
## Summary
Operator feedback after first live demo: model over-calls tools (16+ per query). Quick fix without retraining:
- MAX_TURNS 4 → 2 (agent loop stops compounding)
- Numbered rules in system prompt: minimum tools, no speculative fetching, immediate final answer after tool results

Real fix is a v8 retrain with parsimony-rewarding DPO pairs — captured in MINIMAX-HANDOFF for next session.

Already pushed to the live HF Space; this PR keeps git in sync with what's deployed.

## Test plan
- [ ] CI green
- [ ] After deploy: "List my courses" → 1 tool call (canvas.list_courses), not 16+
- [ ] "Find a 2-hour free block tomorrow" → 1 tool call (calendar.find_free_blocks), not chained