### PR TITLE
fix(hf-space): No API found error + UI polish + homepage hero buttons

### DIFF
--- a/docs-site/index.html
+++ b/docs-site/index.html
@@ -83,6 +83,16 @@
          class="border border-gray-700 hover:border-gray-500 text-gray-300 hover:text-white px-8 py-3 rounded-full transition-colors text-base" target="_blank" rel="noopener">
         View on GitHub
       </a>
+      <a href="https://huggingface.co/collections/kleinpanic93/canvas-calendar-agent-v30-69fa6462f697e0342b21dfe0"
+         class="border border-gray-700 hover:border-gray-500 text-gray-300 hover:text-white px-8 py-3 rounded-full transition-colors text-base" target="_blank" rel="noopener">
+        &#129303; HF Collection
+      </a>
+      <a href="#" aria-disabled="true"
+         class="border border-gray-800 text-gray-500 px-8 py-3 rounded-full transition-colors text-base cursor-not-allowed inline-flex items-center gap-2"
+         onclick="event.preventDefault(); return false;"
+         title="Paper publishing pending — link will activate when DOI is reserved">
+        Paper <span class="text-xs">(coming soon)</span>
+      </a>
     </div>
   </section>
 

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -624,26 +624,27 @@ with gr.Blocks(theme=THEME, css=CUSTOM_CSS, title="Canvas Calendar Agent") as de
                 elem_id="calendar-pane",
             )
 
-    with gr.Accordion("Calendar examples (5 tools)", open=True):
-        with gr.Row():
+    gr.Markdown("### Try one of the 18 tools")
+    with gr.Row():
+        with gr.Column():
+            gr.Markdown("**Calendar (5)**")
             for ex in CALENDAR_EXAMPLES:
                 btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
-                btn.click(lambda x=ex: x, outputs=msg)
-    with gr.Accordion("Canvas examples (8 tools)", open=False):
-        with gr.Row():
-            for ex in CANVAS_EXAMPLES:
-                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
-                btn.click(lambda x=ex: x, outputs=msg)
-    with gr.Accordion("Study examples (4 tools)", open=False):
-        with gr.Row():
-            for ex in STUDY_EXAMPLES:
-                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
-                btn.click(lambda x=ex: x, outputs=msg)
-    with gr.Accordion("Reranker examples (1 tool)", open=False):
-        with gr.Row():
+                btn.click(lambda x=ex: x, outputs=msg, api_name=False)
+            gr.Markdown("**Reranker (1)**")
             for ex in RERANKER_EXAMPLES:
                 btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
-                btn.click(lambda x=ex: x, outputs=msg)
+                btn.click(lambda x=ex: x, outputs=msg, api_name=False)
+        with gr.Column():
+            gr.Markdown("**Canvas (8)**")
+            for ex in CANVAS_EXAMPLES:
+                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
+                btn.click(lambda x=ex: x, outputs=msg, api_name=False)
+        with gr.Column():
+            gr.Markdown("**Study (4)**")
+            for ex in STUDY_EXAMPLES:
+                btn = gr.Button(ex, elem_classes=["example-btn"], size="sm")
+                btn.click(lambda x=ex: x, outputs=msg, api_name=False)
 
     # Wire send button + Enter-key submit. Outputs order MUST match chat() return:
     # (history, state, calendar_html).
@@ -651,13 +652,15 @@ with gr.Blocks(theme=THEME, css=CUSTOM_CSS, title="Canvas Calendar Agent") as de
         fn=chat,
         inputs=[msg, chatbot, state],
         outputs=[chatbot, state, calendar_html],
-    ).then(lambda: "", outputs=msg)
+        api_name=False,
+    ).then(lambda: "", outputs=msg, api_name=False)
 
     msg.submit(
         fn=chat,
         inputs=[msg, chatbot, state],
         outputs=[chatbot, state, calendar_html],
-    ).then(lambda: "", outputs=msg)
+        api_name=False,
+    ).then(lambda: "", outputs=msg, api_name=False)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- **hf-space/app.py**: add `api_name=False` to all 18 example button clicks + chat send/submit (Gradio 5.x API discovery race on cold start was producing a red "Error: No API found" banner)
- **hf-space/app.py**: replace 4 collapsed accordions with a 3-column flat grid (Calendar+Reranker / Canvas / Study) so all 18 tools are visible at once
- **docs-site/index.html**: append "🤗 HF Collection" + disabled "Paper (coming soon)" buttons to the homepage hero CTA row

## Test plan
- [x] Module-load test (stubbed torch/transformers) prints `OK` and confirms `demo` is `Blocks`
- [ ] Post-merge: Pages workflow run succeeds
- [ ] Post-merge: HF Space `runtime.stage` reaches `RUNNING`
- [ ] Live screenshot: no red error banner, 18 buttons in 3-column grid
- [ ] Live screenshot: 4 hero buttons on homepage