### PR TITLE
chore: configure CodeRabbit to skip CI/deps PRs and not block auto-merge

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+language: "en-US"
+reviews:
+  profile: "chill"
+  request_changes_workflow: false
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "chore"
+      - "ci"
+      - "deps"
+      - "dependabot"
+    drafts: false
+  path_filters:
+    - "!.github/workflows/**"
+    - "!requirements*.txt"
+    - "!*.lock"
+    - "!pyproject.toml"
+    - "!CHANGELOG.md"
+chat:
+  auto_reply: true

--- a/ALLOWLIST
+++ b/ALLOWLIST
@@ -58,6 +58,7 @@ tools                   # Repo tooling (linters, hooks, checkers)
 .github                 # GitHub Actions workflows + templates + community files
 .gitignore              # Standard
 .planning               # GSD planning artifacts (gitignored except .planning/archive/ for class deliverables)
+.coderabbit.yaml        # CodeRabbit AI code review configuration
 .pre-commit-config.yaml # Pre-commit hook registry
 .readthedocs.yaml       # ReadTheDocs build config
 .yamllint.yml           # YAML lint config


### PR DESCRIPTION
## Summary

- `request_changes_workflow: false` — CodeRabbit will only comment, never use "Request Changes" review state that blocks auto-merge
- `ignore_title_keywords: [chore, ci, deps, dependabot]` — skips reviewing workflow files, dependency bumps, and CI-only changes
- `path_filters` — excludes `.github/workflows/**`, requirements files, lock files, `pyproject.toml`, `CHANGELOG.md` from review

## Why

Every Dependabot PR and CI-only PR was getting flagged by CodeRabbit with review threads that required manual GraphQL resolution before auto-merge could proceed. This defeats the purpose of automated maintenance.

## Test plan

- [ ] Open a Dependabot PR — CodeRabbit should not leave review threads
- [ ] Merge this PR via auto-merge without needing to resolve any bot threads