### PR TITLE
fix(extension): make assignment-item rows clickable

### DIFF
--- a/extension/src/popup/app.js
+++ b/extension/src/popup/app.js
@@ -154,7 +154,7 @@ function renderAssignmentItem(item, { showCourse = true } = {}) {
   const cls        = urgencyClass(dueDate);
 
   return `
-    <li class="assignment-item ${cls}" data-id="${id}">
+    <li class="assignment-item ${cls}" data-id="${id}" data-html-url="${esc(item.html_url || "")}">
       <div class="assignment-main">
         ${showCourse && courseName ? `<div class="course-name">${esc(courseName)}</div>` : ""}
         <div class="assignment-name">${esc(item.title || item.assignment?.name || "Assignment")}</div>
@@ -179,8 +179,16 @@ function attachItemHandlers(list) {
     });
   });
   list.querySelectorAll(".open-btn").forEach(btn => {
-    btn.addEventListener("click", () => {
+    btn.addEventListener("click", e => {
+      e.stopPropagation();
       const url = btn.dataset.url;
+      if (url) window.open(url, "_blank");
+    });
+  });
+  list.querySelectorAll(".assignment-item").forEach(li => {
+    li.addEventListener("click", e => {
+      if (e.target.closest(".dismiss-btn") || e.target.closest(".open-btn")) return;
+      const url = li.dataset.htmlUrl;
       if (url) window.open(url, "_blank");
     });
   });

--- a/extension/src/popup/styles.css
+++ b/extension/src/popup/styles.css
@@ -291,6 +291,8 @@ main {
 .assignment-item.urgent   { border-left: 4px solid var(--urgent); }
 .assignment-item.due-soon { border-left: 4px solid var(--due-soon); }
 
+.assignment-item[data-html-url]:not([data-html-url=""]) { cursor: pointer; }
+
 .assignment-main { flex: 1; min-width: 0; }
 
 .course-name {


### PR DESCRIPTION
## Summary
Operator reported on the live demo (upcoming-list) that the "Binary Tree Chapter Summary" item with no due date "is not interactive" — clicking the row body did nothing. Only the ✓ dismiss and → open action buttons fired. This wires up the row body to open the assignment in a new tab.

## Changes
- `extension/src/popup/app.js`
  - `renderAssignmentItem`: emit `data-html-url` on the `<li>` so the row handler can read it
  - `attachItemHandlers`: add `e.stopPropagation()` to the `.open-btn` handler so action-button clicks don't bubble up to the new row handler (dismiss-btn already had it)
  - `attachItemHandlers`: new row-level click handler — if the click target isn't a `.dismiss-btn` or `.open-btn`, open `dataset.htmlUrl` in a new tab; rows without a URL no-op gracefully
- `extension/src/popup/styles.css`
  - `cursor: pointer` only on rows that actually have a URL (`[data-html-url]:not([data-html-url=""])`) so non-clickable rows don't lie about being clickable

## Test plan
- [x] Existing dismiss-btn semantics unchanged (still has `stopPropagation()`)
- [x] open-btn now stops propagation so a click on → does NOT also fire the row handler
- [ ] Manually verify in popup: click row body opens Canvas; click ✓ dismisses without navigating; click → opens without double-fire