### PR TITLE
docs(readme): expand badge cluster, drop broken PyPI badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,29 @@
 
 A maintainable, team-ready **Canvas LMS productivity client** with a Textual TUI frontend, Chrome extension, Python SDK, and a fine-tuned calendar agent — with a documented shared-core architecture.
 
+<!-- Build, repo, tooling, downstream — re-grouped 2026-05-06 -->
 [![CI](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/ci.yml?branch=main&label=CI)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/ci.yml)
 [![Security](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/security.yml?branch=main&label=Security)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/security.yml)
 [![Pages](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/pages.yml?branch=main&label=Pages)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/pages.yml)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
-[![PyPI](https://img.shields.io/pypi/v/canvas-sdk?label=PyPI)](https://pypi.org/project/canvas-sdk/)
-[![PyPI Python](https://img.shields.io/pypi/pyversions/canvas-sdk)](https://pypi.org/project/canvas-sdk/)
+[![Release](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/release.yml?label=Release)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/release.yml)
+[![Coverage](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/coverage.yml?branch=main&label=Coverage)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/coverage.yml)
+<br>
+[![release](https://img.shields.io/github/v/release/kleinpanic/CS3704-Canvas-Project?label=release)](https://github.com/kleinpanic/CS3704-Canvas-Project/releases)
+[![last commit](https://img.shields.io/github/last-commit/kleinpanic/CS3704-Canvas-Project)](https://github.com/kleinpanic/CS3704-Canvas-Project/commits/main)
+[![activity](https://img.shields.io/github/commit-activity/m/kleinpanic/CS3704-Canvas-Project?label=activity)](https://github.com/kleinpanic/CS3704-Canvas-Project/commits/main)
+[![contributors](https://img.shields.io/github/contributors/kleinpanic/CS3704-Canvas-Project)](https://github.com/kleinpanic/CS3704-Canvas-Project/graphs/contributors)
+<br>
 [![Python](https://img.shields.io/badge/python-3.11%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+[![code style: ruff](https://img.shields.io/badge/code%20style-ruff-000000?logo=ruff)](https://github.com/astral-sh/ruff)
+[![types: mypy](https://img.shields.io/badge/types-mypy-blue?logo=python&logoColor=white)](https://mypy-lang.org/)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://pre-commit.com/)
+<br>
 [![HF Model](https://img.shields.io/badge/🤗_Model-canvas--calendar--agent--v7--dpo-yellow)](https://huggingface.co/kleinpanic93/canvas-calendar-agent-v7-dpo)
 [![HF Dataset](https://img.shields.io/badge/🤗_Dataset-canvas--calendar--preferences--v7-blue)](https://huggingface.co/datasets/kleinpanic93/canvas-calendar-preferences-v7)
 [![HF Collection](https://img.shields.io/badge/🤗_Collection-Canvas_Calendar_Agent_v3.0-yellow)](https://huggingface.co/collections/kleinpanic93/canvas-calendar-agent-v30-69fa6462f697e0342b21dfe0)
 [![HF Space](https://img.shields.io/badge/🤗_Space-Live_Demo-purple)](https://huggingface.co/spaces/kleinpanic93/canvas-calendar-agent-demo)
+[![ghcr.io](https://img.shields.io/badge/ghcr.io-canvas--tui-2496ED?logo=docker&logoColor=white)](https://github.com/kleinpanic/CS3704-Canvas-Project/pkgs/container/canvas-tui)
 
 ---
 


### PR DESCRIPTION
## Summary

- Drop two broken `shields.io/pypi` badges (`canvas-sdk` not published to PyPI)
- Add 8 new badges in 4 logical rows separated by `<br>`:
  - **Row 1 (workflows):** Release, Coverage (joins existing CI, Security, Pages)
  - **Row 2 (repo activity):** GitHub release tag, last commit, activity, contributors
  - **Row 3 (tooling):** Ruff, Mypy, pre-commit (joins existing Python, License)
  - **Row 4 (downstream):** GHCR docker image (joins existing HF Model/Dataset/Collection/Space)
- Net: 11 → 19 badges (within ≤22 limit)
- Single comment line added above cluster for orientation

## Test plan

- [ ] CI green on this PR
- [ ] No PyPI badges visible in rendered README
- [ ] All 19 badges render without broken images