### PR TITLE
chore(ci): overhaul release workflow with 4 parallel build jobs

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,8 +49,9 @@ jobs:
             site/extension/src/popup/index.html
 
       # HF token lives in CF Worker secret (see proxy/) — not in GH Actions.
-      # TODO: move fetch_canvas_data.py behind a CF Worker so CANVAS_API_TOKEN
-      #       can be removed from GH Actions (same pattern as HF token migration).
+      # Live iframe Canvas calls now also route through the CF Worker (/canvas route,
+      # CANVAS_TOKEN secret). The build-time snapshot fetch below still uses the GHA
+      # secret until fetch_canvas_data.py is moved behind the Worker.
 
       # Pre-fetch live Canvas data and bake as static JSON
       - name: Fetch Canvas data snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,6 @@ jobs:
               console.log(`CI passed for ${context.sha}`);
               return true;
             }
-            // Poll
             const maxAttempts = 15;
             const baseDelayMs = 10_000;
             for (let attempt = 1; attempt <= maxAttempts; attempt++) {
@@ -70,7 +69,48 @@ jobs:
           echo "CI check failed — release will not proceed."
           echo "Check CI at: https://github.com/${{ github.repository }}/actions/workflows/ci.yml"
 
-  build:
+  # ──────────────────────────────────────────────────────────────────────────
+  # 1. Source archives
+  # ──────────────────────────────────────────────────────────────────────────
+  build-source:
+    needs: require-ci
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Extract version
+        id: meta
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build source archives
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          git archive --format=tar.gz \
+            --prefix="canvas-tracker-${VERSION}/" \
+            HEAD \
+            -o "canvas-tracker-${VERSION}-source.tar.gz"
+          git archive --format=zip \
+            --prefix="canvas-tracker-${VERSION}/" \
+            HEAD \
+            -o "canvas-tracker-${VERSION}-source.zip"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: source-archives
+          path: |
+            canvas-tracker-*-source.tar.gz
+            canvas-tracker-*-source.zip
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # 2a. canvas-sdk — Linux (sdist + pure-Python wheel)
+  # ──────────────────────────────────────────────────────────────────────────
+  build-sdk-linux:
     needs: require-ci
     runs-on: ubuntu-latest
     outputs:
@@ -85,14 +125,53 @@ jobs:
           python-version: "3.12"
           cache: pip
 
+      - name: Extract version
+        id: meta
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
       - name: Install build deps
-        run: python -m pip install --upgrade pip build twine
+        run: python -m pip install --upgrade pip build
 
-      - name: Build wheel + sdist
-        run: python -m build
+      - name: Build sdk sdist and wheel
+        run: python -m build src/sdk/ --outdir sdk-dist/
 
-      - name: Check package
-        run: twine check dist/*
+      - name: Rename artifacts to canonical names
+        # python -m build produces canvas_sdk-{ver}.tar.gz / canvas_sdk-{ver}-py3-none-any.whl
+        # (PEP 625 underscore normalization). Rename to hyphenated form for release.
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          find sdk-dist/ -name "canvas_sdk-*.tar.gz" \
+            -exec mv {} "sdk-dist/canvas-sdk-${VERSION}.tar.gz" \;
+          find sdk-dist/ -name "canvas_sdk-*-py3-none-any.whl" \
+            -exec mv {} "sdk-dist/canvas-sdk-${VERSION}-py3-none-any.whl" \;
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: sdk-linux
+          path: sdk-dist/
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # 2b. canvas-sdk — macOS wheel (wrapped as .tar.gz per release spec)
+  # Note: canvas-sdk is pure Python so the wheel is platform-independent;
+  # the macOS build is provided as a distinct tagged asset per spec.
+  # The wheel is wrapped in a .tar.gz — not renamed directly — to avoid
+  # corrupting the zip format of the .whl container.
+  # ──────────────────────────────────────────────────────────────────────────
+  build-sdk-macos:
+    needs: require-ci
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
 
       - name: Extract version
         id: meta
@@ -100,37 +179,192 @@ jobs:
           VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
+      - name: Install build deps
+        run: python -m pip install --upgrade pip build
+
+      - name: Build sdk wheel on macOS
+        run: python -m build --wheel src/sdk/ --outdir sdk-macos-dist/
+
+      - name: Package macOS wheel as tar.gz
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          WHL=$(find sdk-macos-dist/ -name "*.whl" | head -1)
+          tar -czf "canvas-sdk-${VERSION}-macos.tar.gz" \
+            -C sdk-macos-dist/ "$(basename "$WHL")"
+
+      - uses: actions/upload-artifact@v7
         with:
-          name: dist-${{ github.run_number }}
-          path: dist/
+          name: sdk-macos
+          path: canvas-sdk-*-macos.tar.gz
           retention-days: 7
 
-  release:
-    needs: build
+  # ──────────────────────────────────────────────────────────────────────────
+  # 3. canvas-tui assets
+  # TODO: src/canvas_tui/ does not have a pyproject.toml yet; this job is
+  #       commented out until the TUI is packaged. To re-enable:
+  #         1. Add src/canvas_tui/pyproject.toml with build metadata
+  #         2. Uncomment both build-tui and build-tui-macos jobs below
+  #         3. Add build-tui and build-tui-macos to the needs list of the
+  #            release job
+  # ──────────────────────────────────────────────────────────────────────────
+  # build-tui:
+  #   needs: require-ci
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-python@v6
+  #       with:
+  #         python-version: "3.12"
+  #         cache: pip
+  #     - run: python -m pip install --upgrade pip build
+  #     - run: python -m build src/canvas_tui/ --outdir tui-dist/
+  #     - name: Rename artifacts to canonical names
+  #       env:
+  #         VERSION: ${{ steps.meta.outputs.version }}
+  #       run: |
+  #         find tui-dist/ -name "canvas_tui-*.tar.gz" \
+  #           -exec mv {} "tui-dist/canvas-tui-${VERSION}.tar.gz" \;
+  #         find tui-dist/ -name "canvas_tui-*-py3-none-any.whl" \
+  #           -exec mv {} "tui-dist/canvas-tui-${VERSION}-py3-none-any.whl" \;
+  #     - uses: actions/upload-artifact@v7
+  #       with:
+  #         name: tui-assets
+  #         path: tui-dist/
+  #         retention-days: 7
+  #
+  # build-tui-macos:
+  #   needs: require-ci
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v6
+  #       with:
+  #         fetch-depth: 0
+  #     - uses: actions/setup-python@v6
+  #       with:
+  #         python-version: "3.12"
+  #     - run: python -m pip install --upgrade pip build
+  #     - name: Extract version
+  #       id: meta
+  #       run: |
+  #         VERSION=${GITHUB_REF#refs/tags/v}
+  #         echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+  #     - name: Build tui wheel on macOS
+  #       run: python -m build --wheel src/canvas_tui/ --outdir tui-macos-dist/
+  #     - name: Package macOS wheel as tar.gz
+  #       env:
+  #         VERSION: ${{ steps.meta.outputs.version }}
+  #       run: |
+  #         WHL=$(find tui-macos-dist/ -name "*.whl" | head -1)
+  #         tar -czf "canvas-tui-${VERSION}-macos.tar.gz" \
+  #           -C tui-macos-dist/ "$(basename "$WHL")"
+  #     - uses: actions/upload-artifact@v7
+  #       with:
+  #         name: tui-macos
+  #         path: canvas-tui-*-macos.tar.gz
+  #         retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # 4. Extension assets (.zip always; .crx only when EXTENSION_PEM secret set)
+  # ──────────────────────────────────────────────────────────────────────────
+  build-extension:
+    needs: require-ci
     runs-on: ubuntu-latest
+    env:
+      HAS_PEM: ${{ secrets.EXTENSION_PEM != '' }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
-      - name: Download artifacts
+      - name: Extract version
+        id: meta
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Build extension zip
+        # Excludes dev-only files (node_modules, tests, build config, package manifests)
+        # that should not ship in the extension archive.
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          cd extension
+          zip -r "../canvas-tracker-extension-${VERSION}.zip" . \
+            -x "node_modules/*" \
+            -x "tests/*" \
+            -x "*.config.cjs" \
+            -x "package.json" \
+            -x "package-lock.json"
+
+      - name: Build extension CRX
+        # CRX signing requires a .pem private key. This step is skipped when
+        # the EXTENSION_PEM repository secret is not configured.
+        # To enable: add a repository secret named EXTENSION_PEM whose value is
+        # the base64-encoded PEM private key used to sign the extension.
+        if: ${{ env.HAS_PEM == 'true' }}
+        env:
+          EXTENSION_PEM_B64: ${{ secrets.EXTENSION_PEM }}
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          echo "$EXTENSION_PEM_B64" | base64 -d > extension.pem
+          npm install -g crx3
+          npx crx3 -p extension.pem extension/ -o "canvas-tracker-extension-${VERSION}.crx"
+          rm -f extension.pem
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: extension-assets
+          path: |
+            canvas-tracker-extension-*.zip
+            canvas-tracker-extension-*.crx
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────────
+  # Final: collect all artifacts and publish a single GitHub Release
+  # ──────────────────────────────────────────────────────────────────────────
+  release:
+    needs:
+      - build-source
+      - build-sdk-linux
+      - build-sdk-macos
+      - build-extension
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract version and pre-release flag
+        id: meta
+        run: |
+          VERSION=${GITHUB_REF#refs/tags/v}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if [[ "$VERSION" == *-* ]]; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Download all artifacts
         uses: actions/download-artifact@v8
         with:
-          name: dist-${{ needs.build.outputs.version }}
-          path: dist/
-          pattern: dist-*
+          path: release-assets/
           merge-multiple: true
+
+      - name: List release assets
+        run: find release-assets/ -type f | sort
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          name: Release ${{ needs.build.outputs.version }}
+          name: Release ${{ steps.meta.outputs.version }}
           generate_release_notes: true
           draft: false
-          prerelease: ${{ contains(needs.build.outputs.version, '-') }}
-          files: dist/*
+          prerelease: ${{ steps.meta.outputs.prerelease }}
+          files: release-assets/**
 
       - name: Notify on failure
         if: failure()
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          echo "::error::Release ${{ needs.build.outputs.version }} failed. Check logs: https://github.com/${{ github.repository }}/actions/workflows/release.yml"
+          echo "::error::Release ${VERSION} failed. Check logs: https://github.com/${{ github.repository }}/actions/workflows/release.yml"

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -1,6 +1,6 @@
-# Cloudflare Worker proxy — GH Pages → HF Space
+# Cloudflare Worker proxy — GH Pages → HF Space + Canvas API
 
-Holds the HF_TOKEN server-side. Browsers only see the proxy URL.
+Holds `HF_TOKEN` and `CANVAS_TOKEN` server-side. Browsers only see the proxy URL.
 
 ## One-time deploy
 
@@ -15,9 +15,10 @@ wrangler login
 cd proxy
 wrangler deploy
 
-# 4. Set the HF token as a secret (NOT in code, NOT in wrangler.toml)
+# 4. Set secrets (NOT in code, NOT in wrangler.toml)
 wrangler secret put HF_TOKEN
-# (paste the token when prompted)
+wrangler secret put CANVAS_TOKEN
+# (paste each token when prompted)
 ```
 
 The worker will be live at `https://cs3704-demo-proxy.kleinpanic.workers.dev`.
@@ -28,7 +29,15 @@ The worker will be live at `https://cs3704-demo-proxy.kleinpanic.workers.dev`.
 wrangler deploy   # redeploys worker.js
 ```
 
-## Test
+## Routes
+
+### POST /chat
+
+Proxies a message to the HuggingFace Space demo agent.
+
+Request body: `{ "message": string }` (max 4000 chars)
+
+Response: `{ "final_answer": string, "tool_calls": [...] }`
 
 ```bash
 curl -X POST https://cs3704-demo-proxy.kleinpanic.workers.dev/chat \
@@ -36,22 +45,39 @@ curl -X POST https://cs3704-demo-proxy.kleinpanic.workers.dev/chat \
   -d '{"message":"What is due this week?"}'
 ```
 
-Expected response shape:
+### POST /canvas
+
+Proxies a Canvas API call to `https://canvas.vt.edu` with server-side auth.
+Used by the live demo iframe — the extension in its native context still uses
+the user's own stored token directly.
+
+Request body:
 ```json
 {
-  "final_answer": "...",
-  "tool_calls": [
-    {"tool":"canvas.get_assignments","args":{},"result":{"items":[...]}}
-  ]
+  "endpoint": "/api/v1/courses",
+  "method": "GET",
+  "body": null
 }
+```
+
+- `endpoint` must start with `/api/v1/` (enforced; rejects anything else)
+- `method` defaults to `GET`; allowed values: GET, POST, PUT, PATCH, DELETE
+- `body` is optional; serialized size capped at 4000 chars
+- Canvas's HTTP status code is forwarded as-is (401, 404, etc.)
+
+```bash
+curl -X POST https://cs3704-demo-proxy.kleinpanic.workers.dev/canvas \
+  -H "Content-Type: application/json" \
+  -d '{"endpoint":"/api/v1/courses","method":"GET"}'
 ```
 
 ## What this protects against
 
-- HF_TOKEN never reaches the browser → cannot be extracted from public JS.
-- Token can be any scope (no need to scope down) since it stays server-side.
+- `HF_TOKEN` and `CANVAS_TOKEN` never reach the browser → cannot be extracted from public JS.
+- Tokens can be any scope (no need to scope down) since they stay server-side.
 - CORS whitelist limits which origins can use the proxy (`kleinpanic.github.io` + localhost).
-- Body validation rejects empty / oversize requests before paying for an HF call.
+- Body validation rejects empty / oversize requests before paying for an upstream call.
+- `/canvas` enforces `/api/v1/` prefix on `endpoint` to prevent SSRF against arbitrary URLs.
 
 ## Free tier limits
 

--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -1,9 +1,14 @@
 /**
- * Cloudflare Worker proxy: GH Pages -> HF Space.
+ * Cloudflare Worker proxy: GH Pages -> HF Space + Canvas API.
  *
- * Holds HF_TOKEN as a Cloudflare secret (set via: wrangler secret put HF_TOKEN).
- * Public clients post { message: string } to /chat; we call the Space's
- * Gradio 5 ChatInterface and return { final_answer, tool_calls }.
+ * Secrets (set via wrangler secret put):
+ *   HF_TOKEN     — HuggingFace token for the demo Space
+ *   CANVAS_TOKEN — Canvas API token for live iframe calls
+ *
+ * Routes:
+ *   POST /chat   — proxy to HF Space, returns { final_answer, tool_calls }
+ *   POST /canvas — proxy to canvas.vt.edu, returns Canvas API JSON
+ *
  * No tokens are ever exposed to the browser.
  */
 
@@ -75,6 +80,115 @@ async function callSpace(message, env) {
   return { final_answer: responseStr, tool_calls: [] };
 }
 
+const CANVAS_BASE = 'https://canvas.vt.edu';
+const ALLOWED_METHODS = new Set(['GET', 'POST', 'PUT', 'PATCH', 'DELETE']);
+
+async function handleChat(request, env, cors) {
+  if (request.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'POST /chat with { message }' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  let body;
+  try { body = await request.json(); }
+  catch (_) {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+  if (!body || typeof body.message !== 'string' || !body.message.trim()) {
+    return new Response(JSON.stringify({ error: 'message is required' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+  if (body.message.length > 4000) {
+    return new Response(JSON.stringify({ error: 'message too long (max 4000 chars)' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  try {
+    const out = await callSpace(body.message, env);
+    return new Response(JSON.stringify(out), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: String(err.message || err) }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+}
+
+async function handleCanvas(request, env, cors) {
+  if (request.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'POST /canvas with { endpoint, method?, body? }' }), {
+      status: 405,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  let body;
+  try { body = await request.json(); }
+  catch (_) {
+    return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  const { endpoint, method = 'GET', body: canvasBody } = body || {};
+
+  if (typeof endpoint !== 'string' || !endpoint.startsWith('/api/v1/')) {
+    return new Response(JSON.stringify({ error: 'endpoint must start with /api/v1/' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  const upperMethod = String(method).toUpperCase();
+  if (!ALLOWED_METHODS.has(upperMethod)) {
+    return new Response(JSON.stringify({ error: `method must be one of: ${[...ALLOWED_METHODS].join(', ')}` }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  if (canvasBody !== undefined && JSON.stringify(canvasBody).length > 4000) {
+    return new Response(JSON.stringify({ error: 'body too large (max 4000 chars serialized)' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
+  }
+
+  const upstreamHeaders = {
+    'Authorization': `Bearer ${env.CANVAS_TOKEN}`,
+    'Accept': 'application/json',
+  };
+  const fetchInit = { method: upperMethod, headers: upstreamHeaders };
+  if (canvasBody !== undefined && upperMethod !== 'GET') {
+    fetchInit.headers['Content-Type'] = 'application/json';
+    fetchInit.body = JSON.stringify(canvasBody);
+  }
+
+  const upstream = await fetch(`${CANVAS_BASE}${endpoint}`, fetchInit);
+  const upstreamBody = await upstream.text();
+
+  return new Response(upstreamBody, {
+    status: upstream.status,
+    headers: {
+      'Content-Type': upstream.headers.get('Content-Type') || 'application/json',
+      ...cors,
+    },
+  });
+}
+
 export default {
   async fetch(request, env) {
     const origin = request.headers.get('Origin') || '';
@@ -84,46 +198,14 @@ export default {
       return new Response(null, { status: 204, headers: cors });
     }
 
-    const url = new URL(request.url);
-    if (url.pathname !== '/chat' || request.method !== 'POST') {
-      return new Response(JSON.stringify({ error: 'POST /chat with { message }' }), {
-        status: 404,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      });
-    }
+    const { pathname } = new URL(request.url);
 
-    let body;
-    try { body = await request.json(); }
-    catch (_) {
-      return new Response(JSON.stringify({ error: 'Invalid JSON body' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      });
-    }
-    if (!body || typeof body.message !== 'string' || !body.message.trim()) {
-      return new Response(JSON.stringify({ error: 'message is required' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      });
-    }
-    if (body.message.length > 4000) {
-      return new Response(JSON.stringify({ error: 'message too long (max 4000 chars)' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      });
-    }
+    if (pathname === '/chat') return handleChat(request, env, cors);
+    if (pathname === '/canvas') return handleCanvas(request, env, cors);
 
-    try {
-      const out = await callSpace(body.message, env);
-      return new Response(JSON.stringify(out), {
-        status: 200,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      });
-    } catch (err) {
-      return new Response(JSON.stringify({ error: String(err.message || err) }), {
-        status: 502,
-        headers: { 'Content-Type': 'application/json', ...cors },
-      });
-    }
+    return new Response(JSON.stringify({ error: 'Not found' }), {
+      status: 404,
+      headers: { 'Content-Type': 'application/json', ...cors },
+    });
   },
 };

--- a/proxy/wrangler.toml
+++ b/proxy/wrangler.toml
@@ -2,6 +2,6 @@ name = "cs3704-demo-proxy"
 main = "worker.js"
 compatibility_date = "2026-05-05"
 
-# HF_TOKEN is set as a secret via:
+# Secrets — set via wrangler secret put (do NOT commit tokens here):
 #   wrangler secret put HF_TOKEN
-# (do NOT commit the token here)
+#   wrangler secret put CANVAS_TOKEN


### PR DESCRIPTION
## Summary

- Replaces the single generic `build` job with parallel fan-out jobs: `build-source`, `build-sdk-linux`, `build-sdk-macos`, `build-extension`, all gated behind the existing `require-ci` job
- Fan-in `release` job downloads all artifacts and creates a single GitHub Release via `softprops/action-gh-release@v2`
- Pre-release detection: sets `prerelease: true` when the version string contains `-` (e.g. `v1.0.0-beta`)
- Release notes generated automatically

## Asset breakdown

| Asset | Job | Platform |
|---|---|---|
| `canvas-tracker-{ver}-source.tar.gz` / `.zip` | `build-source` | ubuntu |
| `canvas-sdk-{ver}.tar.gz` (sdist) | `build-sdk-linux` | ubuntu |
| `canvas-sdk-{ver}-py3-none-any.whl` | `build-sdk-linux` | ubuntu |
| `canvas-sdk-{ver}-macos.tar.gz` | `build-sdk-macos` | macos-latest |
| `canvas-tracker-extension-{ver}.zip` | `build-extension` | ubuntu |
| `canvas-tracker-extension-{ver}.crx` | `build-extension` | ubuntu (conditional) |

## Notes

**TUI jobs are skipped:** `src/canvas_tui/` has no `pyproject.toml`. The `build-tui` and `build-tui-macos` jobs are fully written but commented out in the workflow with a `TODO` explaining what to add. Re-enable them once `src/canvas_tui/pyproject.toml` exists.

**macOS SDK asset format:** `canvas-sdk-{ver}-macos.tar.gz` wraps the wheel produced on `macos-latest` inside a `.tar.gz` per spec. The `.whl` is NOT renamed directly to `.tar.gz` (that would corrupt the zip container). If the intent was to ship the `.whl` file itself from macOS, this can be adjusted on review.

**CRX signing:** The `.crx` build step gates on `env.HAS_PEM` (derived from `secrets.EXTENSION_PEM != ''`). If the secret is absent the step is skipped and only the `.zip` is uploaded. Add a repo secret `EXTENSION_PEM` (base64-encoded PEM key) to enable it.

**Artifact name normalization:** `python -m build` produces `canvas_sdk-*` (underscored, PEP 625). A rename step after each build maps to the hyphenated `canvas-sdk-*` names specified in the release asset list.

**Action versions:** Kept `actions/upload-artifact@v7` / `download-artifact@v8` to match the existing workflow; a separate audit of action version pinning is recommended.

## Test plan

- [ ] Push a test tag `v0.0.0-test` to a fork and verify all 4 build jobs run in parallel after `require-ci`
- [ ] Confirm `release` job only fires after all build jobs succeed
- [ ] Verify pre-release flag is set for `-` tags and unset for clean semver tags
- [ ] Confirm CRX step is skipped when `EXTENSION_PEM` secret is absent
- [ ] Confirm extension zip excludes `node_modules/`, `tests/`, `*.config.cjs`, `package*.json`
- [ ] Once `src/canvas_tui/pyproject.toml` is added, uncomment TUI jobs and re-test