### PR TITLE
fix(hf-space): remove deprecated gr.Chatbot type=messages (gradio 6.x runtime fix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **New `tools/check-repo-org.sh` warning hook:** 4 checks against repo top-level structure (entries off ALLOWLIST, root `*.md` unjustified, Dockerfile outside `docker/` + `hf-space*/`, `pyproject.toml` outside `src/sdk/` + repo root). Registered in `.pre-commit-config.yaml`. **WARNING MODE** — prints to stderr, always exits 0. Promotes to blocking after one milestone of stable usage.
 - **PR template (`.github/pull_request_template.md`):** new "Repo Org Compliance" checklist section makes ALLOWLIST + repo-org-warn expectations explicit at PR-open time.
 
+### Fixed — v2.1 Phase 4 hot-fix (live demo runtime regression)
+
+- `hf-space/app.py`: removed `type="messages"` from `gr.Chatbot(...)`. The Space build succeeded after the prior hot-fix (sdk_version + Dockerfile fixes) but crashed at startup because gradio 6.x removed the `type=` keyword (messages format is now default). Verified by reproducing the failure in a fresh venv with `gradio==6.7.0`.
+
 ## [2.0.0] - 2026-05-06
 
 ### Public-Contribution Hardening — 12-phase milestone

--- a/hf-space/app.py
+++ b/hf-space/app.py
@@ -783,7 +783,8 @@ with gr.Blocks(theme=THEME, css=CUSTOM_CSS, title="Canvas Calendar Agent") as de
             </div>
             """)
             chatbot = gr.Chatbot(
-                type="messages",
+                # gradio 6.x: `type="messages"` is the default and the keyword
+                # was removed. Specifying it crashes the Space at startup.
                 height=440,
                 show_label=False,
                 avatar_images=None,


### PR DESCRIPTION
## Summary

Live demo (canvas-calendar-agent-demo) was reaching **RUNTIME_ERROR** after the prior hot-fix (PR #195) unblocked the build. Cause: gradio 6.x removed the \`type="messages"\` keyword from \`gr.Chatbot.__init__\` — startup crashes with \`TypeError\`.

One-line fix in \`hf-space/app.py\`: remove the now-deprecated keyword. The messages format is the default in 6.x.

## Reproduction

\`\`\`
pip install gradio==6.7.0
python -c "import gradio as gr; gr.Chatbot(type='messages', height=440)"
# TypeError: Chatbot.__init__() got an unexpected keyword argument 'type'
\`\`\`

## Verification

In a fresh venv with \`gradio==6.7.0\` I tested every gradio API surface app.py uses:
- \`Chatbot\` (no \`type\`): OK
- \`Examples\`, \`Markdown(elem_classes)\`, \`Textbox\`, \`Button\`, \`HTML\`, \`Row(elem_classes)\`, \`Column(scale)\`, \`State\`, \`Blocks\`, \`themes.Monochrome\`, \`themes.GoogleFont\`: all OK

No other 6.x deprecations in this app.

## Why the Phase 4 audit chain didn't catch this

Same root cause as the previous HF Space gap (PR #195 PR body): HF Space builds + runtime happen on HF infra, our CI doesn't simulate them. Phase 14 SPEC (already pre-drafted) adds:
- \`hf-space-build-check.yml\`: runs \`docker build\` + dependency-resolution check on PRs touching \`hf-space/\` or \`hf-space-pii/\`
- \`tools/check-hf-space-config.py\`: validates README.md frontmatter \`sdk_version\` consistency with \`requirements.txt\` floors

Plus Claude Code GitHub Actions integration to catch this class of "build succeeds but runtime fails" gap. None of that has shipped yet — Phase 14 is still 9th in execution order.

## Test plan

- [ ] All required CI checks pass
- [ ] Post-merge: \`deploy-hf-space.yml\` re-runs and the smoke test reaches HF Space \`RUNNING\`
- [ ] Manual: visit https://kleinpanic93-canvas-calendar-agent-demo.hf.space/ — should load (was 503 + RUNTIME_ERROR)