### PR TITLE
feat(pii-scrub): regex fallback layer for phone + name (Piiranha v1 gaps)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Bumped `transformers >= 4.53.0` and `torch >= 2.8.0` across `requirements.txt`, `hf-space/requirements.txt`, and `hf-space-pii/requirements.txt`. Closes ~26 of the 28 open MEDIUM-severity Dependabot alerts (multiple CVEs in transformers 4.4x and torch 2.6.x). Phase 2 hardening closed all critical+high; this closes the medium-severity tail. Some lows remain (RC versions only — `5.0.0rc3` and `2.7.1-rc1` — not pinning to RCs).
 
+### Improved — pii-scrub regex fallback layer (catches Piiranha v1 gaps)
+
+- `hf-space-pii/app.py`: added regex fallback layer for phone numbers and Title-Case person-name patterns. Piiranha v1 has known recall gaps on conversational sentences (e.g., misses "Alice Johnson" entirely; mis-labels "Bob Smith" as CITY). Regex fallback runs alongside the model's entity extraction; results are deduplicated against model entities (overlap-skip). Phone-number regex covers US formats: 540-231-1234, (540) 231-1234, +1-540-231-1234, 540.231.1234, 5402311234. Name regex catches Title-Case First+Last with stopwords for months, days, courses, and common false positives. Both add `@PERSON_N` tokens to the existing registry.
+
 ### Security — v2.1 Phase 2: OSSF Scorecard Score Lift
 
 - Workflow permissions scope-downs across 8 workflows: top-level `permissions: read-all` + job-level write grants only where required. Closes the OSSF Token-Permissions check (was 0/10).

--- a/hf-space-pii/app.py
+++ b/hf-space-pii/app.py
@@ -58,6 +58,26 @@ _ROOM_PATTERN = re.compile(
     r"\s+\d{2,3}\b"
 )
 
+# Phone numbers — US-format heuristic (catches Piiranha v1 gaps).
+# Patterns: 540-231-1234, (540) 231-1234, +1-540-231-1234, 540.231.1234, 5402311234
+_PHONE_PATTERN = re.compile(
+    r"(?:\+?1[\s.\-]?)?\(?\d{3}\)?[\s.\-]?\d{3}[\s.\-]?\d{4}\b"
+)
+
+# Person-name heuristic — Title-Case word followed by Title-Case word, with
+# stopwords excluded. Aggressive but tunable. Stopwords cover months, days,
+# courses, and common false positives.
+_NAME_PATTERN = re.compile(
+    r"\b(?!(?:January|February|March|April|May|June|July|August|September|October|November|December"
+    r"|Monday|Tuesday|Wednesday|Thursday|Friday|Saturday|Sunday"
+    r"|Spring|Fall|Summer|Winter|Week|Chapter|Section|Unit|Hall|Building|Lab|Center|Annex|Room"
+    r"|Canvas|Calendar|Agent|TA|Professor|Doctor|Mr|Mrs|Ms|Dr"
+    r"|United|States|North|South|East|West|New|Main|First|Last|Final|Quiz|Exam"
+    r"|Office|Virginia|Tech|Course|Group|Team|Project|Student|Faculty"
+    r"|Due|Assignment|Homework|Lecture|Discussion|Recitation|Syllabus|Grade|Credit"
+    r")\b)[A-Z][a-z]{2,}\s+[A-Z][a-z]{2,}\b"
+)
+
 _MAX_BODY_BYTES = 2 * 1024 * 1024  # 2 MB
 
 
@@ -78,11 +98,35 @@ def _apply_room_regex(text: str, loc_reg: dict) -> list[tuple[int, int, str]]:
     return replacements
 
 
+def _apply_phone_regex(text: str, person_reg: dict) -> list[tuple[int, int, str]]:
+    replacements = []
+    for m in _PHONE_PATTERN.finditer(text):
+        raw = m.group()
+        if raw not in person_reg:
+            person_reg[raw] = f"@PERSON_{len(person_reg) + 1}"
+        replacements.append((m.start(), m.end(), person_reg[raw]))
+    return replacements
+
+
+def _apply_name_regex(text: str, person_reg: dict) -> list[tuple[int, int, str]]:
+    replacements = []
+    for m in _NAME_PATTERN.finditer(text):
+        raw = m.group()
+        if "@COURSE" in raw or "@PERSON" in raw or "@LOC" in raw:
+            continue
+        if raw not in person_reg:
+            person_reg[raw] = f"@PERSON_{len(person_reg) + 1}"
+        replacements.append((m.start(), m.end(), person_reg[raw]))
+    return replacements
+
+
 def _anon_text(text: str, person_reg: dict, loc_reg: dict) -> str:
     if text.startswith("<|tool_call>"):
         return text
 
     replacements = _apply_room_regex(text, loc_reg)
+    replacements += _apply_phone_regex(text, person_reg)
+    replacements += _apply_name_regex(text, person_reg)
 
     entities = _ner(text)
     for ent in entities:


### PR DESCRIPTION
## Summary

- Adds `_PHONE_PATTERN` regex covering US phone formats (540-231-1234, (540) 231-1234, +1-540-231-1234, 540.231.1234, 5402311234)
- Adds `_NAME_PATTERN` regex for Title-Case First+Last names with stopwords (months, days, courses, honorifics, common academic terms) to suppress false positives
- Both run via `_apply_phone_regex` / `_apply_name_regex` helpers called from `_anon_text` **before** the entity loop — the existing overlap-skip (`any(s <= start < e ...)`) already deduplicates against model entities
- Both emit `@PERSON_N` tokens into the existing person registry

## Motivation

Post-#199 live testing revealed upstream Piiranha v1 recall gaps:
- "Alice Johnson" → not labeled at all
- "Bob Smith" → mis-labeled CITY
- "540-231-1234" → not detected

These are upstream model limitations, not code bugs. Regex fallback is the pragmatic short-term fix until a better PII model is available.

## Test plan

- [ ] `python3 -c "import sys; sys.path.insert(0,'hf-space-pii'); from app import _NAME_PATTERN, _PHONE_PATTERN; print(_NAME_PATTERN.findall('My name is Alice Johnson and I work with Bob Smith.')); print(_PHONE_PATTERN.findall('Call me at 540-231-1234 or (704) 555-1234.'))"` — should print `['Alice Johnson', 'Bob Smith']` and `['540-231-1234', '(704) 555-1234']`
- [ ] Stopwords do not match: Spring 2026, Final Exam, Canvas Calendar, Office Hours, Virginia Tech, Due Sunday
- [ ] CI passes (hf-space-pii smoke test, scorecard gate)