### PR TITLE
feat(ci): full repo autopilot — auto-merge all PRs, prune nightly tags, update all BEHIND branches

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,27 @@
+name: Auto-Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  enable:
+    name: Enable auto-merge on all non-draft PRs
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2
+        with:
+          egress-policy: audit
+
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: gh pr merge --auto --squash "$PR_NUMBER" --repo "$REPO"

--- a/.github/workflows/cleanup.yml
+++ b/.github/workflows/cleanup.yml
@@ -1,7 +1,6 @@
 name: Cleanup Artifacts
 
-# Runs weekly to clean up old workflow artifacts.
-# GitHub caps at 10 GB; proactive cleanup keeps costs low and UI clean.
+# Runs weekly to clean up old workflow artifacts, runs, and nightly tags.
 on:
   schedule:
     - cron: "0 6 * * 0"  # every Sunday at 06:00 UTC
@@ -14,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       actions: write
+      contents: write
     steps:
       - name: Harden runner
         uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450  # v2
@@ -52,7 +52,6 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
         with:
           script: |
-            // Dynamically list all workflows in the repo
             const workflows = await github.paginate(github.rest.actions.listRepoWorkflows, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -60,7 +59,6 @@ jobs:
             });
 
             const KEEP_LAST = 20;
-            // To protect a run: use the GitHub API to add 'protect-run' label when API supports it
 
             for (const wf of workflows) {
               const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
@@ -75,9 +73,7 @@ jobs:
                 continue;
               }
 
-              const toDelete = runs.slice(KEEP_LAST);
-
-              for (const run of toDelete) {
+              for (const run of runs.slice(KEEP_LAST)) {
                 console.log(`Deleting run: ${wf.name} #${run.run_number} (${run.id})`);
                 await github.rest.actions.deleteWorkflowRun({
                   owner: context.repo.owner,
@@ -86,3 +82,47 @@ jobs:
                 });
               }
             }
+
+      - name: Prune nightly tags older than 7 days
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9
+        with:
+          script: |
+            const KEEP_DAYS = 7;
+            const cutoff = Date.now() - KEEP_DAYS * 24 * 60 * 60 * 1000;
+
+            const tags = await github.paginate(github.rest.repos.listTags, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              per_page: 100
+            });
+
+            let pruned = 0;
+            for (const tag of tags.filter(t => t.name.startsWith('nightly-'))) {
+              const match = tag.name.match(/^nightly-(\d{8})-/);
+              if (!match) continue;
+              const d = match[1];
+              const tagDate = new Date(`${d.slice(0,4)}-${d.slice(4,6)}-${d.slice(6,8)}`).getTime();
+              if (tagDate >= cutoff) continue;
+
+              // Delete associated GitHub release if present
+              try {
+                const rels = await github.rest.repos.listReleases({
+                  owner: context.repo.owner, repo: context.repo.repo, per_page: 100
+                });
+                const rel = rels.data.find(r => r.tag_name === tag.name);
+                if (rel) await github.rest.repos.deleteRelease({
+                  owner: context.repo.owner, repo: context.repo.repo, release_id: rel.id
+                });
+              } catch (_) {}
+
+              await github.rest.git.deleteRef({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                ref: `tags/${tag.name}`
+              });
+
+              console.log(`Pruned: ${tag.name}`);
+              pruned++;
+            }
+
+            console.log(`Pruned ${pruned} nightly tag(s) older than ${KEEP_DAYS} days`);

--- a/.github/workflows/dependabot-branch-updater.yml
+++ b/.github/workflows/dependabot-branch-updater.yml
@@ -1,4 +1,4 @@
-name: Dependabot Branch Updater
+name: Branch Updater
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   update-behind-prs:
-    name: Rebase BEHIND Dependabot PRs
+    name: Rebase all BEHIND open PRs
     runs-on: ubuntu-latest
     steps:
       - name: Harden runner
@@ -18,14 +18,13 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Update BEHIND Dependabot branches
+      - name: Update BEHIND branches
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
         run: |
           set -e
           PAGER='' gh pr list \
-            --author "dependabot[bot]" \
             --state open \
             --json number \
             --jq '.[].number' | while read PR; do


### PR DESCRIPTION
## Summary

- **auto-merge.yml** — enables squash auto-merge on every non-draft PR immediately when opened. Any PR that passes all required CI checks lands on main automatically, no human or manual `--auto` flag needed.
- **cleanup.yml** — weekly nightly tag pruning: keeps the last 7 days, deletes older nightly releases and tags. Currently 16 tags are accumulating with no upper bound.
- **dependabot-branch-updater.yml** — expanded from Dependabot-only to all open PRs. Every push to main now rebases the full open PR queue, not just Dependabot branches.

## Result

Open a PR → auto-merge enabled → CI runs → branch stays current → lands on main. Zero manual steps required for the full lifecycle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated build and deployment infrastructure, including improved artifact cleanup procedures and branch synchronization workflows.
  * Added automatic pull request merging capabilities to streamline the review process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/kleinpanic/CS3704-Canvas-Project/pull/247?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->