### PR TITLE
feat(hf-space): session state, calendar pane, 18-tool surface

### DIFF
--- a/hf-space/UPGRADE-GAP-AUDIT.md
+++ b/hf-space/UPGRADE-GAP-AUDIT.md
@@ -1,0 +1,64 @@
+# HF Space Upgrade — Gap Audit
+
+Audit performed during the `feat/hf-space-state-calendar-upgrade` PR. Captures the state of `hf-space/app.py` as deployed (commit `8210d61`-era) and the deltas applied in this PR.
+
+## Why mocks at all?
+
+The Space has no Canvas credentials and no Google Calendar OAuth. It's a public demo on ZeroGPU; persistent or per-user state would require backing storage that doesn't exist here. So tool results have to be synthetic.
+
+What this PR fixes is **coherence**: the previous mocks were stateless module-level dicts. `calendar.create_event` always returned `evt_001`; `calendar.list_events` always returned the same one event; `calendar.delete_event` reported `deleted: true` but the next `list_events` showed the deleted event still present. A user trying any multi-step flow (`create → list`, or `delete → list`) saw an obviously broken loop.
+
+The fix: a per-session `gr.State` wrapping an `InMemoryCalendarBackend` (matching the SDK's `CalendarBackend` contract) that holds events in a mutable dict keyed by event_id with an auto-incrementing counter. Calendar tools route through that backend so create/modify/delete/list round-trips behave coherently for the duration of a single browser tab.
+
+## Per-tool table (all 18)
+
+| # | Tool                          | Surfaced as example before? | Mock was stateful? | SDK reuse? | What this PR does |
+|---|-------------------------------|-----------------------------|--------------------|------------|-------------------|
+| 1 | `canvas.list_courses`         | no                          | n/a (read-only)    | no — Space has no Canvas creds          | Add example button. Mock unchanged (read-only is fine stateless). |
+| 2 | `canvas.get_course`           | no                          | n/a                | no                                       | Add example button. |
+| 3 | `canvas.get_assignments`      | yes                         | n/a                | no                                       | Keep example, no behavioural change. |
+| 4 | `canvas.get_grades`           | yes                         | n/a                | no                                       | Keep. |
+| 5 | `canvas.get_syllabus`         | no                          | n/a                | no                                       | Add example button. |
+| 6 | `canvas.get_todo`             | no                          | n/a                | no                                       | Add example button. |
+| 7 | `canvas.list_announcements`   | yes                         | n/a                | no                                       | Keep. |
+| 8 | `canvas.list_planner_items`   | no                          | n/a                | no                                       | Add example button. |
+| 9 | `calendar.create_event`       | yes                         | **NO — broken**    | **YES — added InMemoryCalendarBackend to SDK** | Routes through `InMemoryCalendarBackend.create_event`; assigns auto-incrementing `evt_NNN`; appears in subsequent `list_events`. |
+| 10 | `calendar.delete_event`       | no                          | **NO — broken**    | YES                                      | Routes through `InMemoryCalendarBackend.delete_event`; mutates state; returns `{deleted, found}`. |
+| 11 | `calendar.modify_event`       | no                          | **NO — broken**    | YES                                      | Routes through `InMemoryCalendarBackend.modify_event`; mutates by id. |
+| 12 | `calendar.list_events`        | no                          | **NO — broken**    | YES                                      | Routes through `InMemoryCalendarBackend.list_events`; reflects all prior mutations. |
+| 13 | `calendar.find_free_blocks`   | yes                         | NO                 | YES                                      | Routes through `InMemoryCalendarBackend.find_free_blocks`; computed from actual events. |
+| 14 | `reranker.priority_hint`      | yes                         | n/a                | no — would need real reranker model       | Keep mock. |
+| 15 | `study.exam_bracket`          | yes                         | n/a                | no                                       | Keep mock. |
+| 16 | `study.recommend_block_size`  | no                          | n/a                | no                                       | Add example button. |
+| 17 | `study.semester_schedule`     | no                          | n/a                | no                                       | Add example button. |
+| 18 | `study.spaced_schedule`       | yes                         | n/a                | no                                       | Keep. |
+
+Net change in surfaced examples: **8 → 18**.
+
+## SDK-reuse decision
+
+The advisor brief said "tool dispatch becomes `result = ListEvents(adapter).run(args)` etc." That literal API does not exist:
+
+1. `canvas_sdk.agent_tools.calendar_tools.ListEvents` uses `@staticmethod def call(args)`, not `.run(args)`.
+2. The static `call(args)` resolves the adapter via `CalendarAdapter.from_config()`, which calls `from canvas_tui.config import load_config` — `canvas_tui` is a separate package not installable from PyPI and not in `hf-space/requirements.txt`.
+3. `hf-space/requirements.txt` doesn't include `canvas-sdk`, and the deploy workflow only uploads the `hf-space/` directory to the Space (not `src/sdk/`).
+
+The achievable form of "SDK reuse" is therefore:
+- **SDK side:** add `InMemoryCalendarBackend` to `src/sdk/canvas_sdk/backends/calendar_adapter.py` so the SDK gains a real, in-memory backend matching the `CalendarBackend` abstract contract — with its own round-trip self-test under `if __name__ == "__main__"`. Anyone with `canvas-sdk` installed can now use it.
+- **Space side:** inline a copy of the same class into `hf-space/app.py`. The contract is identical to the SDK class. Both stay in lockstep on contract — not on import.
+
+This is documented as a deviation in the SUMMARY.md (Rule 3 — blocked dependency path).
+
+## Backend semantics: `propose_*` vs immediate mutation
+
+The abstract `CalendarBackend.propose_modification` and `propose_deletion` contract was designed for the TUI's confirmation flow: it returns a pending stub the user must approve before the calendar mutates. That's the right contract for a real user-facing TUI.
+
+The Space, in contrast, is a single-session demo with no confirmation UI — if `delete_event` returned a pending stub, the calendar pane would not update and users would think the agent was broken. So the `InMemoryCalendarBackend` exposes **both**: `propose_modification` / `propose_deletion` (for protocol compatibility) and `modify_event` / `delete_event` (immediate mutation). The Space wires the calendar tools to the immediate-mutation methods.
+
+## What this PR does NOT do (deferred)
+
+- Persist state across sessions (would need HF Space persistent storage).
+- Wire `canvas.*` tools to a real Canvas instance (no creds in a public Space).
+- Fine-grained `find_free_blocks` constraints (quiet hours, holidays, recurring busy windows).
+- Surface tool errors to users — currently mocks always succeed.
+- Replace the 4 study-tool mocks with the real algorithms from `canvas_tui.study_planner` (those depend on local config + grade data).

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -1,9 +1,11 @@
-"""Canvas Calendar Agent — HF Space (ChatInterface + ZeroGPU + agent loop with mock tools)."""
+"""Canvas Calendar Agent — HF Space (Blocks layout, calendar pane, session state, 18-tool surface)."""
 
 from __future__ import annotations
 
+import datetime as dt
 import json
 import re
+from typing import Any
 
 import gradio as gr
 import torch
@@ -17,7 +19,7 @@ except Exception:
     GPU_DECORATOR = _noop
 
 MODEL_ID = "kleinpanic93/canvas-calendar-agent-v7-dpo"
-MAX_TURNS = 2  # was 4 — model over-chained tool calls across rounds
+MAX_TURNS = 2
 MAX_NEW_TOKENS = 384
 
 _TOOL_CALL_RE = re.compile(r"<\|tool_call>(.*?)<tool_call\|>", re.DOTALL)
@@ -63,13 +65,12 @@ def parse_tool_calls(text: str) -> list[dict]:
     return out
 
 
-def format_tool_result(tool_name: str, result: dict) -> str:
+def format_tool_result(tool_name: str, result: Any) -> str:
     body = json.dumps(result)
     return f'<|tool_response>response:{tool_name}{{value:<|"|>{body}<|"|>}}<tool_response|>'
 
 
 def extract_final_answer(text: str) -> str:
-    # Strip both tool-call and stray tool-response markers the model sometimes hallucinates.
     cleaned = re.sub(r"<\|tool_call>.*?<tool_call\|>", "", text, flags=re.DOTALL)
     cleaned = re.sub(r"<\|tool_response>.*?<tool_response\|>", "", cleaned, flags=re.DOTALL)
     cleaned = re.sub(r"<\|tool_response>", "", cleaned)
@@ -78,7 +79,6 @@ def extract_final_answer(text: str) -> str:
 
 
 def summarize_tool_results(tool_log: list[dict]) -> str:
-    """Fallback final answer when the model only emitted tool calls without composing prose."""
     if not tool_log:
         return "(no final answer)"
     parts = []
@@ -89,10 +89,147 @@ def summarize_tool_results(tool_log: list[dict]) -> str:
             parts.append(f"{t['tool']} returned {len(items)} item(s)")
         elif isinstance(result, dict) and "blocks" in result:
             parts.append(f"{t['tool']} found {len(result.get('blocks', []))} free block(s)")
+        elif isinstance(result, list):
+            parts.append(f"{t['tool']} returned {len(result)} item(s)")
         else:
             parts.append(f"{t['tool']} ran successfully")
     return "Done. " + "; ".join(parts) + "."
 
+
+# ---------------------------------------------------------------------------
+# InMemoryCalendarBackend — duplicated from canvas_sdk.backends.calendar_adapter.
+# The HF Space deploy workflow only uploads hf-space/, so canvas_sdk is not
+# importable here. The contract is kept identical to the SDK class so behaviour
+# stays in lockstep with src/sdk/canvas_sdk/backends/calendar_adapter.py.
+# ---------------------------------------------------------------------------
+
+class InMemoryCalendarBackend:
+    def __init__(self, seed_events: list[dict] | None = None) -> None:
+        self._events: dict[str, dict[str, Any]] = {}
+        self._counter = 100
+        for ev in seed_events or []:
+            eid = ev.get("id") or self._next_id()
+            ev = {**ev, "id": eid}
+            self._events[eid] = ev
+
+    def _next_id(self) -> str:
+        eid = f"evt_{self._counter:03d}"
+        self._counter += 1
+        return eid
+
+    def _in_window(self, ev, start, end):
+        if not (start or end):
+            return True
+        s = ev.get("start_iso")
+        if not s:
+            return True
+        try:
+            ev_start = dt.datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+        except ValueError:
+            return True
+        if ev_start.tzinfo is None:
+            ev_start = ev_start.replace(tzinfo=dt.timezone.utc)
+        if start and ev_start < start:
+            return False
+        if end and ev_start > end:
+            return False
+        return True
+
+    def list_events(self, calendar_id="primary", start_iso=None, end_iso=None, include_all_day=True):
+        start = dt.datetime.fromisoformat(start_iso.replace("Z", "+00:00")) if start_iso else None
+        end = dt.datetime.fromisoformat(end_iso.replace("Z", "+00:00")) if end_iso else None
+        if start and start.tzinfo is None:
+            start = start.replace(tzinfo=dt.timezone.utc)
+        if end and end.tzinfo is None:
+            end = end.replace(tzinfo=dt.timezone.utc)
+        out = []
+        for ev in self._events.values():
+            if not include_all_day and ev.get("all_day"):
+                continue
+            if not self._in_window(ev, start, end):
+                continue
+            out.append(dict(ev))
+        out.sort(key=lambda e: e.get("start_iso", ""))
+        return out
+
+    def find_free_blocks(self, min_minutes=90, horizon_days=7, earliest_hour=7, latest_hour=22, calendar_id="primary", exclude_weekends=False):
+        now = dt.datetime.now(dt.timezone.utc)
+        end = now + dt.timedelta(days=horizon_days)
+        events = self.list_events(start_iso=now.isoformat(), end_iso=end.isoformat(), include_all_day=False)
+        busy = []
+        for ev in events:
+            if ev.get("start_iso") and ev.get("end_iso"):
+                s = dt.datetime.fromisoformat(str(ev["start_iso"]).replace("Z", "+00:00"))
+                e = dt.datetime.fromisoformat(str(ev["end_iso"]).replace("Z", "+00:00"))
+                if s.tzinfo is None: s = s.replace(tzinfo=dt.timezone.utc)
+                if e.tzinfo is None: e = e.replace(tzinfo=dt.timezone.utc)
+                busy.append((s, e))
+        busy.sort()
+        free_blocks = []
+        cursor = now.replace(minute=0, second=0, microsecond=0) + dt.timedelta(hours=1)
+        while cursor < end and len(free_blocks) < 20:
+            if exclude_weekends and cursor.weekday() >= 5:
+                cursor = (cursor + dt.timedelta(days=1)).replace(hour=earliest_hour, minute=0, second=0, microsecond=0)
+                continue
+            day_start = cursor.replace(hour=max(cursor.hour, earliest_hour), minute=0, second=0, microsecond=0)
+            day_end = cursor.replace(hour=latest_hour, minute=0, second=0, microsecond=0)
+            slot_start = day_start
+            if slot_start >= day_end:
+                cursor = (cursor + dt.timedelta(days=1)).replace(hour=earliest_hour, minute=0, second=0, microsecond=0)
+                continue
+            for b_s, b_e in busy:
+                if b_s >= day_end: break
+                if b_e <= slot_start: continue
+                if slot_start < b_s:
+                    gap = int((b_s - slot_start).total_seconds() / 60)
+                    if gap >= min_minutes:
+                        free_blocks.append({
+                            "start_iso": slot_start.isoformat(),
+                            "end_iso": (slot_start + dt.timedelta(minutes=min_minutes)).isoformat(),
+                            "minutes": min_minutes,
+                        })
+                slot_start = max(slot_start, b_e)
+            gap = int((day_end - slot_start).total_seconds() / 60)
+            if gap >= min_minutes:
+                free_blocks.append({
+                    "start_iso": slot_start.isoformat(),
+                    "end_iso": (slot_start + dt.timedelta(minutes=min_minutes)).isoformat(),
+                    "minutes": min_minutes,
+                })
+            cursor = (cursor + dt.timedelta(days=1)).replace(hour=earliest_hour, minute=0, second=0, microsecond=0)
+        return free_blocks
+
+    def create_event(self, title, start_iso, end_iso, description="", calendar_id="primary", rationale=""):
+        eid = self._next_id()
+        ev = {
+            "id": eid, "title": title, "start_iso": start_iso, "end_iso": end_iso,
+            "description": description, "rationale": rationale,
+            "calendar_id": calendar_id, "all_day": False,
+        }
+        self._events[eid] = ev
+        return {"id": eid, "title": title, "start_iso": start_iso, "end_iso": end_iso, "status": "created"}
+
+    def modify_event(self, event_id, title=None, start_iso=None, end_iso=None, rationale=""):
+        ev = self._events.get(event_id)
+        if ev is None:
+            return {"status": "not_found", "event_id": event_id, "modified": False}
+        if title is not None: ev["title"] = title
+        if start_iso is not None: ev["start_iso"] = start_iso
+        if end_iso is not None: ev["end_iso"] = end_iso
+        if rationale: ev["rationale"] = rationale
+        return {"status": "modified", "event_id": event_id, "modified": True,
+                **{k: ev[k] for k in ("title", "start_iso", "end_iso")}}
+
+    def delete_event(self, event_id, rationale=""):
+        if event_id in self._events:
+            del self._events[event_id]
+            return {"status": "deleted", "event_id": event_id, "deleted": True, "found": True}
+        return {"status": "not_found", "event_id": event_id, "deleted": False, "found": False}
+
+
+# ---------------------------------------------------------------------------
+# Mock data for canvas.* / reranker.* / study.* (no real backend possible here).
+# ---------------------------------------------------------------------------
 
 SYSTEM_PROMPT = """You are the Canvas Calendar Agent. You have these 18 tools available:
 - canvas.{get_assignments,get_course,get_grades,get_syllabus,get_todo,list_announcements,list_courses,list_planner_items}
@@ -123,49 +260,136 @@ _MOCK_COURSES = [
 ]
 
 
-def mock_tool_result(tool_name: str, args: dict) -> dict:
+def _seed_events() -> list[dict]:
+    """Initial events the demo starts with — gives users something to list/modify/delete out of the box."""
+    return [
+        {"id": "evt_001", "title": "CS 3704 lecture", "start_iso": "2026-05-06T10:00:00+00:00", "end_iso": "2026-05-06T11:00:00+00:00", "calendar_id": "primary"},
+        {"id": "evt_002", "title": "MATH 2114 office hours", "start_iso": "2026-05-06T15:00:00+00:00", "end_iso": "2026-05-06T16:00:00+00:00", "calendar_id": "primary"},
+        {"id": "evt_003", "title": "PHYS 2306 lab", "start_iso": "2026-05-07T13:00:00+00:00", "end_iso": "2026-05-07T15:00:00+00:00", "calendar_id": "primary"},
+    ]
+
+
+def init_state() -> dict:
+    """Per-session state — held in gr.State."""
+    return {
+        "backend": InMemoryCalendarBackend(seed_events=_seed_events()),
+        "tool_log": [],
+    }
+
+
+def apply_tool(tool_name: str, args: dict, state: dict) -> tuple[Any, dict]:
+    """Pure-ish tool dispatch: given (name, args, state), produce (result, possibly-mutated-state).
+
+    Calendar tools mutate state["backend"] in place; canvas/reranker/study tools are stateless mocks.
+    """
+    backend: InMemoryCalendarBackend = state["backend"]
+
+    if tool_name == "calendar.create_event":
+        return backend.create_event(**args), state
+    if tool_name == "calendar.delete_event":
+        return backend.delete_event(**args), state
+    if tool_name == "calendar.modify_event":
+        return backend.modify_event(**args), state
+    if tool_name == "calendar.list_events":
+        return {"items": backend.list_events(**args)}, state
+    if tool_name == "calendar.find_free_blocks":
+        return {"blocks": backend.find_free_blocks(**args)}, state
+
+    # Canvas tools — stateless mocks.
     if tool_name == "canvas.get_assignments":
-        return {"items": _MOCK_ASSIGNMENTS}
+        return {"items": _MOCK_ASSIGNMENTS}, state
     if tool_name == "canvas.get_course":
         cid = int(args.get("course_id", 1))
-        return next((c for c in _MOCK_COURSES if c["id"] == cid), _MOCK_COURSES[0])
+        return next((c for c in _MOCK_COURSES if c["id"] == cid), _MOCK_COURSES[0]), state
     if tool_name == "canvas.get_grades":
-        return {"items": [{"course": c["code"], "grade": "A-", "score": 91.2} for c in _MOCK_COURSES]}
+        return {"items": [{"course": c["code"], "grade": "A-", "score": 91.2} for c in _MOCK_COURSES]}, state
     if tool_name == "canvas.get_syllabus":
-        return {"course_id": args.get("course_id", 1), "syllabus": "MWF 10–10:50 McBryde 113. Final TBD."}
+        return {"course_id": args.get("course_id", 1), "syllabus": "MWF 10–10:50 McBryde 113. Final TBD."}, state
     if tool_name == "canvas.get_todo":
-        return {"items": [{"title": "Submit PM4", "course": "CS 3704", "due": "2026-05-08T23:59:00Z"}]}
+        return {"items": [{"title": "Submit PM4", "course": "CS 3704", "due": "2026-05-08T23:59:00Z"}]}, state
     if tool_name == "canvas.list_announcements":
-        return {"items": [{"course": "CS 3704", "title": "PM4 rubric posted"}, {"course": "MATH 2114", "title": "Final: McBryde 100"}]}
+        return {"items": [{"course": "CS 3704", "title": "PM4 rubric posted"}, {"course": "MATH 2114", "title": "Final: McBryde 100"}]}, state
     if tool_name == "canvas.list_courses":
-        return {"items": _MOCK_COURSES}
+        return {"items": _MOCK_COURSES}, state
     if tool_name == "canvas.list_planner_items":
-        return {"items": [{"title": a["title"], "course": a["course"], "due": a["due_at"]} for a in _MOCK_ASSIGNMENTS]}
-    if tool_name == "calendar.create_event":
-        return {"event_id": "evt_001", "created": True, "title": args.get("title")}
-    if tool_name == "calendar.delete_event":
-        return {"event_id": args.get("event_id"), "deleted": True}
-    if tool_name == "calendar.find_free_blocks":
-        return {"blocks": [
-            {"start": "2026-05-06T09:00:00", "end": "2026-05-06T11:30:00", "duration_min": 150},
-            {"start": "2026-05-07T13:00:00", "end": "2026-05-07T17:00:00", "duration_min": 240},
-        ]}
-    if tool_name == "calendar.list_events":
-        return {"events": [{"id": "evt_001", "title": "CS 3704 lecture", "start": "2026-05-06T10:00:00"}]}
-    if tool_name == "calendar.modify_event":
-        return {"event_id": args.get("event_id"), "modified": True}
-    if tool_name == "reranker.priority_hint":
-        return {"ranked": _MOCK_ASSIGNMENTS, "rationale": "sorted by due date"}
-    if tool_name == "study.exam_bracket":
-        return {"bracket": [{"phase": "deep_prep", "blocks_min": 240}, {"phase": "review", "blocks_min": 150}, {"phase": "light_cram", "blocks_min": 90}]}
-    if tool_name == "study.recommend_block_size":
-        return {"recommended_block_min": 90}
-    if tool_name == "study.semester_schedule":
-        return {"weeks": [{"week": 1, "study_hours": 9}, {"week": 14, "study_hours": 22}]}
-    if tool_name == "study.spaced_schedule":
-        return {"intervals_days_before_exam": [9, 4, 1]}
-    return {"ok": True, "note": f"mock {tool_name}", "args": args}
+        return {"items": [{"title": a["title"], "course": a["course"], "due": a["due_at"]} for a in _MOCK_ASSIGNMENTS]}, state
 
+    if tool_name == "reranker.priority_hint":
+        return {"ranked": _MOCK_ASSIGNMENTS, "rationale": "sorted by due date"}, state
+    if tool_name == "study.exam_bracket":
+        return {"bracket": [{"phase": "deep_prep", "blocks_min": 240}, {"phase": "review", "blocks_min": 150}, {"phase": "light_cram", "blocks_min": 90}]}, state
+    if tool_name == "study.recommend_block_size":
+        return {"recommended_block_min": 90}, state
+    if tool_name == "study.semester_schedule":
+        return {"weeks": [{"week": 1, "study_hours": 9}, {"week": 14, "study_hours": 22}]}, state
+    if tool_name == "study.spaced_schedule":
+        return {"intervals_days_before_exam": [9, 4, 1]}, state
+
+    return {"ok": True, "note": f"mock {tool_name}", "args": args}, state
+
+
+# ---------------------------------------------------------------------------
+# Calendar pane rendering — HTML week-view of state["backend"]._events.
+# ---------------------------------------------------------------------------
+
+def render_calendar_html(state: dict) -> str:
+    backend: InMemoryCalendarBackend = state["backend"]
+    events = backend.list_events()
+    if not events:
+        return (
+            '<div style="padding:20px;color:#9ca3af;font-size:0.85rem;text-align:center;">'
+            'Calendar is empty. Try: "Schedule a study block tomorrow 3-5pm".'
+            '</div>'
+        )
+
+    # Group by date
+    by_date: dict[str, list[dict]] = {}
+    for ev in events:
+        try:
+            d = dt.datetime.fromisoformat(str(ev["start_iso"]).replace("Z", "+00:00"))
+            key = d.strftime("%a %b %d")
+        except Exception:
+            key = "Unknown"
+        by_date.setdefault(key, []).append(ev)
+
+    html_parts = ['<div style="padding:8px;font-size:0.82rem;line-height:1.5;">']
+    html_parts.append(
+        f'<div style="color:#9ca3af;font-size:0.72rem;margin-bottom:8px;">'
+        f'{len(events)} event{"s" if len(events) != 1 else ""} in session calendar'
+        f'</div>'
+    )
+    for date_key, day_events in by_date.items():
+        html_parts.append(
+            f'<div style="margin-bottom:10px;">'
+            f'<div style="color:#d63e36;font-weight:600;font-size:0.78rem;'
+            f'border-bottom:1px solid #2e2e38;padding-bottom:3px;margin-bottom:5px;">'
+            f'{date_key}</div>'
+        )
+        for ev in day_events:
+            try:
+                s = dt.datetime.fromisoformat(str(ev["start_iso"]).replace("Z", "+00:00"))
+                e = dt.datetime.fromisoformat(str(ev["end_iso"]).replace("Z", "+00:00"))
+                tspan = f'{s.strftime("%H:%M")}–{e.strftime("%H:%M")}'
+            except Exception:
+                tspan = ""
+            html_parts.append(
+                f'<div style="background:#18181f;border:1px solid #2e2e38;'
+                f'border-left:3px solid #d63e36;border-radius:4px;'
+                f'padding:6px 8px;margin-bottom:4px;">'
+                f'<div style="color:#d4d4db;font-weight:500;">{ev.get("title", "(untitled)")}</div>'
+                f'<div style="color:#9ca3af;font-size:0.72rem;">'
+                f'<code style="background:#0a0a0b;padding:1px 4px;border-radius:2px;">{ev.get("id","?")}</code> '
+                f'· {tspan}</div>'
+                f'</div>'
+            )
+        html_parts.append('</div>')
+    html_parts.append('</div>')
+    return "".join(html_parts)
+
+
+# ---------------------------------------------------------------------------
+# Model loading (must remain — runs at HF Space build time on ZeroGPU).
+# ---------------------------------------------------------------------------
 
 print(f"Loading {MODEL_ID} ...", flush=True)
 tokenizer = AutoTokenizer.from_pretrained(MODEL_ID)
@@ -188,21 +412,25 @@ def generate_step(messages):
         model.to("cuda")
         input_ids = input_ids.to("cuda")
     with torch.inference_mode():
-        # Gemma-4 official sampling for production inference per
-        # https://ai.google.dev/gemma/docs/core/model_card_4
         out = model.generate(
             input_ids,
-            do_sample=True,
-            temperature=1.0,
-            top_p=0.95,
-            top_k=64,
+            do_sample=True, temperature=1.0, top_p=0.95, top_k=64,
             max_new_tokens=MAX_NEW_TOKENS,
             pad_token_id=tokenizer.eos_token_id,
         )
     return tokenizer.decode(out[0, input_ids.shape[1]:], skip_special_tokens=False)
 
 
-def chat(message, history):
+# ---------------------------------------------------------------------------
+# Chat function — bound to gr.Blocks layout.
+# Signature: (message, history, state) -> (history, state, calendar_html).
+# Order MUST match the Blocks .click() outputs binding below.
+# ---------------------------------------------------------------------------
+
+def chat(message: str, history: list, state: dict | None):
+    if state is None:
+        state = init_state()
+
     msgs = [{"role": "system", "content": SYSTEM_PROMPT}]
     for h in history or []:
         if isinstance(h, dict):
@@ -212,9 +440,9 @@ def chat(message, history):
             if h[1]: msgs.append({"role": "assistant", "content": h[1]})
     msgs.append({"role": "user", "content": message})
 
-    tool_log = []
+    tool_log: list[dict] = []
     raw = ""
-    MAX_CALLS_PER_TURN = 2  # cap concurrent tool calls in a single generation
+    MAX_CALLS_PER_TURN = 2
     for _ in range(MAX_TURNS):
         raw = generate_step(msgs)
         calls = parse_tool_calls(raw)[:MAX_CALLS_PER_TURN]
@@ -222,14 +450,13 @@ def chat(message, history):
         if not calls:
             break
         for call in calls:
-            # Skip duplicate (same tool+args already called this conversation)
             already = any(
                 t["tool"] == call["tool"] and t["args"] == call["args"]
                 for t in tool_log
             )
             if already:
                 continue
-            result = mock_tool_result(call["tool"], call["args"])
+            result, state = apply_tool(call["tool"], call["args"], state)
             tool_log.append({"tool": call["tool"], "args": call["args"], "result": result})
             msgs.append({"role": "user", "content": format_tool_result(call["tool"], result)})
 
@@ -243,9 +470,21 @@ def chat(message, history):
         )
         table = f"| Tool | Args | Result |\n|------|------|--------|\n{rows}"
         label = f"{len(tool_log)} tool call{'s' if len(tool_log) > 1 else ''}"
-        return f"{final}\n\n<details><summary>🔧 {label} (mock data)</summary>\n\n{table}\n\n</details>"
-    return final
+        reply = f"{final}\n\n<details><summary>🔧 {label} (mock data — session-local state)</summary>\n\n{table}\n\n</details>"
+    else:
+        reply = final
 
+    new_history = (history or []) + [
+        {"role": "user", "content": message},
+        {"role": "assistant", "content": reply},
+    ]
+    state["tool_log"].extend(tool_log)
+    return new_history, state, render_calendar_html(state)
+
+
+# ---------------------------------------------------------------------------
+# UI: Blocks layout (chat left, calendar right) + 4 accordions of examples.
+# ---------------------------------------------------------------------------
 
 THEME = gr.themes.Monochrome(
     primary_hue="red",
@@ -282,10 +521,8 @@ THEME = gr.themes.Monochrome(
 )
 
 CUSTOM_CSS = """
-.gradio-container { max-width: 960px !important; padding: 24px 20px !important; }
+.gradio-container { max-width: 1280px !important; padding: 20px 16px !important; }
 .block { box-shadow: none !important; border-radius: 8px !important; }
-/* chatbot */
-#component-0 .chatbot { min-height: 440px; }
 .message-bubble-border { border-radius: 8px !important; }
 .user .message {
     background: #d63e36 !important;
@@ -298,26 +535,24 @@ CUSTOM_CSS = """
     border-radius: 8px 8px 8px 2px !important;
     line-height: 1.6 !important;
 }
-/* bot message: tool-call table */
 .bot .message table { font-size: 0.75rem !important; border-collapse: collapse !important; width: 100% !important; margin-top: 6px; }
 .bot .message th, .bot .message td { padding: 3px 8px !important; border: 1px solid #2e2e38 !important; text-align: left !important; }
 .bot .message th { background: #111114 !important; color: #9ca3af !important; font-weight: 500 !important; }
 .bot .message details summary { cursor: pointer; color: #6b7280; font-size: 0.78rem; user-select: none; }
-/* input */
 .input-row textarea { border-radius: 6px !important; font-size: 0.875rem !important; min-height: 48px !important; }
-/* example buttons — pill style */
-.examples-holder { flex-wrap: wrap !important; gap: 6px !important; }
-.examples-holder button {
-    border-radius: 20px !important;
-    font-size: 0.78rem !important;
-    padding: 4px 14px !important;
+.example-btn button {
+    border-radius: 16px !important;
+    font-size: 0.74rem !important;
+    padding: 3px 10px !important;
     border: 1px solid #2e2e38 !important;
     background: #18181f !important;
-    transition: border-color 0.15s, background 0.15s !important;
+    text-align: left !important;
+    white-space: normal !important;
+    min-height: auto !important;
 }
-.examples-holder button:hover { border-color: #d63e36 !important; background: #1f1010 !important; }
-/* description */
+.example-btn button:hover { border-color: #d63e36 !important; background: #1f1010 !important; }
 .description { font-size: 0.82rem !important; line-height: 1.6 !important; color: #9ca3af !important; }
+#calendar-pane { background: #111114; border: 1px solid #2e2e38; border-radius: 8px; min-height: 440px; max-height: 600px; overflow-y: auto; }
 """
 
 DESCRIPTION_MD = """
@@ -325,32 +560,105 @@ Fine-tuned **Gemma-4-E2B-IT** (DPO · β=0.1 · 181 trajectories · 90.3% reward
 
 `canvas.*` assignments · grades · syllabi · planner &nbsp;|&nbsp; `calendar.*` scheduling · free blocks &nbsp;|&nbsp; `reranker.*` priority hints &nbsp;|&nbsp; `study.*` exam prep · spaced repetition
 
-> ⚠️ **Mock data** — no Canvas credentials in this Space. For live data: `pip install canvas-sdk[autodownload]`
+> ⚠️ **Mock data** — no Canvas credentials in this Space. Calendar uses a **session-local in-memory backend** (mirrors `canvas_sdk.backends.calendar_adapter.InMemoryCalendarBackend`) so create/delete/modify/list round-trips behave coherently within a single browser tab. For live data: `pip install canvas-sdk[autodownload]`.
 > ⏱ Cold-start after inactivity ~30 s (ZeroGPU). Subsequent responses are fast.
 
 [Model](https://huggingface.co/kleinpanic93/canvas-calendar-agent-v7-dpo) · [Dataset](https://huggingface.co/datasets/kleinpanic93/canvas-calendar-preferences-v7) · [Collection](https://huggingface.co/collections/kleinpanic93/canvas-calendar-agent-v30-69fa6462f697e0342b21dfe0) · [GitHub](https://github.com/kleinpanic/CS3704-Canvas-Project) · [Docs](https://kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/method.html)
 """
 
-demo = gr.ChatInterface(
-    fn=chat,
-    title="Canvas Calendar Agent",
-    description=DESCRIPTION_MD,
-    examples=[
-        "What assignments do I have due this week?",
-        "Find me a 2-hour free block tomorrow afternoon",
-        "Build me an exam-prep bracket for the May 12 final",
-        "Rank my todos by priority",
-        "What are my current grades?",
-        "Plan a spaced-repetition schedule for my Linear Algebra final",
-        "Create a study block from 3pm to 5pm tomorrow",
-        "What announcements are in my CS 3704 course?",
-    ],
-    type="messages",
-    theme=THEME,
-    css=CUSTOM_CSS,
-    cache_examples=False,
-    fill_height=True,
-)
+
+CANVAS_EXAMPLES = [
+    "List my courses",
+    "Tell me about my CS 3704 course",
+    "What assignments do I have due this week?",
+    "What are my current grades?",
+    "Show me the syllabus for MATH 2114",
+    "What's on my Canvas todo list?",
+    "Any new announcements in my courses?",
+    "What's on my planner this week?",
+]
+CALENDAR_EXAMPLES = [
+    "What's on my calendar this week?",
+    "Find a 2-hour free block tomorrow afternoon",
+    "Schedule a study block tomorrow 3-5pm",
+    "Move my 2pm event to 4pm",
+    "Cancel my 3pm meeting",
+]
+STUDY_EXAMPLES = [
+    "Build a study bracket for the May 12 final",
+    "What study block size do you recommend for me?",
+    "Build a semester study schedule",
+    "Plan spaced repetition for Linear Algebra final",
+]
+RERANKER_EXAMPLES = [
+    "Rank my todos by priority",
+]
+
+
+with gr.Blocks(theme=THEME, css=CUSTOM_CSS, title="Canvas Calendar Agent") as demo:
+    gr.Markdown("# Canvas Calendar Agent")
+    gr.Markdown(DESCRIPTION_MD, elem_classes=["description"])
+
+    state = gr.State(value=init_state)
+
+    with gr.Row(equal_height=True):
+        with gr.Column(scale=3):
+            chatbot = gr.Chatbot(
+                type="messages",
+                height=440,
+                show_label=False,
+                avatar_images=None,
+            )
+            with gr.Row(elem_classes=["input-row"]):
+                msg = gr.Textbox(
+                    placeholder="Ask the agent anything…",
+                    show_label=False,
+                    scale=8,
+                    lines=1,
+                )
+                send_btn = gr.Button("Send", variant="primary", scale=1)
+        with gr.Column(scale=2):
+            gr.Markdown("### Calendar (session-local)")
+            calendar_html = gr.HTML(
+                value=render_calendar_html(init_state()),
+                elem_id="calendar-pane",
+            )
+
+    with gr.Accordion("Calendar examples (5 tools)", open=True):
+        with gr.Row():
+            for ex in CALENDAR_EXAMPLES:
+                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
+                btn.click(lambda x=ex: x, outputs=msg)
+    with gr.Accordion("Canvas examples (8 tools)", open=False):
+        with gr.Row():
+            for ex in CANVAS_EXAMPLES:
+                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
+                btn.click(lambda x=ex: x, outputs=msg)
+    with gr.Accordion("Study examples (4 tools)", open=False):
+        with gr.Row():
+            for ex in STUDY_EXAMPLES:
+                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
+                btn.click(lambda x=ex: x, outputs=msg)
+    with gr.Accordion("Reranker examples (1 tool)", open=False):
+        with gr.Row():
+            for ex in RERANKER_EXAMPLES:
+                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
+                btn.click(lambda x=ex: x, outputs=msg)
+
+    # Wire send button + Enter-key submit. Outputs order MUST match chat() return:
+    # (history, state, calendar_html).
+    send_btn.click(
+        fn=chat,
+        inputs=[msg, chatbot, state],
+        outputs=[chatbot, state, calendar_html],
+    ).then(lambda: "", outputs=msg)
+
+    msg.submit(
+        fn=chat,
+        inputs=[msg, chatbot, state],
+        outputs=[chatbot, state, calendar_html],
+    ).then(lambda: "", outputs=msg)
+
 
 if __name__ == "__main__":
     demo.queue().launch(server_name="0.0.0.0", server_port=7860)

--- a/src/sdk/canvas_sdk/backends/calendar_adapter.py
+++ b/src/sdk/canvas_sdk/backends/calendar_adapter.py
@@ -255,7 +255,12 @@ class InMemoryCalendarBackend(CalendarBackend):
             ev["end_iso"] = end_iso
         if rationale:
             ev["rationale"] = rationale
-        return {"status": "modified", "event_id": event_id, "modified": True, **{k: ev[k] for k in ("title", "start_iso", "end_iso")}}
+        return {
+            "status": "modified",
+            "event_id": event_id,
+            "modified": True,
+            **{k: ev[k] for k in ("title", "start_iso", "end_iso")},
+        }
 
     def delete_event(self, event_id: str, rationale: str = "") -> dict[str, Any]:
         if event_id in self._events:
@@ -687,9 +692,16 @@ class CalendarAdapter:
 
 if __name__ == "__main__":
     # Round-trip self-test for InMemoryCalendarBackend.
-    b = InMemoryCalendarBackend(seed_events=[
-        {"id": "evt_001", "title": "CS 3704 lecture", "start_iso": "2026-05-06T10:00:00+00:00", "end_iso": "2026-05-06T11:00:00+00:00"},
-    ])
+    b = InMemoryCalendarBackend(
+        seed_events=[
+            {
+                "id": "evt_001",
+                "title": "CS 3704 lecture",
+                "start_iso": "2026-05-06T10:00:00+00:00",
+                "end_iso": "2026-05-06T11:00:00+00:00",
+            },
+        ]
+    )
     assert len(b.list_events()) == 1, "seed event missing"
     created = b.create_event(title="study", start_iso="2026-05-07T14:00:00+00:00", end_iso="2026-05-07T16:00:00+00:00")
     assert created["status"] == "created"

--- a/src/sdk/canvas_sdk/backends/calendar_adapter.py
+++ b/src/sdk/canvas_sdk/backends/calendar_adapter.py
@@ -83,6 +83,207 @@ class _NopBackend(CalendarBackend):
         return {"status": "pending_delete", "event_id": event_id, "rationale": rationale}
 
 
+class InMemoryCalendarBackend(CalendarBackend):
+    """In-memory calendar backend.
+
+    Stores events in a dict keyed by event_id with an auto-incrementing counter.
+    Used by the HF Space demo (where there's no real Canvas/Google Calendar) and
+    in test contexts where we want a coherent round-trip without external state.
+
+    Unlike Google/iCal backends, modify and delete operations mutate immediately
+    via the `modify_event` / `delete_event` methods. The abstract `propose_*`
+    methods still return pending stubs for protocol compatibility.
+    """
+
+    def __init__(self, seed_events: list[dict] | None = None) -> None:
+        self._events: dict[str, dict[str, Any]] = {}
+        self._counter = 100
+        for ev in seed_events or []:
+            eid = ev.get("id") or self._next_id()
+            ev = {**ev, "id": eid}
+            self._events[eid] = ev
+
+    def _next_id(self) -> str:
+        eid = f"evt_{self._counter:03d}"
+        self._counter += 1
+        return eid
+
+    def _in_window(self, ev: dict, start: dt.datetime | None, end: dt.datetime | None) -> bool:
+        if not (start or end):
+            return True
+        s = ev.get("start_iso")
+        if not s:
+            return True
+        try:
+            ev_start = dt.datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+        except ValueError:
+            return True
+        if ev_start.tzinfo is None:
+            ev_start = ev_start.replace(tzinfo=dt.timezone.utc)
+        if start and ev_start < start:
+            return False
+        if end and ev_start > end:
+            return False
+        return True
+
+    def list_events(
+        self,
+        calendar_id: str = "primary",
+        start_iso: str | None = None,
+        end_iso: str | None = None,
+        include_all_day: bool = True,
+    ) -> list[dict[str, Any]]:
+        start = dt.datetime.fromisoformat(start_iso.replace("Z", "+00:00")) if start_iso else None
+        end = dt.datetime.fromisoformat(end_iso.replace("Z", "+00:00")) if end_iso else None
+        if start and start.tzinfo is None:
+            start = start.replace(tzinfo=dt.timezone.utc)
+        if end and end.tzinfo is None:
+            end = end.replace(tzinfo=dt.timezone.utc)
+        out = []
+        for ev in self._events.values():
+            if not include_all_day and ev.get("all_day"):
+                continue
+            if not self._in_window(ev, start, end):
+                continue
+            out.append(dict(ev))
+        out.sort(key=lambda e: e.get("start_iso", ""))
+        return out
+
+    def find_free_blocks(
+        self,
+        min_minutes: int = 90,
+        horizon_days: int = 7,
+        earliest_hour: int = 7,
+        latest_hour: int = 22,
+        calendar_id: str = "primary",
+        exclude_weekends: bool = False,
+    ) -> list[dict[str, Any]]:
+        now = dt.datetime.now(dt.timezone.utc)
+        end = now + dt.timedelta(days=horizon_days)
+        events = self.list_events(start_iso=now.isoformat(), end_iso=end.isoformat(), include_all_day=False)
+        busy: list[tuple[dt.datetime, dt.datetime]] = []
+        for ev in events:
+            if ev.get("start_iso") and ev.get("end_iso"):
+                s = dt.datetime.fromisoformat(str(ev["start_iso"]).replace("Z", "+00:00"))
+                e = dt.datetime.fromisoformat(str(ev["end_iso"]).replace("Z", "+00:00"))
+                if s.tzinfo is None:
+                    s = s.replace(tzinfo=dt.timezone.utc)
+                if e.tzinfo is None:
+                    e = e.replace(tzinfo=dt.timezone.utc)
+                busy.append((s, e))
+        busy.sort()
+
+        free_blocks = []
+        cursor = now.replace(minute=0, second=0, microsecond=0) + dt.timedelta(hours=1)
+        while cursor < end and len(free_blocks) < 20:
+            if exclude_weekends and cursor.weekday() >= 5:
+                cursor = (cursor + dt.timedelta(days=1)).replace(hour=earliest_hour, minute=0, second=0, microsecond=0)
+                continue
+            day_start = cursor.replace(hour=max(cursor.hour, earliest_hour), minute=0, second=0, microsecond=0)
+            day_end = cursor.replace(hour=latest_hour, minute=0, second=0, microsecond=0)
+            slot_start = day_start
+            if slot_start >= day_end:
+                cursor = (cursor + dt.timedelta(days=1)).replace(hour=earliest_hour, minute=0, second=0, microsecond=0)
+                continue
+            for b_s, b_e in busy:
+                if b_s >= day_end:
+                    break
+                if b_e <= slot_start:
+                    continue
+                if slot_start < b_s:
+                    gap = int((b_s - slot_start).total_seconds() / 60)
+                    if gap >= min_minutes:
+                        free_blocks.append(
+                            {
+                                "start_iso": slot_start.isoformat(),
+                                "end_iso": (slot_start + dt.timedelta(minutes=min_minutes)).isoformat(),
+                                "minutes": min_minutes,
+                            }
+                        )
+                slot_start = max(slot_start, b_e)
+            gap = int((day_end - slot_start).total_seconds() / 60)
+            if gap >= min_minutes:
+                free_blocks.append(
+                    {
+                        "start_iso": slot_start.isoformat(),
+                        "end_iso": (slot_start + dt.timedelta(minutes=min_minutes)).isoformat(),
+                        "minutes": min_minutes,
+                    }
+                )
+            cursor = (cursor + dt.timedelta(days=1)).replace(hour=earliest_hour, minute=0, second=0, microsecond=0)
+        return free_blocks
+
+    def create_event(
+        self,
+        title: str,
+        start_iso: str,
+        end_iso: str,
+        description: str = "",
+        calendar_id: str = "primary",
+        rationale: str = "",
+    ) -> dict[str, Any]:
+        eid = self._next_id()
+        ev = {
+            "id": eid,
+            "title": title,
+            "start_iso": start_iso,
+            "end_iso": end_iso,
+            "description": description,
+            "rationale": rationale,
+            "calendar_id": calendar_id,
+            "all_day": False,
+        }
+        self._events[eid] = ev
+        return {"id": eid, "title": title, "start_iso": start_iso, "end_iso": end_iso, "status": "created"}
+
+    def modify_event(
+        self,
+        event_id: str,
+        title: str | None = None,
+        start_iso: str | None = None,
+        end_iso: str | None = None,
+        rationale: str = "",
+    ) -> dict[str, Any]:
+        ev = self._events.get(event_id)
+        if ev is None:
+            return {"status": "not_found", "event_id": event_id, "modified": False}
+        if title is not None:
+            ev["title"] = title
+        if start_iso is not None:
+            ev["start_iso"] = start_iso
+        if end_iso is not None:
+            ev["end_iso"] = end_iso
+        if rationale:
+            ev["rationale"] = rationale
+        return {"status": "modified", "event_id": event_id, "modified": True, **{k: ev[k] for k in ("title", "start_iso", "end_iso")}}
+
+    def delete_event(self, event_id: str, rationale: str = "") -> dict[str, Any]:
+        if event_id in self._events:
+            del self._events[event_id]
+            return {"status": "deleted", "event_id": event_id, "deleted": True, "found": True}
+        return {"status": "not_found", "event_id": event_id, "deleted": False, "found": False}
+
+    def propose_modification(
+        self,
+        event_id: str,
+        title: str | None = None,
+        start_iso: str | None = None,
+        end_iso: str | None = None,
+        rationale: str = "",
+    ) -> dict[str, Any]:
+        return {
+            "status": "pending",
+            "event_id": event_id,
+            "title": title,
+            "start_iso": start_iso,
+            "end_iso": end_iso,
+            "rationale": rationale,
+        }
+
+    def propose_deletion(self, event_id: str, rationale: str = "") -> dict[str, Any]:
+        return {"status": "pending_delete", "event_id": event_id, "rationale": rationale}
+
+
 class GoogleCalendarBackend(CalendarBackend):
     """Google Calendar backend.
 
@@ -482,3 +683,24 @@ class CalendarAdapter:
             return ICalBackend(ical_path, write_path)
 
         return _NopBackend()
+
+
+if __name__ == "__main__":
+    # Round-trip self-test for InMemoryCalendarBackend.
+    b = InMemoryCalendarBackend(seed_events=[
+        {"id": "evt_001", "title": "CS 3704 lecture", "start_iso": "2026-05-06T10:00:00+00:00", "end_iso": "2026-05-06T11:00:00+00:00"},
+    ])
+    assert len(b.list_events()) == 1, "seed event missing"
+    created = b.create_event(title="study", start_iso="2026-05-07T14:00:00+00:00", end_iso="2026-05-07T16:00:00+00:00")
+    assert created["status"] == "created"
+    eid = created["id"]
+    assert len(b.list_events()) == 2
+    mod = b.modify_event(event_id=eid, title="study (moved)")
+    assert mod["modified"] is True
+    deleted = b.delete_event(event_id=eid)
+    assert deleted["deleted"] is True and deleted["found"] is True
+    missing = b.delete_event(event_id="evt_999")
+    assert missing["deleted"] is False
+    blocks = b.find_free_blocks(min_minutes=60, horizon_days=1)
+    assert isinstance(blocks, list)
+    print("InMemoryCalendarBackend round-trip OK")


### PR DESCRIPTION
## Summary

Closes operator-flagged gaps in `hf-space/app.py`:

- Examples expanded from **8 → 18** (one per tool) across 4 collapsible Accordions.
- Tool layer is now stateful via `gr.State` + `InMemoryCalendarBackend`. `calendar.create_event` produces unique `evt_NNN` ids; `delete_event` actually removes from state; `list_events` reflects all prior mutations.
- Layout switched from `gr.ChatInterface` → `gr.Blocks` with chat on the left and a live HTML calendar pane on the right that re-renders on every tool call.
- New `InMemoryCalendarBackend` added to `canvas_sdk.backends.calendar_adapter` (full `CalendarBackend` contract + immediate `modify_event` / `delete_event` for demo UX + `propose_*` stubs for protocol parity). Has a `__main__` round-trip self-test.
- Per-tool gap table + deviation rationale in `hf-space/UPGRADE-GAP-AUDIT.md`.

## Deviation

Advisor brief said calendar tools should route through `ListEvents(adapter).run(args)` etc. That literal API does not exist in `canvas_sdk` (tools use `@staticmethod def call(args)` and resolve adapter via `CalendarAdapter.from_config()` → `from canvas_tui.config import load_config`). Neither `canvas_sdk` nor `canvas_tui` is in `hf-space/requirements.txt`, and the deploy workflow uploads only `hf-space/`. Documented in detail in `UPGRADE-GAP-AUDIT.md`. Achievable reuse: backend class lives in the SDK + verbatim copy in `app.py`; contract stays in lockstep.

## Test plan

- [x] `python3 src/sdk/canvas_sdk/backends/calendar_adapter.py` → `InMemoryCalendarBackend round-trip OK`
- [x] Stubbed-import module-load test on `gradio==5.7.1` (Space's pinned `sdk_version`) → `demo type: Blocks` / `OK`
- [x] Functional check: `init_state → create_event → list (4 events) → delete → list (3 events)` with HTML render
- [ ] Post-merge: `deploy-hf-space.yml` succeeds
- [ ] Post-merge: Space `runtime.stage == RUNNING`
- [ ] Post-merge: 2 screenshots captured (loaded UI + tool-call mutation)