### PR TITLE
fix: gradio 6 theme/css to launch() + docker SBOM perms

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,7 @@ jobs:
       contents: read
       packages: write
       id-token: write
+      attestations: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — agent-demo gradio 6 API breakage + docker SBOM perms
+
+- `huggingface/agent-demo/app.py`: moved `theme=` and `css=` from `gr.Blocks(...)` constructor to `demo.launch(...)` per gradio 6.0 breaking change. The constructor warning was actually a hard error — Space crashed at startup.
+- `.github/workflows/docker.yml`: added `attestations: write` to build-push job permissions. Previous SBOM step failed with "Resource not accessible by integration".
+
 ### Fixed — release.yml publish-pypi environment matches existing trusted publisher
 
 - `.github/workflows/release.yml`: changed `publish-pypi` job environment from `pypi` to `test-pypi` to match the trusted publisher entry already configured at pypi.org. The previous mismatch caused both jobs to fail with `Trusted publishing exchange failure` (`sub: ...:environment:test-pypi` claim didn't match `environment:pypi` workflow). One-line config fix instead of requiring a maintainer to reconfigure pypi.org.

--- a/huggingface/agent-demo/app.py
+++ b/huggingface/agent-demo/app.py
@@ -710,7 +710,7 @@ RERANKER_EXAMPLES = [
 ]
 
 
-with gr.Blocks(theme=THEME, css=CUSTOM_CSS, title="Canvas Calendar Agent") as demo:
+with gr.Blocks(title="Canvas Calendar Agent") as demo:
     gr.HTML("""
     <div style="background:#1a0a0a;border:1px solid #d63e36;border-radius:6px;
                 padding:10px 14px;margin-bottom:8px;font-size:0.82rem;color:#d4d4db;">
@@ -856,4 +856,4 @@ with gr.Blocks(theme=THEME, css=CUSTOM_CSS, title="Canvas Calendar Agent") as de
 
 
 if __name__ == "__main__":
-    demo.queue().launch(server_name="0.0.0.0", server_port=7860)
+    demo.queue().launch(server_name="0.0.0.0", server_port=7860, theme=THEME, css=CUSTOM_CSS)


### PR DESCRIPTION
Two fixes:

1. `huggingface/agent-demo/app.py`: move theme/css from `gr.Blocks()` to `.launch()` per gradio 6.0 breaking change.
2. `.github/workflows/docker.yml`: add `attestations: write` for SBOM step.