### PR TITLE
fix: agent-demo torch rollback + decouple publish-pypi from test-pypi gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -380,7 +380,13 @@ jobs:
   # Requires trusted publisher configured at pypi.org. See docs/release-process.md.
   # Forks: this job will be skipped automatically if the 'pypi' environment is not configured.
   publish-pypi:
-    needs: [release, build-sdk-linux, test-pypi]
+    # `test-pypi` removed from `needs:` — TestPyPI's trusted-publisher config is
+    # a separate maintainer click-op (test.pypi.org/manage/account/publishing/)
+    # and was blocking v2.0.1 publish-pypi (skipped because test-pypi failed).
+    # The dry-run is a defense-in-depth check, not a correctness gate; pypi.org
+    # has its own trusted publisher already configured. test-pypi job remains
+    # in the workflow for opt-in verification but no longer gates publish-pypi.
+    needs: [release, build-sdk-linux]
     if: ${{ !contains(needs.build-sdk-linux.outputs.version, '-') }}
     runs-on: ubuntu-latest
     environment:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — agent-demo Space RUNTIME_ERROR after torch 2.8 bump
+
+- `huggingface/agent-demo/requirements.txt`: rolled back `torch>=2.8.0` to `torch==2.7.0`. PR #200's bump caused the canvas-calendar-agent-demo Space to fail with RUNTIME_ERROR at startup (model.safetensors loaded 10.2 GB, crashed at `generation_config.json` step). torch 2.7.0 was the last known-working version with this Space's transformers + Gemma-4 model combo. The torch CVEs fixed in 2.8.0 are not in this Space's request path (model is loaded once at startup, no `torch.load` on user input).
+
+### Fixed — release.yml publish-pypi unblocked from TestPyPI gate
+
+- `.github/workflows/release.yml`: removed `test-pypi` from `publish-pypi` `needs:`. TestPyPI's trusted publisher config is a separate maintainer click-op (`test.pypi.org/manage/account/publishing/`) that wasn't yet set up for this repo. v2.0.1 release.yml ran with publish-pypi SKIPPED because the dry-run failed. Decoupling lets the next release publish to PyPI directly via its already-configured trusted publisher (`pypi.org/manage/...` already done). The Test PyPI Dry-Run job remains in the workflow for opt-in verification but no longer gates the real publish.
+
 ### Fixed — README badges rendering as raw markdown on github.com
 
 - `README.md`: surrounded the two stripped-badge HTML comments (`<!-- codecov badge: removed... -->` and `<!-- canvas-tui badge restored when #177 ships -->`) with blank lines. CommonMark spec rule 4 (HTML block start): an HTML comment without surrounding blank lines triggers HTML block mode for everything below it until the next blank line — meaning every badge after the codecov comment was being rendered as LITERAL `[![PyPI canvas-sdk](...)](...)` markdown text on github.com instead of as images. Only the 4 workflow status badges (CI/Security/Pages/Release) above the comment were rendering. Fix: blank lines around both comments.

--- a/huggingface/agent-demo/requirements.txt
+++ b/huggingface/agent-demo/requirements.txt
@@ -1,5 +1,11 @@
 gradio>=6.7.0  # bumped from 6.6.0 to close GHSA-39mp-8hj3-5c49 (fixed_in 6.7.0); API compat verified
 transformers==5.8.0  # pinned because git-HEAD broke us once
-torch>=2.8.0  # bumped from 2.7.0; closes torch medium CVEs fixed in 2.8.0
+# torch: rolled back from >=2.8.0 to 2.7.0 — 2.8.0 caused RUNTIME_ERROR on Space
+# (model loaded 10.2GB safetensors, crashed at generation_config.json step). 2.7.0
+# was the last known-working version with this Space's transformers + model combo.
+# The torch CVEs fixed in 2.8.0 are not exposed in this Space's request path
+# (model.safetensors is loaded once, no torch.load on user input). Revisit when
+# transformers 6.x lands or when v2-piiranha-style retraining happens.
+torch==2.7.0
 accelerate==1.7.0  # pinned because git-HEAD broke us once
 spaces


### PR DESCRIPTION
Two post-merge regressions:

**(1) agent-demo Space RUNTIME_ERROR after torch>=2.8.0** (PR #200): model loads 10.2GB safetensors successfully then crashes at `generation_config.json` step. Rolled back to `torch==2.7.0` (last working). Security trade-off documented in changelog: torch 2.8 CVEs are not in this Space's request path.

**(2) v2.0.1 release.yml had publish-pypi SKIPPED** because Test PyPI Dry-Run failed (TestPyPI trusted-publisher click-op not configured). pypi.org's trusted publisher IS configured. Removed `test-pypi` from `publish-pypi` `needs:` so the next release tag (v2.0.2 to be cut after this lands) actually ships to PyPI.

Test plan:
- [ ] Required CI checks pass
- [ ] Post-merge: deploy-hf-space.yml triggers + agent-demo rebuilds with torch 2.7.0 + reaches RUNNING
- [ ] Post-merge: cut v2.0.2 tag → release.yml publish-pypi runs (no longer skipped) → canvas-sdk@v2.0.2 on pypi.org