### PR TITLE
fix(ci): rename huggingface-cli to hf in deploy workflow

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - "hf-space/**"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -26,7 +27,7 @@ jobs:
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
-          huggingface-cli upload kleinpanic93/canvas-calendar-agent-demo \
+          hf upload kleinpanic93/canvas-calendar-agent-demo \
             hf-space/ . \
             --repo-type space \
             --commit-message "deploy: ${{ github.sha }}"


### PR DESCRIPTION
## Summary

PR #145's deploy run [25423635456](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/runs/25423635456) failed because \`huggingface-cli upload\` was deprecated in newer \`huggingface_hub\` releases and no longer works (the binary now prints \"\`huggingface-cli\` is deprecated and no longer works. Use \`hf\` instead.\" and exits 1).

This PR:
- Replaces \`huggingface-cli upload\` with \`hf upload\` (drop-in: same positional args \`<repo_id> <local_path> <path_in_repo>\`, same flags \`--repo-type --commit-message\`).
- Adds \`workflow_dispatch:\` so we can manually re-deploy without a \`hf-space/**\` change.

## Test plan

- [x] Verified \`hf upload --help\` accepts the same arg structure
- [ ] Post-merge: trigger \`workflow_dispatch\` to re-deploy \#145's hf-space upgrade
- [ ] Confirm Space \`runtime.stage == RUNNING\`