### PR TITLE
fix(hf-space): gr.Examples(elem_classes=) bug + HF_TOKEN propagation to both Spaces

### DIFF
--- a/.github/workflows/deploy-hf-space.yml
+++ b/.github/workflows/deploy-hf-space.yml
@@ -41,6 +41,24 @@ jobs:
             --repo-type space \
             --commit-message "deploy: ${{ github.sha }}"
 
+      - name: Propagate HF_TOKEN as Space runtime secret
+        if: ${{ env.HAS_HF_TOKEN == 'true' }}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from huggingface_hub import HfApi
+          api = HfApi()
+          api.add_space_secret(
+              repo_id="kleinpanic93/canvas-calendar-agent-demo",
+              key="HF_TOKEN",
+              value=os.environ["HF_TOKEN"],
+              description="Inherited from GH repo secret via deploy-hf-space.yml; enables authenticated downloads + faster rate limits",
+          )
+          print("HF_TOKEN propagated to Space runtime secrets")
+          PY
+
       - name: Skip notice (fork - no HF_TOKEN)
         if: ${{ env.HAS_HF_TOKEN != 'true' }}
         run: |

--- a/.github/workflows/deploy-pii-space.yml
+++ b/.github/workflows/deploy-pii-space.yml
@@ -36,6 +36,24 @@ jobs:
             --repo-type space \
             --commit-message "deploy: $GIT_SHA"
 
+      - name: Propagate HF_TOKEN as Space runtime secret
+        if: ${{ env.HAS_HF_TOKEN == 'true' }}
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: |
+          python3 - <<'PY'
+          import os
+          from huggingface_hub import HfApi
+          api = HfApi()
+          api.add_space_secret(
+              repo_id="kleinpanic93/canvas-pii-scrub",
+              key="HF_TOKEN",
+              value=os.environ["HF_TOKEN"],
+              description="Inherited from GH repo secret via deploy-pii-space.yml",
+          )
+          print("HF_TOKEN propagated to Space runtime secrets")
+          PY
+
       - name: Fork notice (no HF_TOKEN)
         if: ${{ env.HAS_HF_TOKEN != 'true' }}
         run: |

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -835,7 +835,6 @@ with gr.Blocks(theme=THEME, css=CUSTOM_CSS, title="Canvas Calendar Agent") as de
         run_on_click=True,
         cache_examples=False,
         label="Try one of the 18 tools — click to auto-submit",
-        elem_classes=["example-btn"],
     )
 
     # Wire send button + Enter-key submit. Outputs order MUST match chat_stream() yield:


### PR DESCRIPTION
Two real fixes:
1. `hf-space/app.py:838` passed `elem_classes=['example-btn']` to `gr.Examples()` — rejected by current gradio version (`TypeError: create_examples() got an unexpected keyword argument 'elem_classes'`). Space has been in RUNTIME_ERROR since v2.0 Phase 7 shipped. PR #190 smoke-test fix will catch this on future deploys.
2. Both deploy workflows now propagate `HF_TOKEN` from GH repo secrets into the Space's runtime secrets via `HfApi.add_space_secret()`. Fixes 'unauthenticated requests' warnings + faster downloads. Establishes the canonical GH-secret -> HF-Space-secret bridge pattern for any future HF Space added to this repo.