### PR TITLE
fix(ci): bump pypa/gh-action-pypi-publish (old twine misread Metadata 2.4)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,7 +369,7 @@ jobs:
           python -m build src/sdk/ --outdir dist/
 
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
@@ -414,7 +414,7 @@ jobs:
           ls -la dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@ec4db0b4ddc65acdf4bff5fa45ac92d78b56bdf0  # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
         with:
           skip-existing: true
           packages-dir: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — bump pypa/gh-action-pypi-publish (twine bug)
+
+- `.github/workflows/release.yml`: bumped `pypa/gh-action-pypi-publish@ec4db0b4` -> `@cef22109` (latest release/v1). The pinned SHA was running an old twine that misread Metadata-Version 2.4 wheels with "Metadata is missing required fields: Name, Version". Wheels themselves were valid (verified by direct twine upload of the same artifact, canvas-sdk 2.0.5 + 2.0.8 LIVE on pypi.org). Action bump fixes the CI publish path.
+
 ### Fixed — release.yml build env explicitly pins setuptools>=70
 
 - `.github/workflows/release.yml`: all 4 `Install build deps` steps now do `pip install --upgrade --no-cache-dir pip build "setuptools>=70" wheel`. The previous `pip install --upgrade pip build` left setup-python's pre-cached old setuptools in place; combined with pip's cache, build was honoring an ancient setuptools that produced wheels with Metadata-Version 1.x. Explicit upgrade + no-cache forces fresh setuptools >= 70 (PEP 621-compliant) → wheels get Metadata-Version 2.4.


### PR DESCRIPTION
Bumps action SHA to fix CI publish-pypi. Wheels were valid; bundled twine in old action SHA was broken.