### PR TITLE
fix(security): Piiranha PII scrub + Space desc corrections + worker scrub

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -62,6 +62,7 @@ jobs:
       - name: Fetch Canvas data snapshot
         env:
           CANVAS_TOKEN: ${{ secrets.CANVAS_API_TOKEN }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
         run: |
           python3 docs-site/fetch_canvas_data.py --out site/data
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.2] — 2026-05-06
+
+### Changed
+- **HF Space description**: removed unverified v7-broken numbers (β=0.1, 181 trajectories, 90.3% reward accuracy); replaced with β=0.3 (per small-N regularization research) and TBD status for trajectory/bench counts pending phase 1/4; links to cited method.html for details. (`hf-space/app.py`)
+- **fetch_canvas_data.py**: upgraded PII scrubbing from regex-only to Piiranha-first with regex fallback. When `HF_TOKEN` is set, strings >20 chars are sent to `iiiorg/piiranha-v1-detect-personal-information` via HF Inference API; 503 warm-up is retried once after 5 s; any error disables Piiranha for the remainder of the run and falls back to existing regex. Self-test extended with Piiranha mock.
+
+### Security
+- **CF Worker `/canvas` PII scrub**: defense-in-depth regex scrub (email, phone, SSN, address) applied to Canvas API JSON responses before returning to caller. Opt out with `?nopiiscrub=1` for SDK consumers that need raw field values. (`proxy/worker.js`)
+
+---
+
 ## [1.2.1] — 2026-05-06
 
 ### Fixed

--- a/docs-site/fetch_canvas_data.py
+++ b/docs-site/fetch_canvas_data.py
@@ -4,7 +4,7 @@ CI script: pre-fetch Canvas API data and save as static JSON for the live demo.
 
 Usage:
   CANVAS_TOKEN=<token> python3 docs-site/fetch_canvas_data.py --out site/data
-  python3 docs-site/fetch_canvas_data.py --self-test   # regex sanity check, no network
+  python3 docs-site/fetch_canvas_data.py --self-test   # regex + Piiranha mock self-test
 
 Output files (all in --out dir):
   courses.json
@@ -16,13 +16,11 @@ Output files (all in --out dir):
   course_<id>_modules.json
   course_<id>_grades.json
 
