### PR TITLE
fix(docs): unbreak README badge rendering — blank lines around HTML comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — README badges rendering as raw markdown on github.com
+
+- `README.md`: surrounded the two stripped-badge HTML comments (`<!-- codecov badge: removed... -->` and `<!-- canvas-tui badge restored when #177 ships -->`) with blank lines. CommonMark spec rule 4 (HTML block start): an HTML comment without surrounding blank lines triggers HTML block mode for everything below it until the next blank line — meaning every badge after the codecov comment was being rendered as LITERAL `[![PyPI canvas-sdk](...)](...)` markdown text on github.com instead of as images. Only the 4 workflow status badges (CI/Security/Pages/Release) above the comment were rendering. Fix: blank lines around both comments.
+
 ### Fixed — pip syntax regression in pii-scrub requirements
 
 - `huggingface/pii-scrub/requirements.txt`: changed `torch>=2.8.0+cpu` to `torch==2.8.0+cpu`. PEP 440 requires the `+local` version label (e.g., `+cpu`) to be paired with `==` or `!=`, not `>=`. The previous syntax broke the `Dependency Graph` workflow on `main` (`InstallationError: Local version label can only be used with == or != operators`).

--- a/README.md
+++ b/README.md
@@ -29,10 +29,13 @@ See [Quick Start](docs/QUICKSTART.md) · [Examples](examples/) · [Public Roadma
 [![Security](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/security.yml?branch=main&label=Security)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/security.yml)
 [![Pages](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/pages.yml?branch=main&label=Pages)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/pages.yml)
 [![Release](https://img.shields.io/github/actions/workflow/status/kleinpanic/CS3704-Canvas-Project/release.yml?label=Release)](https://github.com/kleinpanic/CS3704-Canvas-Project/actions/workflows/release.yml)
+
 <!-- codecov badge: removed pending codecov.io registration; see Phase 5/8 for restoration when CODECOV_TOKEN is wired -->
-<br>
+
 [![PyPI canvas-sdk](https://img.shields.io/pypi/v/canvas-sdk?label=canvas-sdk)](https://pypi.org/project/canvas-sdk/)
+
 <!-- canvas-tui badge restored when #177 ships -->
+
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/canvas-sdk)](https://pypi.org/project/canvas-sdk/)
 [![ghcr.io](https://img.shields.io/badge/ghcr.io-canvas--tui-2496ED?logo=docker&logoColor=white)](https://github.com/kleinpanic/CS3704-Canvas-Project/pkgs/container/canvas-tui)
 <br>


### PR DESCRIPTION
User flagged: badges below the 4 workflow status badges (CI/Security/Pages/Release) render as LITERAL MARKDOWN TEXT on github.com instead of as images.

Cause: the HTML comment placeholders for stripped badges (codecov + canvas-tui) added in PR #196 were placed flush against surrounding markdown without blank lines. Per CommonMark spec rule 4, an HTML comment without surrounding blank lines triggers HTML block mode for everything until the next blank line — meaning every badge below was being parsed as raw HTML, not markdown.

Fix: blank lines around both HTML comments (lines 32 and 36).

This was a pre-existing rendering bug since PR #196. Phase 3 audit chain didn't catch it because string-pattern checks alone don't render-test markdown.