### PR TITLE
ci: auto-update BEHIND Dependabot branches on push to main

### DIFF
--- a/.github/workflows/dependabot-branch-updater.yml
+++ b/.github/workflows/dependabot-branch-updater.yml
@@ -1,0 +1,40 @@
+name: Dependabot Branch Updater
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-behind-prs:
+    name: Rebase BEHIND Dependabot PRs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2
+        with:
+          egress-policy: audit
+
+      - name: Update BEHIND Dependabot branches
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          PAGER='' gh pr list \
+            --author "dependabot[bot]" \
+            --state open \
+            --json number \
+            --jq '.[].number' | while read PR; do
+            STATE=$(gh api "repos/$REPO/pulls/$PR" --jq '.mergeable_state')
+            if [ "$STATE" = "behind" ] || [ "$STATE" = "blocked" ]; then
+              echo "Updating PR #$PR (state=$STATE)"
+              gh api "repos/$REPO/pulls/$PR/update-branch" \
+                --method PUT || echo "PR #$PR update skipped"
+            else
+              echo "PR #$PR state=$STATE — skipping"
+            fi
+          done


### PR DESCRIPTION
## Summary

- Adds `dependabot-branch-updater.yml` triggered on every push to `main`
- On each trigger, queries all open Dependabot PRs and calls `update-branch` on any that are `behind` or `blocked`
- Closes the cascade loop permanently — no more manual `gh api ... update-branch` calls needed

## Why

`strict: true` branch protection requires every PR to be up-to-date before merge. Each time any PR lands on main, all other PRs become `BEHIND` and CI won't auto-merge them. This workflow auto-triggers the rebase so the queue drains itself.

## Test plan

- [ ] Merge any PR to main — watch this workflow fire and update remaining open Dependabot PRs
- [ ] Confirm those PRs pass CI and auto-merge via the existing `dependabot-auto-merge.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated workflow to manage Dependabot pull requests. The system now automatically updates branches that fall behind or are blocked, keeping dependency updates synchronized with the main branch and reducing manual maintenance requirements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kleinpanic/CS3704-Canvas-Project/pull/243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->