### PR TITLE
fix(ci): pages graceful skip on missing CANVAS_BASE_URL + README broken image

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -61,8 +61,11 @@ jobs:
       # CANVAS_TOKEN secret). The build-time snapshot fetch below still uses the GHA
       # secret until fetch_canvas_data.py is moved behind the Worker.
 
-      # PII scrub regex sanity check -- fail the build if regexes regress
+      # PII scrub regex sanity check -- fail the build if regexes regress.
+      # Self-test does no live HTTP; CANVAS_BASE_URL just satisfies the env-required check.
       - name: PII scrub self-test
+        env:
+          CANVAS_BASE_URL: ${{ secrets.CANVAS_BASE_URL || 'https://canvas.example.edu' }}
         run: |
           python3 docs-site/fetch_canvas_data.py --self-test
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       HAS_CANVAS_TOKEN: ${{ secrets.CANVAS_API_TOKEN != '' }}
+      HAS_CANVAS_BASE_URL: ${{ secrets.CANVAS_BASE_URL != '' }}
       HAS_HF_TOKEN: ${{ secrets.HF_TOKEN != '' }}
     steps:
       - name: Harden runner
@@ -69,15 +70,28 @@ jobs:
         run: |
           python3 docs-site/fetch_canvas_data.py --self-test
 
-      # Pre-fetch live Canvas data and bake as static JSON (PII-scrubbed)
+      # Pre-fetch live Canvas data and bake as static JSON (PII-scrubbed).
+      # Skip gracefully when CANVAS_BASE_URL secret is unset (forks; or maintainer
+      # hasn't configured it yet). The site still publishes; data is just static.
       - name: Fetch Canvas data snapshot
-        if: ${{ env.HAS_CANVAS_TOKEN == 'true' }}
+        if: ${{ env.HAS_CANVAS_TOKEN == 'true' && env.HAS_CANVAS_BASE_URL == 'true' }}
         env:
           CANVAS_TOKEN: ${{ secrets.CANVAS_API_TOKEN }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           CANVAS_BASE_URL: ${{ secrets.CANVAS_BASE_URL }}
+          HAS_CANVAS_BASE_URL: ${{ secrets.CANVAS_BASE_URL != '' }}
         run: |
           python3 docs-site/fetch_canvas_data.py --out site/data
+
+      - name: Skip notice (CANVAS_BASE_URL secret unset)
+        if: ${{ env.HAS_CANVAS_TOKEN == 'true' }}
+        env:
+          HAS_CANVAS_BASE_URL: ${{ secrets.CANVAS_BASE_URL != '' }}
+        run: |
+          if [ "$HAS_CANVAS_BASE_URL" != "true" ]; then
+            echo "CANVAS_BASE_URL secret not configured -- skipping live fetch."
+            echo "Set it in repo Settings -> Secrets -> Actions to enable live data."
+          fi
 
       - name: Skip notice (fork - no CANVAS_API_TOKEN)
         if: ${{ env.HAS_CANVAS_TOKEN != 'true' }}

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A maintainable, team-ready **Canvas LMS productivity client** with a Textual TUI
 <!-- asciinema cast: docs-site/casts/tui-demo.cast -->
 <!-- TODO: record cast with `asciinema rec docs-site/casts/tui-demo.cast` + upload to asciinema.org -->
 <!-- Static screenshot fallback: -->
-![TUI demo](docs-site/screenshots/01-home-live.png)
+![TUI demo](docs-site/screenshots/10-final-home.png)
 
 | Deploy | Link |
 |--------|------|


### PR DESCRIPTION
Fixes two regressions hitting main after v2.0:
1. Pages build hard-fails on `Fetch Canvas data snapshot` because Phase 5 made `CANVAS_BASE_URL` required at module import, but the repo secret was never configured. Adds graceful skip + maintainer notice.
2. README hero image references untracked `01-home-live.png` (broken `?` icon on GitHub). Swap to tracked `10-final-home.png`.