### PR TITLE
docs: add contrib.rocks contributor graph to README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] — 2026-05-06
 
 ### Added
+- **Contributor graph** (contrib.rocks) in README showing all contributors with auto-refresh.
 - **HF Space session state + 18-tool surface**: calendar pane, 18 dispatched mock tools, pill examples, table tool calls, fill_height, Gemma-4 sampling params (#145)
 - **18 interactive tool buttons** on agent demo page with visible labels (#121, #122, #163, #164)
 - **Live Demo page** on docs-site with HF links across nav (#143, #144)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ For team workflow, branch naming, repo structure, and dev setup, see [`CONTRIBUT
 
 ---
 
+## Contributors
+
+[![Contributors](https://contrib.rocks/image?repo=kleinpanic/CS3704-Canvas-Project)](https://github.com/kleinpanic/CS3704-Canvas-Project/graphs/contributors)
+
+Made with [contrib.rocks](https://contrib.rocks).
+
+---
+
 ## License
 
 GPL-3.0-or-later. See [LICENSE](LICENSE).


### PR DESCRIPTION
## Summary

Adds a contributor graph to the README using contrib.rocks — a free service that auto-refreshes on every commit. The graph image links directly to the GitHub contributors page.

## Type of change

- [x] docs — documentation only

## Changes

- **README.md**: added `## Contributors` section before `## License` with contrib.rocks badge and link
- **CHANGELOG.md**: recorded under v1.2.0 Added

## Checklist

- [x] Conventional commit title
- [x] CHANGELOG.md updated under v1.2.0
- [x] No secrets or credentials introduced