### PR TITLE
fix(pii-scrub): drop BIO prefix from label sets (silent no-op pre-existing bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `hf-space/app.py`: removed `type="messages"` from `gr.Chatbot(...)`. The Space build succeeded after the prior hot-fix (sdk_version + Dockerfile fixes) but crashed at startup because gradio 6.x removed the `type=` keyword (messages format is now default). Verified by reproducing the failure in a fresh venv with `gradio==6.7.0`.
 
+### Fixed — v2.1 pii-scrub silent-no-op regression (pre-existing)
+
+- `hf-space-pii/app.py`: `_PERSON_LABELS` and `_LOC_LABELS` were checking for BIO-prefixed labels (`I-GIVENNAME`, `I-CITY`, etc.) but the model is loaded with `aggregation_strategy="simple"`, which collapses spans and drops the BIO prefix. The model returns `entity_group: "EMAIL"`, `"USERNAME"`, `"GIVENNAME"` etc. — never `"I-..."`. Result: `/scrub` always returned the input unchanged with `redactions: []` and `registry: {}` — a silent no-op for every request. `/entities` was unaffected (it returns the raw entity list without label-set filtering). Live-verified by hitting `/scrub` against `https://kleinpanic93-canvas-pii-scrub.hf.space/`. Fix: drop `I-` prefix from both label sets and add `EMAIL` to person-class.
+
 ## [2.0.0] - 2026-05-06
 
 ### Public-Contribution Hardening — 12-phase milestone

--- a/hf-space-pii/app.py
+++ b/hf-space-pii/app.py
@@ -40,8 +40,14 @@ except Exception as _load_err:
 # Label maps and target fields — copied from anon_worker_piiranha.py
 # ---------------------------------------------------------------------------
 
-_PERSON_LABELS = {"I-GIVENNAME", "I-SURNAME", "I-USERNAME"}
-_LOC_LABELS = {"I-CITY", "I-STREET", "I-BUILDINGNUM", "I-ZIPCODE"}
+# Piiranha is loaded with `aggregation_strategy="simple"`, which collapses
+# adjacent same-class tokens AND DROPS the BIO prefix from `entity_group`.
+# Live verification: POST /entities returns `entity_group: "EMAIL"`, "USERNAME"
+# etc. — NOT "I-EMAIL" / "I-USERNAME". The previous I- prefix in these sets
+# meant /scrub never matched any entity → silent no-op (registry={}).
+# Adding EMAIL to person-class so emails get @PERSON_N tokenized too.
+_PERSON_LABELS = {"GIVENNAME", "SURNAME", "USERNAME", "EMAIL"}
+_LOC_LABELS = {"CITY", "STREET", "BUILDINGNUM", "ZIPCODE"}
 
 _TARGET_FIELDS = {"content", "text", "final_answer"}
 


### PR DESCRIPTION
## Summary

User-flagged: live demo regression. Live usability probe of canvas-pii-scrub revealed `/scrub` returns every input UNCHANGED with `redactions: []` and `registry: {}` — silent no-op on every request.

## Reproduction (pre-fix, against current main)

\`\`\`
$ curl -s -X POST https://kleinpanic93-canvas-pii-scrub.hf.space/scrub \\
    -H "Content-Type: application/json" \\
    -d '{"document":{"content":"My name is Alice Johnson and my email is alice.johnson@vt.edu and my phone is 540-231-1234. My TA is Bob Smith."}}'
{
  "document": {"content": "My name is Alice Johnson and my email is alice.johnson@vt.edu and my phone is 540-231-1234. My TA is Bob Smith."},
  "redactions": [],
  "registry": {}
}
\`\`\`

## Root cause

\`hf-space-pii/app.py\` lines 43-44 (pre-fix):

\`\`\`python
_PERSON_LABELS = {"I-GIVENNAME", "I-SURNAME", "I-USERNAME"}
_LOC_LABELS = {"I-CITY", "I-STREET", "I-BUILDINGNUM", "I-ZIPCODE"}
\`\`\`

Piiranha model is loaded with \`aggregation_strategy="simple"\`. That strategy **collapses adjacent same-class tokens AND drops the BIO prefix** from \`entity_group\`. The model returns \`entity_group: "EMAIL"\`, \`"USERNAME"\` etc. — NEVER \`"I-..."\`.

Live evidence via \`/entities\` (which is unaffected — uses raw entity list):

\`\`\`
$ curl -s -X POST https://kleinpanic93-canvas-pii-scrub.hf.space/entities \\
    -d '{"inputs":"My name is Alice Johnson and my email is alice.johnson@vt.edu"}'
[{"entity_group":"EMAIL","score":0.78,...}, {"entity_group":"USERNAME","score":0.49,...}, ...]
\`\`\`

Note: \`entity_group: "EMAIL"\`, NOT \`"I-EMAIL"\`. Every output was being filtered out by \`if label in _PERSON_LABELS\` (false).

## Fix

Drop \`I-\` prefix from both sets. Also add \`EMAIL\` to person-class — emails were missing entirely from both sets even after the prefix fix.

\`\`\`python
_PERSON_LABELS = {"GIVENNAME", "SURNAME", "USERNAME", "EMAIL"}
_LOC_LABELS = {"CITY", "STREET", "BUILDINGNUM", "ZIPCODE"}
\`\`\`

## Pre-existing scope

This bug is **older than Phase 2**. Older than v2.0. The Space has been silent-no-op'ing since first deploy. The local \`share_my_canvas.py --inspect\` regression test against \`Williammm23.jsonl\` did not surface it because that harness tests the LOCAL anon logic directly via raw entity-list iteration, not the HF Space's \`_PERSON_LABELS\` filter path.

## Test plan

- [ ] All required CI checks pass
- [ ] Post-merge: \`deploy-pii-space.yml\` re-runs and HF rebuilds the Space
- [ ] Manual probe POST /scrub returns \`redactions\` non-empty + \`registry\` populated for the test payload above
- [ ] Manual probe with \`{"document":{"content":"@COURSE_X has TA Bob Smith"}}\` correctly scrubs Bob Smith but not @COURSE_X