### PR TITLE
feat: add automated PR quality enforcement + release-drafter

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,17 +1,26 @@
 ## Summary
-- What changed?
-- Why?
+
+<!-- 1-3 sentences explaining what this PR does and why -->
+
+## Type of change
+
+- [ ] feat — new feature
+- [ ] fix — bug fix
+- [ ] docs — documentation only
+- [ ] refactor — code restructure, no behavior change
+- [ ] perf — performance improvement
+- [ ] test — test additions or fixes
+- [ ] chore — tooling, build, CI
+- [ ] BREAKING CHANGE — incompatible API or behavior change
+
+## Testing
+
+<!-- How was this verified? Tests added? Manual checks? -->
 
 ## Checklist
-- [ ] Linked issue/task
-- [ ] Tests added or updated (if applicable)
-- [ ] `ruff check src tests` passes locally
-- [ ] `pytest tests` passes locally
-- [ ] Docs/README updated (if behavior changed)
-- [ ] No secrets or credentials introduced
 
-## Screenshots / Evidence (if UI/docs changed)
-
-## Risk / Rollback
-- Risk level: low / medium / high
-- Rollback plan:
+- [ ] Conventional commit title (`feat:`, `fix:`, etc.)
+- [ ] CHANGELOG.md updated under [Unreleased] or current version
+- [ ] Tests added or updated (or `skip-changelog` label justified)
+- [ ] Documentation updated if user-facing behavior changed
+- [ ] No secrets, tokens, or PII committed

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,59 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels: ['feat', 'feature', 'enhancement']
+  - title: '🐛 Bug Fixes'
+    labels: ['fix', 'bugfix', 'bug']
+  - title: '📝 Documentation'
+    labels: ['docs', 'documentation']
+  - title: '🔒 Security'
+    labels: ['security']
+  - title: '🧹 Maintenance'
+    labels: ['chore', 'refactor', 'ci', 'build']
+  - title: '⚠️ Breaking Changes'
+    labels: ['breaking', 'breaking-change']
+autolabeler:
+  - label: 'feat'
+    title:
+      - '/^feat(\(.+\))?:/'
+  - label: 'fix'
+    title:
+      - '/^fix(\(.+\))?:/'
+  - label: 'docs'
+    title:
+      - '/^docs(\(.+\))?:/'
+  - label: 'chore'
+    title:
+      - '/^chore(\(.+\))?:/'
+  - label: 'refactor'
+    title:
+      - '/^refactor(\(.+\))?:/'
+  - label: 'ci'
+    title:
+      - '/^ci(\(.+\))?:/'
+  - label: 'build'
+    title:
+      - '/^build(\(.+\))?:/'
+  - label: 'security'
+    title:
+      - '/^fix\(security\):/'
+  - label: 'breaking-change'
+    title:
+      - '/BREAKING CHANGE/'
+change-template: '- $TITLE (#$NUMBER) by @$AUTHOR'
+change-title-escapes: '\<*_&'
+version-resolver:
+  major:
+    labels: ['breaking', 'breaking-change']
+  minor:
+    labels: ['feat', 'feature', 'enhancement']
+  patch:
+    labels: ['fix', 'bugfix', 'bug', 'docs', 'chore']
+  default: patch
+template: |
+  ## What's Changed
+
+  $CHANGES
+
+  **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/pr-quality.yml
+++ b/.github/workflows/pr-quality.yml
@@ -1,0 +1,60 @@
+name: PR Quality
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+    branches: [main]
+permissions:
+  pull-requests: read
+  contents: read
+jobs:
+  conventional-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            chore
+            refactor
+            test
+            perf
+            style
+            ci
+            build
+            revert
+
+  changelog-required:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          changeLogPath: CHANGELOG.md
+          skipLabels: 'skip-changelog,dependencies'
+
+  size-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check PR size
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          additions=$(gh pr view "$PR_NUMBER" --json additions -q '.additions')
+          deletions=$(gh pr view "$PR_NUMBER" --json deletions -q '.deletions')
+          total=$((additions + deletions))
+          echo "PR diff size: $total lines ($additions added, $deletions deleted)"
+          labels=$(gh pr view "$PR_NUMBER" --json labels -q '[.labels[].name] | join(",")')
+          if [ "$total" -gt 1000 ] && [[ "$labels" != *"large-pr"* ]]; then
+            echo "::error::PR is $total lines (limit: 1000). Add 'large-pr' label to override."
+            exit 1
+          fi

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,16 @@
+name: Release Drafter
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, reopened, synchronize, edited]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] — 2026-05-06
 
 ### Added
+- **Automated PR quality enforcement**: conventional title check (`amannn/action-semantic-pull-request@v5`), CHANGELOG enforcer (`dangoslen/changelog-enforcer@v3`), size limit gate (>1000 lines requires `large-pr` label), PR template, and release-drafter for auto-generated release notes.
 - **Contributor graph** (contrib.rocks) in README showing all contributors with auto-refresh.
 - **HF Space session state + 18-tool surface**: calendar pane, 18 dispatched mock tools, pill examples, table tool calls, fill_height, Gemma-4 sampling params (#145)
 - **18 interactive tool buttons** on agent demo page with visible labels (#121, #122, #163, #164)


### PR DESCRIPTION
## Summary

Adds a three-job PR quality gate (conventional title, CHANGELOG enforcer, size check), an expanded PR template, and release-drafter to auto-generate release notes from PR labels.

## Type of change

- [x] feat — new feature

## Changes

- **pr-quality.yml**: three jobs — conventional title via `amannn/action-semantic-pull-request@v5`, CHANGELOG enforcement via `dangoslen/changelog-enforcer@v3` (skip with `skip-changelog` or `dependencies` labels), size gate (>1000 diff lines → requires `large-pr` label)
- **pull_request_template.md**: expanded with type-of-change checklist, testing section, and 5-item checklist
- **release-drafter.yml** (config): categorizes PRs into Features/Fixes/Docs/Security/Maintenance/Breaking by label; autolabeler maps conventional commit title prefixes to labels
- **release-drafter.yml** (workflow): maintains a rolling draft release on main pushes and PR events

Note: changelog-enforcer is introduced in this PR but won't gate this PR itself — it takes effect on subsequent PRs after merge.

## Checklist

- [x] Conventional commit title
- [x] CHANGELOG.md updated under v1.2.0
- [x] No secrets or credentials introduced