### PR TITLE
docs(readme): add Distribution table for 3-pkg channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,21 @@ A maintainable, team-ready **Canvas LMS productivity client** with a Textual TUI
 
 ---
 
+## Distribution
+
+| Surface | Channel | Status |
+|---------|---------|--------|
+| **canvas-sdk** (Python) | [PyPI](https://pypi.org/project/canvas-sdk/) | publish queued — see `release.yml` `publish-pypi` job |
+| **canvas-tui** (Python) | [PyPI](https://pypi.org/project/canvas-tui/) | publish queued — `pyproject.toml` v1.1.1 |
+| **canvas-tui** (Docker) | `ghcr.io/kleinpanic/canvas-tui` | live — built nightly + on tag (#140) |
+| **Chrome extension** | [Chrome Web Store](https://chromewebstore.google.com/) | listing in progress — install via `Load unpacked` for now |
+| **HF Space demo** | [Live](https://huggingface.co/spaces/kleinpanic93/canvas-calendar-agent-demo) | live — auto-deploys on push to `main` |
+| **HF Model** | [v7-DPO](https://huggingface.co/kleinpanic93/canvas-calendar-agent-v7-dpo) | live |
+
+> **PyPI publication queued — Chrome Web Store listing in progress.** Trusted publisher registration at pypi.org pending; first stable tag (`v1.0.0`+) will fire `publish-pypi`.
+
+---
+
 ## Quick Start
 
 ### Chrome Extension


### PR DESCRIPTION
## Summary

- Adds `## Distribution` section after the badge cluster, before `## Quick Start`
- Table covers canvas-sdk (PyPI queued), canvas-tui (PyPI queued + GHCR live), Chrome extension (in progress), HF Space/Model (live)
- No 404-prone PyPI version badges — table format tells the same story without broken images

## Test plan

- [ ] README renders correctly on github.com with Distribution table visible
- [ ] No broken badge images introduced