### PR TITLE
fix(ci+demo): publish-pypi via API token + RMP teachers fetch (#173)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,20 +376,24 @@ jobs:
     needs: [release, build-sdk-linux]
     if: ${{ !contains(needs.build-sdk-linux.outputs.version, '-') }}
     runs-on: ubuntu-latest
-    environment: pypi
-    permissions:
-      id-token: write
     steps:
-      - name: Download dist artifacts
-        uses: actions/download-artifact@v8
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
         with:
-          name: dist-${{ github.run_number }}
-          path: dist/
-          pattern: dist-*
-          merge-multiple: true
+          python-version: "3.12"
+
+      - name: Build PEP 625-compliant sdist + wheel from source
+        # build-sdk-linux renames canvas_sdk-*.tar.gz to canvas-sdk-* for the GH release.
+        # PyPI requires PEP 625 underscore names, so we rebuild fresh here.
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build src/sdk/ --outdir dist/
+          ls -la dist/
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           skip-existing: true
           packages-dir: dist/
+          password: ${{ secrets.PYPI_API_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Quick-checks + pip caching**: added cleanup workflow and changelog tooling (#92)
 
 ### Fixed
+- **release.yml publish-pypi**: switched from OIDC trusted publishing to API token (`PYPI_API_TOKEN` secret); rebuilt sdist + wheel from `src/sdk/` source inside the publish-pypi job so PyPI gets PEP 625-compliant underscore filenames (the GH-release artifacts are renamed to hyphens for human readability). (#173)
+- **fetch_canvas_data.py**: added `?include[]=teachers` to the `/courses` query so teacher `display_name` fields populate, letting the RMP map at `site/data/rmp.json` actually fill in. (#173)
 - **release.yml publish-pypi action ref**: `pypa/gh-action-pypi-publish@v1` doesn't resolve; use `@release/v1` (the canonical major-version pointer). Surfaced when `publish-pypi` ran on the v1.2.0 release. (#172)
 - **release.yml require-ci result-encoding**: `'escape'` → `'string'` (only `string` or `json` are valid for `actions/github-script@v9`). Latent from #132's overhaul; surfaced on first `v*` tag push. (#171)
 - **Empty-send guard + example-btn color + Ask AI height overflow** (#160, #163)

--- a/docs-site/fetch_canvas_data.py
+++ b/docs-site/fetch_canvas_data.py
@@ -181,8 +181,12 @@ def main():
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    print("Fetching courses...")
-    courses = fetch("/courses", {"enrollment_state": "active", "per_page": "50"})
+    print("Fetching courses (with teachers for RMP lookup)...")
+    courses = fetch("/courses", {
+        "enrollment_state": "active",
+        "per_page": "50",
+        "include[]": "teachers",
+    })
     save(out_dir, "courses.json", clean(courses))
 
     print("Fetching upcoming assignments...")


### PR DESCRIPTION
Two small fixes:

1. **publish-pypi switches to API token auth** — operator added `PYPI_API_TOKEN` secret. Trusted-publisher registration is operator-only and not registered yet, so we use the token path instead. Rebuilds the SDK fresh inside publish-pypi so PyPI gets PEP 625-compliant underscore filenames.

2. **RMP teacher names populate** — `fetch_canvas_data.py` now passes `?include[]=teachers` to the `/courses` query so `teacher.display_name` comes back, letting the RMP downstream actually find names to look up.