-PII scrubbing: by default, every payload is run through scrub_recursive() before
-being written to disk. The data baked into site/data/*.json is deployed to a
-PUBLIC GitHub Pages site, so live Canvas content (assignment titles, descriptions,
-announcement bodies, syllabus text) is regex-redacted for emails, phone numbers,
-SSNs, and street addresses. Pass --no-scrub for local debugging only.
-TODO: upgrade to a model-based scrub (e.g. iiiorg/piiranha) if the false-negative
-rate of these regexes becomes a concern.
+PII scrubbing: two-layer approach. When HF_TOKEN is set, strings longer than 20 chars
+are first sent to iiiorg/piiranha-v1-detect-personal-information via the HF Inference
+API. On any error (503 warm-up, 429 rate-limit, timeout) Piiranha is disabled for the
+rest of the run and the regex fallback takes over. Without HF_TOKEN the script falls
+back directly to regex. Pass --no-scrub for local debugging only.
 """
 
 import argparse
@@ -30,6 +28,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.request
 import urllib.error
 import urllib.parse
@@ -37,6 +36,7 @@ from pathlib import Path
 
 CANVAS_BASE = "https://canvas.vt.edu/api/v1"
 TOKEN = os.environ.get("CANVAS_TOKEN") or os.environ.get("CANVAS_API_TOKEN", "")
+HF_TOKEN = os.environ.get("HF_TOKEN", "")
 
 # ── PII scrub ────────────────────────────────────────────────────────────────
 EMAIL_RE = re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b")
@@ -53,6 +53,69 @@ SCRUB_KEYS = {
     "course_name", "short_name", "original_name",
 }
 
+# Module-level flag: set to False if Piiranha returns a non-retryable error
+# during a run, so subsequent strings skip the API and use regex directly.
+_piiranha_available = True
+
+PIIRANHA_URL = (
+    "https://api-inference.huggingface.co/models/"
+    "iiiorg/piiranha-v1-detect-personal-information"
+)
+
+
+def scrub_piiranha(text, hf_token):
+    """Call Piiranha via HF Inference API. Returns redacted text or None on any error."""
+    global _piiranha_available
+    if not _piiranha_available:
+        return None
+    payload = json.dumps({"inputs": text}).encode()
+    req = urllib.request.Request(
+        PIIRANHA_URL,
+        data=payload,
+        headers={
+            "Authorization": f"Bearer {hf_token}",
+            "Content-Type": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=15) as resp:
+            entities = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        if e.code == 503:
+            # Model loading — retry once after 5 s
+            print("  Piiranha: model loading (503), retrying in 5 s…", file=sys.stderr)
+            time.sleep(5)
+            try:
+                with urllib.request.urlopen(req, timeout=15) as resp:
+                    entities = json.loads(resp.read())
+            except Exception as retry_err:
+                print(f"  Piiranha: retry failed ({retry_err}), falling back to regex",
+                      file=sys.stderr)
+                _piiranha_available = False
+                return None
+        else:
+            print(f"  Piiranha: HTTP {e.code}, falling back to regex", file=sys.stderr)
+            _piiranha_available = False
+            return None
+    except Exception as e:
+        print(f"  Piiranha: {e}, falling back to regex", file=sys.stderr)
+        _piiranha_available = False
+        return None
+
+    if not isinstance(entities, list):
+        return None
+
+    # Walk in reverse so offsets remain valid as we splice
+    chars = list(text)
+    for ent in sorted(entities, key=lambda x: x.get("start", 0), reverse=True):
+        start = ent.get("start")
+        end = ent.get("end")
+        group = ent.get("entity_group", "PII")
+        if start is None or end is None:
+            continue
+        chars[start:end] = list(f"[{group}]")
+    return "".join(chars)
+
 
 def scrub(text):
     if not isinstance(text, str):
@@ -64,12 +127,21 @@ def scrub(text):
     return text
 
 
+def scrub_string(text):
+    """Scrub a single string: Piiranha-first (if HF_TOKEN set), regex fallback."""
+    if HF_TOKEN and len(text) > 20:
+        result = scrub_piiranha(text, HF_TOKEN)
+        if result is not None:
+            return result
+    return scrub(text)
+
+
 def scrub_recursive(obj, target_keys=SCRUB_KEYS):
     if isinstance(obj, dict):
         out = {}
         for k, v in obj.items():
             if k in target_keys and isinstance(v, str):
-                out[k] = scrub(v)
+                out[k] = scrub_string(v)
             else:
                 out[k] = scrub_recursive(v, target_keys)
         return out
@@ -77,7 +149,7 @@ def scrub_recursive(obj, target_keys=SCRUB_KEYS):
         return [scrub_recursive(x, target_keys) for x in obj]
     if isinstance(obj, str):
         # belt-and-braces: catch PII anywhere, even outside whitelisted keys
-        return scrub(obj)
+        return scrub_string(obj)
     return obj
 
 
@@ -138,6 +210,10 @@ def collect_teachers(courses):
 
 
 def self_test():
+    import io
+    from unittest.mock import patch, MagicMock
+
+    # ── regex path ────────────────────────────────────────────────────────────
     sample = {
         "name": "Email Prof at jane@vt.edu about HW",
         "description": "Call 540-555-1234 or visit 123 Main Street",
@@ -152,7 +228,29 @@ def self_test():
     assert "[SSN]" in cleaned["courses"][0]["description"], cleaned
     assert "[EMAIL]" in cleaned["nested"]["body"], cleaned
     assert "[PHONE]" in cleaned["nested"]["body"], cleaned
-    print("scrub self-test PASSED")
+    print("scrub self-test (regex) PASSED")
+
+    # ── Piiranha mock path ────────────────────────────────────────────────────
+    # Simulate Piiranha returning entity spans for "Hello jane@vt.edu end"
+    # start=6, end=18 covers "jane@vt.edu"
+    fake_entities = [{"entity_group": "EMAIL", "score": 0.99, "word": "jane@vt.edu",
+                      "start": 6, "end": 17}]
+    fake_response = io.BytesIO(json.dumps(fake_entities).encode())
+    mock_cm = MagicMock()
+    mock_cm.__enter__ = MagicMock(return_value=mock_cm)
+    mock_cm.__exit__ = MagicMock(return_value=False)
+    mock_cm.read = MagicMock(return_value=json.dumps(fake_entities).encode())
+
+    global _piiranha_available
+    _piiranha_available = True  # reset in case a prior test tripped it
+
+    with patch("urllib.request.urlopen", return_value=mock_cm):
+        result = scrub_piiranha("Hello jane@vt.edu end", "fake-token")
+
+    assert result is not None, "scrub_piiranha returned None with mock"
+    assert "jane@vt.edu" not in result, f"PII not redacted: {result!r}"
+    assert "[EMAIL]" in result, f"Expected [EMAIL] tag: {result!r}"
+    print("scrub self-test (Piiranha mock) PASSED")
 
 
 def main():

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -562,7 +562,7 @@ button.example-btn:hover { border-color: #d63e36 !important; background: #1f1010
 """
 
 DESCRIPTION_MD = """
-Fine-tuned **Gemma-4-E2B-IT** (DPO · β=0.1 · 181 trajectories · 90.3% reward accuracy) — speaks the native Gemma-4 tool protocol for **18 tools** across 4 families:
+Fine-tuned **Gemma-4-E2B-IT** with DPO (β=0.3, small-N regularization). Speaks the native Gemma-4 tool protocol for **18 tools** across 4 families. _Trajectory counts and bench scores are TBD post-phase-1/4; numbers shown in v7-broken artifacts are pre-rebuild and not verified. See [How it Works](https://kleinpanic.github.io/CS3704-Canvas-Project/agent-demo/method.html) for the cited methodology._
 
 `canvas.*` assignments · grades · syllabi · planner &nbsp;|&nbsp; `calendar.*` scheduling · free blocks &nbsp;|&nbsp; `reranker.*` priority hints &nbsp;|&nbsp; `study.*` exam prep · spaced repetition
 

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -64,6 +64,12 @@ Request body:
 - `method` defaults to `GET`; allowed values: GET, POST, PUT, PATCH, DELETE
 - `body` is optional; serialized size capped at 4000 chars
 - Canvas's HTTP status code is forwarded as-is (401, 404, etc.)
+- By default the response JSON is scrubbed for PII (emails, phone numbers, SSNs,
+  street addresses) before being returned to the caller. This is defense-in-depth —
+  the live demo does not currently route through this path, but if it ever does,
+  PII won't leak.
+- Append `?nopiiscrub=1` to opt out of scrubbing if you need raw field values
+  (e.g. an extension author building their own UI that displays full names).
 
 ```bash
 curl -X POST https://cs3704-demo-proxy.kleinpanic.workers.dev/canvas \

--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -12,6 +12,33 @@
  * No tokens are ever exposed to the browser.
  */
 
