### PR TITLE
chore: bump versions to v1.2.1 (publish-pypi token auth + RMP fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.1] — 2026-05-06
+
+### Fixed
+- **publish-pypi**: switched to API token auth (`PYPI_API_TOKEN` secret) and rebuilds SDK from source inside the job for PEP 625-compliant filenames. Fixes the failed publish-pypi step from the v1.2.0 release. (#173)
+- **RMP teacher names** now populate via `?include[]=teachers` on the `/courses` Canvas API call. The pre-fetched `site/data/rmp.json` will fill in starting next pages.yml run. (#173)
+
 ## [1.2.0] — 2026-05-06
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-tui"
-version = "1.2.0"
+version = "1.2.1"
 description = "Canvas LMS TUI client for the CS3704 Canvas project"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -66,14 +66,14 @@ where = ["src"]
 
 [tool.towncrier]
 name = "canvas-tui"
-version = "1.2.0"
+version = "1.2.1"
 directory = "newsfragments"
 filename = "CHANGELOG.md"
 issue_format = "[#{issue}](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/{issue})"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.2.0"
+version = "1.2.1"
 tag_format = "v$version"
 version_source = "commitizen"
 

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-sdk"
-version = "1.2.0"
+version = "1.2.1"
 description = "Canvas LMS Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Patch bump after #173 lands the publish-pypi token-auth fix + RMP teachers fetch. After this merges, push v1.2.1 tag — release.yml will publish to PyPI properly this time.