### PR TITLE
fix(security): bump pii-space deps + sanitize worker error responses

### DIFF
--- a/hf-space-pii/requirements.txt
+++ b/hf-space-pii/requirements.txt
@@ -1,7 +1,7 @@
 # pinned: transformers model API stability — avoid git-HEAD breakage (see hf-space/requirements.txt)
-transformers==4.47.1
+transformers==4.48.0
 # pinned: CPU-only wheel keeps image under 3 GB on HF Spaces CPU Basic
-torch==2.5.1+cpu
+torch==2.6.0+cpu
 # pinned: FastAPI + Uvicorn for HTTP layer
 fastapi==0.115.6
 uvicorn==0.32.1

--- a/proxy/worker.js
+++ b/proxy/worker.js
@@ -145,7 +145,10 @@ async function handleChat(request, env, cors) {
       headers: { 'Content-Type': 'application/json', ...cors },
     });
   } catch (err) {
-    return new Response(JSON.stringify({ error: String(err.message || err) }), {
+    // CodeQL: don't expose raw error messages (potential stack-trace exposure).
+    // Log internally; return a generic 502 to clients.
+    console.error('handleChat error:', err);
+    return new Response(JSON.stringify({ error: 'Upstream Space error' }), {
       status: 502,
       headers: { 'Content-Type': 'application/json', ...cors },
     });


### PR DESCRIPTION
Closes critical CVEs (torch.load RCE, transformers untrusted-data deserialization) on the PII Space requirements + closes CodeQL js/stack-trace-exposure in proxy/worker.js. Other alerts on older manifest snapshots resolve on next dependabot scan.