### PR TITLE
fix(ci): keep wheel filename in PEP 427 form (canvas_sdk- not canvas-sdk-)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -158,8 +158,7 @@ jobs:
         run: |
           find sdk-dist/ -name "canvas_sdk-*.tar.gz" \
             -exec mv {} "sdk-dist/canvas-sdk-${VERSION}.tar.gz" \;
-          find sdk-dist/ -name "canvas_sdk-*-py3-none-any.whl" \
-            -exec mv {} "sdk-dist/canvas-sdk-${VERSION}-py3-none-any.whl" \;
+          # Wheel intentionally NOT renamed — PEP 427 requires underscored package name in wheel filename. PyPI rejects hyphen-named wheels with metadata errors.
 
       - name: Compute artifact hashes
         id: hash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — release.yml wheel rename violated PEP 427
+
+- `.github/workflows/release.yml`: removed the build-sdk-linux step that renamed `canvas_sdk-*.whl` → `canvas-sdk-*.whl`. PEP 427 mandates underscored package name in wheel filenames; the hyphenated form caused twine to parse the filename incorrectly and fail with "Metadata is missing required fields: Name, Version". Sdist rename to hyphenated form is preserved (sdist names are more permissive).
+
 ### Fixed — bump src/sdk/pyproject.toml to 2.0.5
 
 - `src/sdk/pyproject.toml`: version `2.0.0` -> `2.0.5`. Build was producing `canvas_sdk-2.0.0-py3-none-any.whl` regardless of tag (release.yml's build runs `python -m build src/sdk/` which uses pyproject's hardcoded version). Phase 5 release-standardization will replace this with version.txt + sed substitution at build time.


### PR DESCRIPTION
Wheel filename rename was violating PEP 427. PyPI/twine reject hyphenated wheel names.