### PR TITLE
feat: add nightly release channel and docs/RELEASING.md

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,55 @@
+name: Nightly Release
+on:
+  schedule:
+    - cron: '0 6 * * *'  # 06:00 UTC daily
+  workflow_dispatch:
+permissions:
+  contents: write
+concurrency:
+  group: nightly
+  cancel-in-progress: true
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Build SDK wheel
+        run: |
+          cd src/sdk
+          pip install build
+          python -m build --wheel --sdist
+      - name: Build extension archive
+        run: |
+          tar -czf canvas-extension-nightly.tar.gz -C extension src manifest.json
+      - name: Compute tag
+        id: tag
+        run: |
+          SHA=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y%m%d)
+          TAG="nightly-${DATE}-${SHA}"
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+      - name: Create tag
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+      - name: Publish pre-release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          name: 'Nightly ${{ steps.tag.outputs.tag }}'
+          prerelease: true
+          body: |
+            Automated nightly snapshot of `main`.
+
+            This is a pre-release build for testing. NOT published to PyPI. Use stable `v*` releases for production.
+
+            Commit: ${{ github.sha }}
+          files: |
+            src/sdk/dist/*
+            canvas-extension-nightly.tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.2.0] — 2026-05-06
 
 ### Added
+- **Nightly release channel**: daily cron (06:00 UTC) builds SDK wheel + extension archive, tags as `nightly-YYYYMMDD-<sha>`, publishes as GitHub pre-release. `docs/RELEASING.md` documents the 3-channel model (stable, nightly, snapshot) and branch protection recommendations.
 - **Automated PR quality enforcement**: conventional title check (`amannn/action-semantic-pull-request@v5`), CHANGELOG enforcer (`dangoslen/changelog-enforcer@v3`), size limit gate (>1000 lines requires `large-pr` label), PR template, and release-drafter for auto-generated release notes.
 - **Contributor graph** (contrib.rocks) in README showing all contributors with auto-refresh.
 - **HF Space session state + 18-tool surface**: calendar pane, 18 dispatched mock tools, pill examples, table tool calls, fill_height, Gemma-4 sampling params (#145)

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,64 @@
+# Release Channels
+
+This project ships through three channels:
+
+## 1. Stable releases (`v*`)
+
+- Tag format: `v1.2.0`, `v1.3.0-rc1`, etc.
+- Triggered by pushing a `v*` tag to `main`.
+- Workflow: `.github/workflows/release.yml`
+- Publishes to: GitHub Releases + PyPI (canvas-sdk via OIDC trusted publishing) + GHCR (canvas-tui Docker image)
+- PyPI publishing requires a one-time trusted-publisher registration at pypi.org for repo `kleinpanic/CS3704-Canvas-Project`, workflow `release.yml`, environment `pypi`.
+
+## 2. Nightly snapshots (`nightly-*`)
+
+- Tag format: `nightly-YYYYMMDD-<sha>`
+- Triggered: daily cron at 06:00 UTC, or manual `workflow_dispatch`.
+- Workflow: `.github/workflows/nightly.yml`
+- Publishes to: GitHub Releases (marked as pre-release) ONLY. NOT PyPI.
+- Use case: bleeding-edge testing without PyPI noise.
+
+## 3. CI snapshot tags (`snapshot-*`)
+
+Legacy. Created by older release.yml versions. Do not push new ones.
+
+## Cutting a stable release
+
+1. Decide on the new version (e.g., v1.3.0). Bump:
+   - `pyproject.toml` (root) version field
+   - `src/sdk/pyproject.toml` version field
+   - Add CHANGELOG entry under `## [1.3.0] — YYYY-MM-DD`
+2. PR + merge. CI's version-check + changelog-enforcer must pass.
+3. From `main`: `git tag v1.3.0 && git push origin v1.3.0`
+4. `release.yml` fires: builds artifacts, creates GitHub Release, uploads to PyPI/GHCR.
+
+## Branch protection (operator action — manual)
+
+Recommended `main` branch protection:
+
+- [ ] Require pull request before merging
+- [ ] Require approvals: 1+ (codeowners review)
+- [ ] Dismiss stale approvals on new commits
+- [ ] Require status checks to pass before merging:
+  - Branch Name Policy
+  - Ruff Format / Ruff Lint
+  - Mypy Type Check
+  - Test
+  - Coverage (advisory)
+  - CodeQL Analyze
+  - Conventional title (PR Quality)
+  - Changelog required (PR Quality)
+  - Version Check
+- [ ] Require branches to be up to date before merging
+- [ ] Require signed commits
+- [ ] Require linear history
+- [ ] Do NOT allow force pushes
+- [ ] Do NOT allow deletions
+
+Apply via: GitHub Repo Settings → Branches → Branch protection rules → Edit rule for `main`.
+
+Or via API:
+```bash
+gh api -X PUT repos/kleinpanic/CS3704-Canvas-Project/branches/main/protection \
+  --input branch-protection.json
+```


### PR DESCRIPTION
## Summary

Adds a daily nightly release channel (cron + manual dispatch) that builds the SDK wheel and extension archive, tags as `nightly-YYYYMMDD-<sha>`, and publishes as a GitHub pre-release. Also adds `docs/RELEASING.md` documenting the 3-channel model and branch protection recommendations for the operator.

## Type of change

- [x] feat — new feature

## Changes

- **.github/workflows/nightly.yml**: daily 06:00 UTC cron + `workflow_dispatch`; builds `canvas-sdk` wheel/sdist and extension tar; computes `nightly-YYYYMMDD-<sha>` tag; pushes tag; creates pre-release via `softprops/action-gh-release@v2`. NOT published to PyPI.
- **docs/RELEASING.md**: 3-channel model (stable `v*`, nightly `nightly-*`, legacy `snapshot-*`); stable release procedure; branch protection checklist (operator action required).
- **CHANGELOG.md**: recorded under v1.2.0 Added.

## Checklist

- [x] Conventional commit title
- [x] CHANGELOG.md updated under v1.2.0
- [x] No secrets or credentials introduced