### PR TITLE
feat(demo): pre-fetch RMP ratings at build time

### DIFF
--- a/docs-site/chrome_shim_prod.js
+++ b/docs-site/chrome_shim_prod.js
@@ -47,7 +47,17 @@
     GET_COURSE_FILES: async (msg) => fetchJson(`course_${msg.courseId}_files.json`),
     GET_PLANNER_NOTES: async () => fetchJson('planner_notes.json'),
 
-    GET_RMP_RATING: async () => ({ ok: false, error: 'Not available in demo' }),
+    GET_RMP_RATING: async (msg) => {
+      const name = (msg.professorName || '').trim();
+      if (!name) return { ok: true, rating: null, difficulty: null, numRatings: 0 };
+      const lastName = name.split(' ').pop();
+      const map = await fetchJson('rmp.json');
+      if (!map?.ok) return { ok: true, rating: null, difficulty: null, numRatings: 0 };
+      const hit = map.data[name] || map.data[lastName] || null;
+      return hit
+        ? { ok: true, rating: hit.rating, difficulty: hit.difficulty, numRatings: hit.numRatings }
+        : { ok: true, rating: null, difficulty: null, numRatings: 0 };
+    },
     GET_DASHBOARD_CARDS: async () => fetchJson('dashboard_cards.json'),
     GET_COURSE_SYLLABUS: async (msg) => fetchJson(`course_${msg.courseId}_syllabus.json`),
     GET_ASSIGNMENT_GROUPS: async (msg) => fetchJson(`course_${msg.courseId}_assignment_groups.json`),

--- a/docs-site/fetch_canvas_data.py
+++ b/docs-site/fetch_canvas_data.py
@@ -32,6 +32,7 @@ import re
 import sys
 import urllib.request
 import urllib.error
+import urllib.parse
 from pathlib import Path
 
 CANVAS_BASE = "https://canvas.vt.edu/api/v1"
@@ -102,6 +103,38 @@ def save(out_dir: Path, filename: str, data):
     with open(path, "w") as f:
         json.dump({"ok": True, "data": data}, f)
     print(f"  wrote {path} ({len(data) if isinstance(data, list) else '...'} items)")
+
+
+def fetch_rmp(last_name: str):
+    if not last_name:
+        return None
+    url = f"https://www.ratemyprofessors.com/filter/teacher?institution_id=1346&query={urllib.parse.quote(last_name)}"
+    try:
+        with urllib.request.urlopen(url, timeout=10) as resp:
+            data = json.loads(resp.read())
+        teacher = (data.get("data") or [None])[0]
+        if not teacher:
+            return None
+        return {
+            "rating": teacher.get("avg_rating"),
+            "difficulty": teacher.get("avg_difficulty"),
+            "numRatings": teacher.get("num_ratings", 0),
+        }
+    except Exception as e:
+        print(f"  RMP fetch failed for {last_name}: {e}", file=sys.stderr)
+        return None
+
+
+def collect_teachers(courses):
+    seen = set()
+    out = []
+    for c in courses or []:
+        for t in c.get("teachers") or []:
+            name = t.get("display_name")
+            if name and name not in seen:
+                seen.add(name)
+                out.append(name)
+    return out
 
 
 def self_test():
@@ -204,6 +237,18 @@ def main():
             syllabus = fetch(f"/courses/{cid}", {"include[]": "syllabus_body"})
             save(out_dir, f"course_{cid}_syllabus.json",
                  clean(syllabus if isinstance(syllabus, dict) else {}))
+
+    # RMP ratings — pre-fetched at build time; chrome_shim_prod.js reads from rmp.json
+    print("Fetching RateMyProfessors ratings...")
+    teachers = collect_teachers(courses if isinstance(courses, list) else [])
+    rmp_map = {}
+    for name in teachers:
+        last = name.split()[-1] if name else ""
+        rating = fetch_rmp(last)
+        if rating:
+            rmp_map[name] = rating
+            rmp_map[last] = rating  # popup looks up by last-name; index both
+    save(out_dir, "rmp.json", rmp_map)
 
     print(f"\nDone. Data written to {out_dir}/")
 


### PR DESCRIPTION
## Summary
- `fetch_canvas_data.py`: adds `fetch_rmp()` + `collect_teachers()`, runs after the courses loop, writes `rmp.json` via `save()` (wrapped as `{ok, data}`)
- `chrome_shim_prod.js`: replaces the hard-stub `GET_RMP_RATING` with a live lookup against `rmp.json`, returning flat `{ok, rating, difficulty, numRatings}` to match the `app.js:271` consumer contract

## Why
Live demo advertises prof ratings on the front page but the shim always returned `{ok: false}`. This wires the full pipeline so ratings appear in the UI after the next CI deploy.

## Failure handling
`fetch_rmp()` wraps the RMP call in `try/except`; any failure (rate-limit, block) prints to stderr and returns None — CI does not fail, `rmp.json` is written with whatever entries succeeded.

## Test plan
- [ ] CI run passes (pages.yml)
- [ ] `site/data/rmp.json` present in deploy artifact with at least one entry
- [ ] Agent-demo page shows rating badge next to a professor name