### PR TITLE
fix(ci): stabilize CI before v2.0.1 release cut (torch +cpu syntax + repo-org BLOCKING)

### DIFF
--- a/.github/workflows/repo-org.yml
+++ b/.github/workflows/repo-org.yml
@@ -1,0 +1,50 @@
+name: Repo Org Compliance
+
+# Phase 4 of v2.1 introduced ALLOWLIST + tools/check-repo-org.sh as a local
+# warning-only pre-commit hook. The hook only runs after `pre-commit install`
+# locally. This workflow runs the same script on every PR in BLOCKING MODE
+# so the standard cannot be silently regressed.
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  repo-org-blocking:
+    name: Repo Org Compliance (blocking)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        with:
+          persist-credentials: false
+
+      - name: Run repo-org checker (BLOCKING)
+        run: |
+          set +e
+          OUTPUT="$(bash tools/check-repo-org.sh 2>&1)"
+          STATUS=$?
+          set -e
+
+          echo "${OUTPUT}"
+
+          if [ "${STATUS}" -ne 0 ]; then
+            echo "::error::tools/check-repo-org.sh exited non-zero (${STATUS})"
+            exit "${STATUS}"
+          fi
+
+          if echo "${OUTPUT}" | grep -qE '^WARN \[repo-org\]:'; then
+            echo "::error::Repo Org Compliance violations detected. Either update ALLOWLIST with the new entries (one-line rationale per entry) or move offending files to a sanctioned location."
+            exit 1
+          fi
+
+          echo "::notice::Repo Org Compliance: clean."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — pip syntax regression in pii-scrub requirements
+
+- `huggingface/pii-scrub/requirements.txt`: changed `torch>=2.8.0+cpu` to `torch==2.8.0+cpu`. PEP 440 requires the `+local` version label (e.g., `+cpu`) to be paired with `==` or `!=`, not `>=`. The previous syntax broke the `Dependency Graph` workflow on `main` (`InstallationError: Local version label can only be used with == or != operators`).
+
+### Added — Repo Org Compliance CI workflow (programmatic enforcement)
+
+- New `.github/workflows/repo-org.yml`: runs `tools/check-repo-org.sh` on every PR + push to main in **BLOCKING mode** (fails the workflow if any `WARN [repo-org]:` line is emitted, even though the local pre-commit hook is warning-only). Contributors still get nag-only warnings during local development; CI enforces the standard at PR time. Closes the gap between Phase 4's policy file (ALLOWLIST) and actual GitHub enforcement.
+
 ### Changed — top-level Hugging Face directory consolidation
 
 - Consolidated `hf-space/` (canvas-calendar-agent-demo) and `hf-space-pii/` (canvas-pii-scrub) into a single top-level `huggingface/` parent. Each Space now lives at `huggingface/agent-demo/` and `huggingface/pii-scrub/`. Cleans up the top-level repo tree (was 2 entries, now 1) and groups all HF deployment surfaces under one umbrella.

--- a/huggingface/pii-scrub/requirements.txt
+++ b/huggingface/pii-scrub/requirements.txt
@@ -1,7 +1,9 @@
 # pinned: transformers model API stability — avoid git-HEAD breakage (see huggingface/agent-demo/requirements.txt)
 transformers>=4.53.0
-# pinned: CPU-only wheel keeps image under 3 GB on HF Spaces CPU Basic
-torch>=2.8.0+cpu
+# pinned: CPU-only wheel keeps image under 3 GB on HF Spaces CPU Basic.
+# `+cpu` local-version-label requires `==` or `!=` — pip rejects it with `>=`.
+# Phase 5 release-standardization will manage version bumps via Dependabot/towncrier.
+torch==2.8.0+cpu
 # pinned: FastAPI + Uvicorn for HTTP layer
 fastapi==0.115.6
 uvicorn==0.32.1


### PR DESCRIPTION
Two stability fixes before cutting the v2.0.1 release:

**(1)** `huggingface/pii-scrub/requirements.txt`: `torch>=2.8.0+cpu` was invalid pip syntax. PEP 440 requires `+local-version-label` to pair with `==` or `!=`, not `>=`. The Dependency Graph workflow has been failing on every commit since PR #200 because of this. Fix: pin to `torch==2.8.0+cpu`.

**(2)** ALLOWLIST + tools/check-repo-org.sh was theater: ran only via local pre-commit hook which most contributors won't install. Added `.github/workflows/repo-org.yml` that runs the same script on every PR + push to main in BLOCKING mode (fails the workflow if any `WARN [repo-org]:` line is emitted). Local hook stays nag-only; CI enforces.

After this lands, main is clean → cut v2.0.1 → OSSF Score lifts → Scorecard Gate stops blocking PRs.