+// Defense-in-depth PII scrub for Canvas API responses. The live demo does not
+// currently route through /canvas, but if it ever does, PII won't leak.
+// SDK consumers who need raw passthrough can opt out with ?nopiiscrub=1.
+const _EMAIL_RE = /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g;
+const _PHONE_RE = /\b(?:\+?1[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}\b/g;
+const _SSN_RE   = /\b\d{3}-\d{2}-\d{4}\b/g;
+const _ADDR_RE  = /\b\d{1,5}\s+[A-Z][A-Za-z]+(?:\s+[A-Z][A-Za-z]+)*\s+(?:Street|St|Avenue|Ave|Road|Rd|Boulevard|Blvd|Drive|Dr|Court|Ct|Lane|Ln)\b/g;
+
+function scrubString(s) {
+  return s
+    .replace(_SSN_RE,   '[SSN]')
+    .replace(_EMAIL_RE, '[EMAIL]')
+    .replace(_PHONE_RE, '[PHONE]')
+    .replace(_ADDR_RE,  '[ADDRESS]');
+}
+
+function scrubJson(obj) {
+  if (typeof obj === 'string') return scrubString(obj);
+  if (Array.isArray(obj)) return obj.map(scrubJson);
+  if (obj !== null && typeof obj === 'object') {
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) out[k] = scrubJson(v);
+    return out;
+  }
+  return obj;
+}
+
 const SPACE_BASE = 'https://kleinpanic93-canvas-calendar-agent-demo.hf.space';
 const ALLOWED_ORIGINS = [
   'https://kleinpanic.github.io',
@@ -134,6 +161,8 @@ async function handleCanvas(request, env, cors) {
     });
   }
 
