### PR TITLE
fix(pii): strip BIO prefix from NER entity_group before label lookup

### DIFF
--- a/huggingface/pii-scrub/app.py
+++ b/huggingface/pii-scrub/app.py
@@ -131,7 +131,7 @@ def _anon_text(text: str, person_reg: dict, loc_reg: dict) -> str:
     entities = _ner(text)
     for ent in entities:
         raw = ent["word"]
-        label = ent["entity_group"]
+        label = ent["entity_group"].split("-", 1)[-1]  # strip BIO prefix (I-/B-)
         start = ent["start"]
         end = ent["end"]
         if "@COURSE" in raw:


### PR DESCRIPTION
## Summary

- Piiranha returns `entity_group` with BIO prefixes: `I-GIVENNAME`, `B-SURNAME`, etc.
- `_PERSON_LABELS` only contained unprefixed names so `label in _PERSON_LABELS` always returned `False`
- Text was passed through unmodified — no PII scrubbing happened for NER-detected entities
- Fix: `.split("-", 1)[-1]` strips any `I-`/`B-` prefix before the membership check

## Tests

Fixes 2 failing tests:
- `test_scrub_person_entity_replaced`
- `test_same_name_twice_same_token`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced entity detection to properly recognize personal information and location entities across different model output formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kleinpanic/CS3704-Canvas-Project/pull/244?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->