### PR TITLE
chore(release): 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [unreleased]
 
+## [2.2.0] - 2026-05-22
+
 ### Changed — .planning/ removed from git tracking
 
 - `.gitignore`: added `/.planning/` — the GSD workflow state directory is local planning tooling, not repo source. It should not appear in the public GitHub view.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-tui"
-version = "2.1.0"
+version = "2.2.0"
 description = "Canvas LMS TUI client for the CS3704 Canvas project"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/sdk/pyproject.toml
+++ b/src/sdk/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "canvas-sdk"
-version = "2.1.0"
+version = "2.2.0"
 description = "Pure-Python (stdlib only) Canvas LMS read-only client and agent SDK"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bumps `src/sdk/pyproject.toml` from `2.1.0` → `2.2.0` and promotes the `[unreleased]` CHANGELOG section to `[2.2.0] - 2026-05-22`.

This release captures everything merged since v2.1.0:
- Mock Canvas data mode (demo always works without live token)
- HF Space deployment removal (Canvas API token revoked by institution)
- OSSF Scorecard gate migrated to `ossf/scorecard-action` (OIDC)
- Dependabot auto-merge workflow
- PyPI publish env fix (`test-pypi` → `pypi`)
- Test PyPI dry-run removed
- Scorecard gate floor lowered 6.5 → 6.0 (solo project ceiling)
- Gitignore broadened to cover full `docs-site/screenshots/`
- `.planning/` removed from git tracking

Tagging `v2.2.0` after merge triggers the release.yml PyPI publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 2.2.0 released with updated project configuration across primary package and SDK distributions, along with changelog documentation updates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kleinpanic/CS3704-Canvas-Project/pull/242?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->