### PR TITLE
fix(hf-space): unblock HF Space builds broken by Phase 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 9 stale Dependabot alerts dismissed as `tolerable_risk` (8 against zombie bare `requirements.txt` path, 1 with no upstream fix).
 - `.github/workflows/docker.yml` build-push job: `contents: read` added (was implicitly `none` after job-level perm narrowing — broke `actions/checkout`).
 
+### Fixed — v2.1 Phase 2 hot-fix (post-merge regressions)
+
+- `hf-space-pii/Dockerfile`: HF Spaces' build parser rejected `FROM image@sha256:DIGEST  # tag-comment` with "FROM requires either one or three arguments". Standard `docker build` is lenient; HF's buildkit treats the inline comment as extra arguments. Fix: move `# tag:` comment to its own line above FROM. Same defensive fix applied to `docker/canvas-tui/Dockerfile`.
+- `hf-space/README.md`: bumped `sdk_version: 5.7.1` → `6.7.0` to resolve gradio resolver conflict between HF's pre-baked `gradio[oauth]==5.7.1` and our `gradio>=6.7.0` floor in `requirements.txt`.
+
 ### Notes
 
 - SCORECARD_READ_TOKEN repo secret created out-of-band 2026-05-07T04:09:55Z; should be rotated post-merge (was pasted in plaintext during a prior orchestration session).

--- a/docker/canvas-tui/Dockerfile
+++ b/docker/canvas-tui/Dockerfile
@@ -1,5 +1,6 @@
 # Usage: docker run -e CANVAS_TOKEN=xxx -e CANVAS_BASE_URL=https://canvas.vt.edu ghcr.io/kleinpanic/canvas-tui
-FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3  # 3.12-slim
+# tag: python:3.12-slim
+FROM python:3.12-slim@sha256:46cb7cc2877e60fbd5e21a9ae6115c30ace7a077b9f8772da879e4590c18c2e3
 
 RUN apt-get update \
     && apt-get install --no-install-recommends -y libsqlite3-dev \

--- a/hf-space-pii/Dockerfile
+++ b/hf-space-pii/Dockerfile
@@ -1,4 +1,5 @@
-FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2  # 3.11-slim
+# tag: python:3.11-slim
+FROM python:3.11-slim@sha256:6d85378d88a19cd4d76079817532d62232be95757cb45945a99fec8e8084b9c2
 
 WORKDIR /app
 

--- a/hf-space/README.md
+++ b/hf-space/README.md
@@ -4,7 +4,7 @@ emoji: 📚
 colorFrom: red
 colorTo: gray
 sdk: gradio
-sdk_version: 5.7.1
+sdk_version: 6.7.0
 python_version: "3.11"
 app_file: app.py
 pinned: false


### PR DESCRIPTION
## Summary

Two regressions from PR #194 (Phase 2 OSSF Scorecard lift) surfaced post-merge in HF Space build logs. Hot-fix.

## Bugs fixed

**(1) `hf-space-pii` (canvas-pii-scrub) Dockerfile parse error**

Phase 2 Plan 03 wrote:
\`\`\`dockerfile
FROM python:3.11-slim@sha256:6d85378d...  # 3.11-slim
\`\`\`

HF Spaces' build parser rejects this with \`FROM requires either one or three arguments\` — the inline tag comment is parsed as extra args, not as a comment. Standard \`docker build\` is lenient here; HF's buildkit is stricter.

Fix: move \`# tag:\` comment to its own line above FROM. Same defensive fix applied to \`docker/canvas-tui/Dockerfile\` even though canvas-tui's Dockerfile is built by docker.yml (standard \`docker build\`, never failed) — keeps the pattern consistent for any future cross-builder use.

**(2) \`hf-space\` (canvas-calendar-agent-demo) gradio version conflict**

Phase 2 Plan 04 bumped \`hf-space/requirements.txt\` to \`gradio>=6.7.0\` (closes GHSA-39mp-8hj3-5c49 path-traversal CVE) but did NOT update \`hf-space/README.md\` frontmatter, which still pinned \`sdk_version: 5.7.1\`. HF Spaces uses sdk_version to bake \`gradio[oauth]==5.7.1\` into the base image — pip then sees both pins and the resolver explodes:

\`\`\`
ERROR: Cannot install gradio==5.7.1 and gradio>=6.7.0 because these package versions have conflicting dependencies.
\`\`\`

Fix: bump README.md frontmatter \`sdk_version: 5.7.1\` → \`6.7.0\`. gradio 6.7.0 is on PyPI (latest is 6.14.0).

## Why the audit chain missed this

The 3-audit chain (gsd-code-reviewer + gsd-security-auditor + gsd-verifier) on PR #194 verified Phase 2 changes against:
- The project's CI required-status-checks (those passed)
- OSSF Scorecard threat-mitigation evidence (those passed)
- Goal-backward score projection (passed: project to 5.9-6.5)

It did NOT verify the resulting HF Space *builds* because:
1. HF Space builds run on HF's infrastructure, not in GitHub Actions
2. \`deploy-hf-space.yml\` returns success on \`push\` (the deploy succeeds) but doesn't wait for HF to build or smoke-test the resulting Space
3. PR #190 added a "polls until RUNNING" smoke test, but it runs on \`workflow_dispatch\` against an existing Space — not against a fresh build

This is the gap the user flagged and is what Phase 6 (CI consolidation) + Phase 14 (HF Deploy hardening) need to close. Both phases now have SPECs that reference this gap. Tracked.

## Test plan

- [ ] All required CI status checks pass (Branch Name Policy, OSSF Scorecard Score Gate, changelog-required, plus 9 standard required checks)
- [ ] Post-merge: \`deploy-pii-space.yml\` re-runs and HF builds canvas-pii-scrub successfully (no FROM parse error)
- [ ] Post-merge: \`deploy-hf-space.yml\` re-runs and HF builds canvas-calendar-agent-demo successfully (no gradio resolver conflict)
- [ ] Both Spaces reach RUNNING status post-build
- [ ] HF_TOKEN propagation verified (PR #191 already shipped)

## Follow-ups (not in this PR)

- Phase 6 SPEC adds harden-runner + workflow_dispatch + concurrency fallback to dataset-validation.yml + scorecard.yml. Will not touch HF deploy workflows directly.
- Phase 14 SPEC includes "Post-deploy smoke test that the Space is RUNNING (extends PR #190 pattern)" — this is the right home for the gap-closure.
- Considering integrating Claude Code GitHub Actions (https://code.claude.com/docs/en/github-actions) for AI-driven CI checks; researching now.