### PR TITLE
fix(ci): replace phantom build job dep in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -367,14 +367,14 @@ jobs:
         env:
           VERSION: ${{ steps.meta.outputs.version }}
         run: |
-          echo "::error::Release ${{ needs.build.outputs.version }} failed. Check logs: https://github.com/${{ github.repository }}/actions/workflows/release.yml"
+          echo "::error::Release ${{ needs.build-sdk-linux.outputs.version }} failed. Check logs: https://github.com/${{ github.repository }}/actions/workflows/release.yml"
 
   # Publishes stable releases (no pre-release suffixes) to PyPI via OIDC trusted publishing.
   # No API token is needed here. Configure the PyPI project for trusted publishing first:
   # https://docs.pypi.org/trusted-publishers/
   publish-pypi:
-    needs: [release, build]
-    if: ${{ !contains(needs.build.outputs.version, '-') }}
+    needs: [release, build-sdk-linux]
+    if: ${{ !contains(needs.build-sdk-linux.outputs.version, '-') }}
     runs-on: ubuntu-latest
     environment: pypi
     permissions:


### PR DESCRIPTION
## Summary

- `publish-pypi.needs` had `build` which doesn't exist — corrected to `build-sdk-linux`
- `needs.build.outputs.version` in the `release` job's failure-reporting step had the same phantom ref — corrected to `needs.build-sdk-linux.outputs.version`

The version output is defined on `build-sdk-linux` (lines 113-117). Introduced by PR #138.

## Test plan

- [ ] YAML validates locally (`python3 -c "import yaml; yaml.safe_load(...)"` passes)
- [ ] CI green on this PR
- [ ] No new `release.yml` run failures on next push to main (trigger is tag-only, so no spurious runs expected)