### PR TITLE
fix(ci): restore environment: pypi on publish-pypi + bump v1.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -376,6 +376,9 @@ jobs:
     needs: [release, build-sdk-linux]
     if: ${{ !contains(needs.build-sdk-linux.outputs.version, '-') }}
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/canvas-sdk/${{ needs.build-sdk-linux.outputs.version }}/
     steps:
       - uses: actions/checkout@v4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] — 2026-05-06
+
+### Fixed
+- **release.yml publish-pypi `environment: pypi`** restored. PR #173 dropped it when switching from OIDC trusted publishing to API-token auth, so v1.2.1/v1.2.2 never registered as `pypi` environment deployments. The repo sidebar stayed pinned to the failed v1.2.0 deployment record. (#176)
+
 ## [1.2.2] — 2026-05-06
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-tui"
-version = "1.2.2"
+version = "1.2.3"
 description = "Canvas LMS TUI client for the CS3704 Canvas project"
 readme = "README.md"
 license = "GPL-3.0-or-later"
@@ -66,14 +66,14 @@ where = ["src"]
 
 [tool.towncrier]
 name = "canvas-tui"
-version = "1.2.2"
+version = "1.2.3"
 directory = "newsfragments"
 filename = "CHANGELOG.md"
 issue_format = "[#{issue}](https://github.com/kleinpanic/CS3704-Canvas-Project/issues/{issue})"
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "1.2.2"
+version = "1.2.3"
 tag_format = "v$version"
 version_source = "commitizen"
 

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-sdk"
-version = "1.2.2"
+version = "1.2.3"
 description = "Canvas LMS Python SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
PR #173 dropped `environment: pypi` when switching to API-token auth. Result: v1.2.1/v1.2.2 never registered pypi deployments → repo sidebar stayed pinned to the failed v1.2.0 record. Old failed record already deleted via API. This restores the line + bumps to v1.2.3 to fire a fresh successful deployment.