### PR TITLE
fix(ci): scorecard gate uses ossf/scorecard-action, drops manual binary

### DIFF
--- a/.github/workflows/scorecard-gate.yml
+++ b/.github/workflows/scorecard-gate.yml
@@ -37,9 +37,6 @@ jobs:
         id: bootstrap
         if: github.event_name == 'pull_request'
         run: |
-          # When this PR touches scorecard-gate.yml, the gate cannot enforce its
-          # own floor against the pre-merge `main` score (chicken-and-egg).
-          # Mark as bootstrap so the floor check becomes informational.
           if git diff --name-only "origin/${{ github.base_ref }}...HEAD" | grep -qE '^\.github/workflows/scorecard-gate\.yml$'; then
             echo "is_bootstrap=true" >> "$GITHUB_OUTPUT"
             echo "Bootstrap PR detected — score floor will be informational only"
@@ -47,30 +44,21 @@ jobs:
             echo "is_bootstrap=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Download and verify Scorecard CLI
-        env:
-          SCORECARD_VERSION: "5.1.1"
-          SCORECARD_SHA256: "a894eb7390308069a49a3ace0f68dddf995cdfa1b6e7f8b2e1ea77de131e4962"
-        run: |
-          TARBALL="scorecard_${SCORECARD_VERSION}_linux_amd64.tar.gz"
-          curl -sL "https://github.com/ossf/scorecard/releases/download/v${SCORECARD_VERSION}/${TARBALL}" \
-            -o "${TARBALL}"
-          echo "${SCORECARD_SHA256}  ${TARBALL}" | sha256sum --check --strict
-          tar -xzf "${TARBALL}" scorecard
-          chmod +x scorecard
-
-      - name: Run Scorecard and enforce floor
+      - name: Run OSSF Scorecard
+        id: scorecard
+        uses: ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186  # v2.4.3
+        with:
+          results_file: scorecard-results.json
+          results_format: json
+          publish_results: false
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.SCORECARD_READ_TOKEN || github.token }}
+
+      - name: Enforce score floor
+        env:
           FLOOR: ${{ inputs.floor || '6.0' }}
           IS_BOOTSTRAP: ${{ steps.bootstrap.outputs.is_bootstrap || 'false' }}
         run: |
-          ./scorecard \
-            --repo="https://github.com/${{ github.repository }}" \
-            --format=json \
-            --show-details \
-            > scorecard-results.json 2>&1 || true
-
           SCORE=$(python3 -c "
           import json, sys
           with open('scorecard-results.json') as f:
@@ -82,7 +70,7 @@ jobs:
           echo "Floor: ${FLOOR}"
 
           if [[ "${IS_BOOTSTRAP}" == "true" ]]; then
-            echo "BOOTSTRAP: PR modifies scorecard-gate.yml itself — floor enforcement skipped."
+            echo "BOOTSTRAP: PR modifies scorecard-gate.yml — floor enforcement skipped."
             echo "Score is ${SCORE}, floor is ${FLOOR}. Will enforce on next PR."
             exit 0
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+### Fixed — Scorecard Gate switches to ossf/scorecard-action (no manual binary)
+
+- `.github/workflows/scorecard-gate.yml`: replaced manual binary download + SHA verification with `ossf/scorecard-action@f49aabe0b5af0936a0987cfb85d86b75731b0186` (same action as `scorecard.yml`). The action handles OIDC auth internally; `SCORECARD_READ_TOKEN` remains as a fallback but is no longer the sole auth path. Fixes score returning 0 when the token was absent.
+
 ### Changed — Dependabot PRs now auto-approve and auto-merge
 
 - Added `.github/workflows/dependabot-auto-merge.yml`: approves and enables squash auto-merge for all Dependabot PRs when required checks pass. Eliminates manual review burden for dependency-only updates.


### PR DESCRIPTION
## Summary

- Replaces the manual scorecard binary download with `ossf/scorecard-action@f49aabe` (same version as `scorecard.yml`)
- The action uses OIDC auth internally — no bare PAT required as the primary auth path
- `SCORECARD_READ_TOKEN` kept as env fallback for higher API rate limits
- Fixes the gate returning score=0 when the token was absent (the binary was failing silently)

## This is a bootstrap PR

This PR modifies `scorecard-gate.yml`, so the gate itself will skip floor enforcement (bootstrap bypass). The fix takes effect on the next PR.

## Test plan
- [ ] Gate runs without downloading a binary
- [ ] Score is non-zero on next PR after this merges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where security scorecard evaluation would return a score of 0 when authentication credentials were unavailable.
  * Enhanced the security scorecard workflow with improved authentication handling and more reliable credential management using modern security practices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kleinpanic/CS3704-Canvas-Project/pull/241?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->