### PR TITLE
fix(hf-space): drop torch pin — let spaces package resolve for ZeroGPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — agent-demo CONFIG_ERROR: ZeroGPU torch version
+
+- `huggingface/agent-demo/requirements.txt`: removed explicit `torch` pin entirely. PR #205's `torch==2.7.0` triggered `No candidate PyTorch version found for ZeroGPU` because the `spaces` package bundles its own ZeroGPU-compatible torch wheel; explicit pin conflicted. Letting `spaces` resolve torch is the canonical pattern for ZeroGPU Spaces.
+
 ### Fixed — agent-demo CONFIG_ERROR (sdk_version unquoted)
 
 - `huggingface/agent-demo/README.md`: re-quoted `sdk_version: 6.7.0` -> `sdk_version: "6.7.0"` per HF Spaces config reference. PR #195 changed it from quoted "5.7.1" to unquoted 6.7.0; HF YAML parser treats unquoted as non-string and triggers CONFIG_ERROR. ref: https://huggingface.co/docs/hub/spaces-config-reference

--- a/huggingface/agent-demo/requirements.txt
+++ b/huggingface/agent-demo/requirements.txt
@@ -1,11 +1,5 @@
 gradio>=6.7.0  # bumped from 6.6.0 to close GHSA-39mp-8hj3-5c49 (fixed_in 6.7.0); API compat verified
 transformers==5.8.0  # pinned because git-HEAD broke us once
-# torch: rolled back from >=2.8.0 to 2.7.0 — 2.8.0 caused RUNTIME_ERROR on Space
-# (model loaded 10.2GB safetensors, crashed at generation_config.json step). 2.7.0
-# was the last known-working version with this Space's transformers + model combo.
 # The torch CVEs fixed in 2.8.0 are not exposed in this Space's request path
-# (model.safetensors is loaded once, no torch.load on user input). Revisit when
-# transformers 6.x lands or when v2-piiranha-style retraining happens.
-torch==2.7.0
 accelerate==1.7.0  # pinned because git-HEAD broke us once
 spaces


### PR DESCRIPTION
Drop `torch==2.7.0` line. spaces==0.49.0 bundles ZeroGPU-compatible torch; explicit pin conflicts.