+  const noPiiScrub = new URL(request.url).searchParams.get('nopiiscrub') === '1';
+
   let body;
   try { body = await request.json(); }
   catch (_) {
@@ -178,14 +207,22 @@ async function handleCanvas(request, env, cors) {
   }
 
   const upstream = await fetch(`${CANVAS_BASE}${endpoint}`, fetchInit);
-  const upstreamBody = await upstream.text();
+  const upstreamText = await upstream.text();
+  const contentType = upstream.headers.get('Content-Type') || 'application/json';
 
-  return new Response(upstreamBody, {
+  let responseBody = upstreamText;
+  if (!noPiiScrub && upstream.ok && contentType.includes('application/json')) {
+    try {
+      const parsed = JSON.parse(upstreamText);
+      responseBody = JSON.stringify(scrubJson(parsed));
+    } catch (_) {
+      // Non-parseable body — pass through as-is
+    }
+  }
+
+  return new Response(responseBody, {
     status: upstream.status,
-    headers: {
-      'Content-Type': upstream.headers.get('Content-Type') || 'application/json',
-      ...cors,
-    },
+    headers: { 'Content-Type': contentType, ...cors },
   });
 }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-tui"
-version = "1.2.1"
+version = "1.2.2"
 description = "Canvas LMS TUI client for the CS3704 Canvas project"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -66,14 +66,14 @@ where = ["src"]
 
 [tool.towncrier]
 name = "canvas-tui"
-version = "1.2.1"
+version = "1.2.2"
 directory = "newsfragments"
 filename = "CHANGELOG.md"
 issue_format = "[#{issue}](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/{issue})"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.2.1"
+version = "1.2.2"
 tag_format = "v$version"
 version_source = "commitizen"
 

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-sdk"
-version = "1.2.1"
+version = "1.2.2"
 description = "Canvas LMS Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- **fetch_canvas_data.py**: Piiranha-first PII detection via HF Inference API, regex fallback on any error (503 warm-up retried once after 5 s, then module-level fallback for rest of run). `HF_TOKEN` env wired in `pages.yml`. Self-test extended with `unittest.mock` stub.
- **hf-space/app.py**: Removed unverified v7-broken numbers from Space description (β=0.1→β=0.3 per small-N regularization research; dropped 181-trajectory and 90.3%-accuracy claims as pre-rebuild artifacts; links to cited `method.html`).
- **proxy/worker.js**: Defense-in-depth regex PII scrub on `/canvas` JSON responses before returning to caller. `?nopiiscrub=1` opt-out for SDK consumers needing raw passthrough. Documented in `proxy/README.md`.
- Version bumped to **1.2.2** (`pyproject.toml` ×3, `src/sdk/pyproject.toml`).

## Test plan

- [x] `python3 docs-site/fetch_canvas_data.py --self-test` — both regex and Piiranha mock paths pass
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pages.yml'))"` — YAML valid
- [x] `node --check proxy/worker.js` — JS syntax valid
- [ ] CI green (Test, Python Compat 3.11/12/13, conventional-title, changelog-required, size-check, version-check)
- [ ] After merge: tag `v1.2.2`, watch `release.yml` publish `canvas-sdk 1.2.2` to PyPI
- [ ] Verify `HF_TOKEN` GH Actions secret exists (if absent, Piiranha silently degrades to regex — functionally correct but worth confirming)