### PR TITLE
chore: bump 2.0.8 — verify setuptools>=70 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `huggingface/pii-scrub/app.py`: `_PERSON_LABELS` and `_LOC_LABELS` were checking for BIO-prefixed labels (`I-GIVENNAME`, `I-CITY`, etc.) but the model is loaded with `aggregation_strategy="simple"`, which collapses spans and drops the BIO prefix. The model returns `entity_group: "EMAIL"`, `"USERNAME"`, `"GIVENNAME"` etc. — never `"I-..."`. Result: `/scrub` always returned the input unchanged with `redactions: []` and `registry: {}` — a silent no-op for every request. `/entities` was unaffected (it returns the raw entity list without label-set filtering). Live-verified by hitting `/scrub` against `https://kleinpanic93-canvas-pii-scrub.hf.space/`. Fix: drop `I-` prefix from both label sets and add `EMAIL` to person-class.
 
+## [2.0.8] - 2026-05-07
+
+### Released
+
+- Verify CI publish path post-setuptools fix.
+
 ## [2.0.7] - 2026-05-07
 
 ### Released

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-tui"
-version = "2.0.7"
+version = "2.0.8"
 description = "Canvas LMS TUI client for the CS3704 Canvas project"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-sdk"
-version = "2.0.7"
+version = "2.0.8"
 description = "Pure-Python (stdlib only) Canvas LMS read-only client and agent SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
test the CI publish path post-setuptools-pin