### PR TITLE
docs(site): replace placeholder logo, expose methods page, modernize README

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,10 @@ All commits to protected branches must be **GPG signed**.
 - **[Agent demo](https://kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/)** — chat with the Canvas Calendar Agent in your browser
 - **[Roadmap](https://kleinpanic.github.io/CS3704-Canvas-Project/roadmap.html)** — planned milestones and feature backlog
 - **[HF Space](https://huggingface.co/spaces/kleinpanic93/canvas-calendar-agent-demo)** — full v7-dpo model behind a Gradio chat UI
+- **[How it Works](https://kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/method.html)** — DPO methodology, 9-method ablation matrix, G1–G13 guardrails, bench harness
+- **[Read the Docs](https://readthedocs.org/projects/canvas-tracker-cs3704/)** — auto-published API + architecture docs (project import pending — see `.readthedocs.yaml`)
+- **[GHCR Docker image](https://github.com/kleinpanic/CS3704-Canvas-Project/pkgs/container/canvas-tui)** — `docker pull ghcr.io/kleinpanic/canvas-tui` (built on push-to-main + tags)
+- **[PyPI: canvas-sdk](https://pypi.org/project/canvas-sdk/)** — `pip install canvas-sdk` (publishes on stable releases via OIDC trusted publishing)
 - **[Architecture docs](https://kleinpanic.github.io/CS3704-Canvas-Project/docs/architecture/)** — system design decisions
 - **[Browser extension docs](https://kleinpanic.github.io/CS3704-Canvas-Project/docs/extension/)** — shared client/runtime architecture
 - **[Workflow guide](https://kleinpanic.github.io/CS3704-Canvas-Project/docs/workflow/)** — how the team works

--- a/docs-site/agent-demo/index.html
+++ b/docs-site/agent-demo/index.html
@@ -109,7 +109,7 @@
   <nav class="sticky top-0 z-40 bg-gray-950/95 backdrop-blur border-b border-gray-800/60">
     <div class="max-w-7xl mx-auto px-6 h-13 flex items-center justify-between" style="height:52px">
       <a href="../index.html" class="flex items-center gap-2.5">
-        <div class="w-7 h-7 rounded bg-canvas-red flex items-center justify-center font-bold text-white text-xs">C</div>
+        <img src="../favicon.svg" alt="Canvas Calendar Agent" class="w-7 h-7" />
         <span class="font-semibold text-sm">Canvas Calendar Agent</span>
       </a>
       <div class="flex items-center gap-5 text-xs text-gray-400">

--- a/docs-site/agent-demo/method.html
+++ b/docs-site/agent-demo/method.html
@@ -105,7 +105,7 @@
   <nav class="sticky top-0 z-40 bg-gray-950/95 backdrop-blur border-b border-gray-800/60">
     <div class="max-w-7xl mx-auto px-6 flex items-center justify-between" style="height:52px">
       <a href="../index.html" class="flex items-center gap-2.5">
-        <div class="w-7 h-7 rounded bg-canvas-red flex items-center justify-center font-bold text-white text-xs">C</div>
+        <img src="../favicon.svg" alt="Canvas Calendar Agent" class="w-7 h-7" />
         <span class="font-semibold text-sm">Canvas Calendar Agent</span>
       </a>
       <div class="flex items-center gap-5 text-xs text-gray-400">

--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -35,11 +35,12 @@
   <nav class="sticky top-0 z-50 bg-gray-950/95 backdrop-blur border-b border-gray-800">
     <div class="max-w-7xl mx-auto px-6 flex items-center justify-between" style="height:52px">
       <a href="index.html" class="flex items-center gap-2.5">
-        <div class="w-7 h-7 rounded bg-canvas-red flex items-center justify-center font-bold text-white text-xs">C</div>
+        <img src="favicon.svg" alt="Canvas Calendar Agent" class="w-7 h-7" />
         <span class="font-semibold text-sm">Canvas Tracker</span>
       </a>
       <div class="flex items-center gap-5 text-xs text-gray-400">
         <a href="agent-demo/" class="hover:text-white transition-colors">Agent Demo</a>
+        <a href="agent-demo/method.html" class="hover:text-white transition-colors">How it Works</a>
         <a href="docs/index.html" class="hover:text-white transition-colors">Docs</a>
         <a href="https://github.com/kleinpanic/CS3704-Canvas-Project"
            target="_blank" rel="noopener" class="hover:text-white transition-colors flex items-center gap-1.5">

--- a/docs-site/roadmap.html
+++ b/docs-site/roadmap.html
@@ -39,12 +39,13 @@
   <nav class="sticky top-0 z-40 bg-gray-950/95 backdrop-blur border-b border-gray-800/60">
     <div class="max-w-7xl mx-auto px-6 flex items-center justify-between" style="height:52px">
       <a href="index.html" class="flex items-center gap-2.5">
-        <div class="w-7 h-7 rounded bg-canvas-red flex items-center justify-center font-bold text-white text-xs">C</div>
+        <img src="favicon.svg" alt="Canvas Calendar Agent" class="w-7 h-7" />
         <span class="font-semibold text-sm">Canvas Calendar Agent</span>
       </a>
       <div class="flex items-center gap-5 text-xs text-gray-400">
         <a href="index.html" class="hover:text-white transition-colors">Home</a>
         <a href="agent-demo/" class="hover:text-white transition-colors">Agent Demo</a>
+        <a href="agent-demo/method.html" class="hover:text-white transition-colors">How it Works</a>
         <a href="docs/architecture/" class="hover:text-white transition-colors">Architecture</a>
         <span class="text-white">Roadmap</span>
         <a href="https://github.com/kleinpanic/CS3704-Canvas-Project" target="_blank" rel="noopener" class="hover:text-white transition-colors">GitHub</a>


### PR DESCRIPTION
## Summary

Operator audit of the live GH Pages site flagged three issues. This PR fixes them.

- **Logo**: All 4 site pages replaced the plain `C`-in-a-red-box placeholder with `favicon.svg` (the pinwheel matching the TUI ASCII spinner). The chat-bubble bot avatar at `agent-demo/index.html:350` is intentionally left as-is — it represents the agent inside the chat conversation.
- **Methods page exposure**: `docs-site/index.html` and `docs-site/roadmap.html` nav now both link to `agent-demo/method.html` (the DPO methodology page from #130). Previously only reachable from `agent-demo/index.html`.
- **README modernization**: Documentation section now includes How it Works (method.html), RTD, GHCR Docker image, and PyPI canvas-sdk links — reflecting recent deployment merges (#137-#140).

## Files

- `docs-site/index.html` — header logo + nav "How it Works"
- `docs-site/roadmap.html` — header logo + nav "How it Works"
- `docs-site/agent-demo/index.html` — header logo only (chat bubble C preserved)
- `docs-site/agent-demo/method.html` — header logo
- `README.md` — Documentation section additions

## Test plan

- [ ] CI green
- [ ] After merge: GH Pages deploy succeeds
- [ ] Live home page renders pinwheel SVG (verified via post-deploy screenshot)
- [ ] Live home nav contains "How it Works" link
- [ ] `method.html` still loads (regression check)