### PR TITLE
fix(ci): explicit setuptools>=70 in build env

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,7 +145,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install build deps
-        run: python -m pip install --upgrade pip build
+        run: python -m pip install --upgrade --no-cache-dir pip build "setuptools>=70" wheel
 
       - name: Build sdk sdist and wheel
         run: python -m build src/sdk/ --outdir sdk-dist/
@@ -202,7 +202,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Install build deps
-        run: python -m pip install --upgrade pip build
+        run: python -m pip install --upgrade --no-cache-dir pip build "setuptools>=70" wheel
 
       - name: Build sdk wheel on macOS
         run: python -m build --wheel src/sdk/ --outdir sdk-macos-dist/
@@ -365,7 +365,7 @@ jobs:
 
       - name: Build sdist + wheel
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade --no-cache-dir pip build "setuptools>=70" wheel
           python -m build src/sdk/ --outdir dist/
 
       - name: Publish to Test PyPI
@@ -409,7 +409,7 @@ jobs:
         # build-sdk-linux renames canvas_sdk-*.tar.gz to canvas-sdk-* for the GH release.
         # PyPI requires PEP 625 underscore names, so we rebuild fresh here.
         run: |
-          python -m pip install --upgrade pip build
+          python -m pip install --upgrade --no-cache-dir pip build "setuptools>=70" wheel
           python -m build src/sdk/ --outdir dist/
           ls -la dist/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — release.yml build env explicitly pins setuptools>=70
+
+- `.github/workflows/release.yml`: all 4 `Install build deps` steps now do `pip install --upgrade --no-cache-dir pip build "setuptools>=70" wheel`. The previous `pip install --upgrade pip build` left setup-python's pre-cached old setuptools in place; combined with pip's cache, build was honoring an ancient setuptools that produced wheels with Metadata-Version 1.x. Explicit upgrade + no-cache forces fresh setuptools >= 70 (PEP 621-compliant) → wheels get Metadata-Version 2.4.
+
 ### Fixed — release.yml wheel rename violated PEP 427
 
 - `.github/workflows/release.yml`: removed the build-sdk-linux step that renamed `canvas_sdk-*.whl` → `canvas-sdk-*.whl`. PEP 427 mandates underscored package name in wheel filenames; the hyphenated form caused twine to parse the filename incorrectly and fail with "Metadata is missing required fields: Name, Version". Sdist rename to hyphenated form is preserved (sdist names are more permissive).


### PR DESCRIPTION
Old setuptools was producing Metadata-Version 1.x wheels. Explicit upgrade fixes.