### PR TITLE
fix(hf-space): empty-send guard, example-btn labels, Ask AI height

### DIFF
--- a/docs-site/agent-demo/index.html
+++ b/docs-site/agent-demo/index.html
@@ -351,7 +351,7 @@ python -c "from canvas_sdk import CanvasAgent; print(CanvasAgent.auto().run('wha
         </div>
 
         <!-- Extension popup -->
-        <div class="ext-popup" style="height: 540px;">
+        <div class="ext-popup" style="height: 720px;">
           <!-- Extension title bar -->
           <div class="ext-titlebar">
             <div class="ext-icon">C</div>

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -430,6 +430,8 @@ def generate_step(messages):
 def chat(message: str, history: list, state: dict | None):
     if state is None:
         state = init_state()
+    if not (message or "").strip():
+        return history or [], state, render_calendar_html(state)
 
     msgs = [{"role": "system", "content": SYSTEM_PROMPT}]
     for h in history or []:
@@ -546,11 +548,12 @@ CUSTOM_CSS = """
     padding: 3px 10px !important;
     border: 1px solid #2e2e38 !important;
     background: #18181f !important;
+    color: #d4d4db !important;
     text-align: left !important;
     white-space: normal !important;
     min-height: auto !important;
 }
-.example-btn button:hover { border-color: #d63e36 !important; background: #1f1010 !important; }
+.example-btn button:hover { border-color: #d63e36 !important; background: #1f1010 !important; color: #ffffff !important; }
 .description { font-size: 0.82rem !important; line-height: 1.6 !important; color: #9ca3af !important; }
 #calendar-pane { background: #111114; border: 1px solid #2e2e38; border-radius: 8px; min-height: 440px; max-height: 600px; overflow-y: auto; }
 """


### PR DESCRIPTION
## Summary

Three production bug fixes confirmed by live HF Space test (2026-05-06):

- **Empty-send guard** (`hf-space/app.py`): `chat()` now returns early on blank input, preventing the Gradio Error toast visible in `live-03-empty-send.png`.
- **Example button text color** (`hf-space/app.py`): `.example-btn button` was missing `color:` rule; labels rendered invisible on dark background (seen in `live-04-after-example-click.png`). Added `color: #d4d4db !important` + hover `color: #ffffff !important`.
- **Ask AI popup height** (`docs-site/agent-demo/index.html`): `.ext-popup` height 540px → 720px so the full chat surface is visible in the agent demo page.

## Test plan

- [ ] `deploy-hf-space.yml` CI green after merge
- [ ] `pages.yml` CI green after merge
- [ ] Live HF Space: empty Send → no error toast
- [ ] Live HF Space: example buttons show label text
- [ ] Live Pages agent-demo: Ask AI tab not cut off